### PR TITLE
Changing plugin to the right naming convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Rest of the command are executed inside `project` folder.
             $bundles = [
                 // ...
     
-                new \Sylius\ShopApiPlugin\ShopApiPlugin(),
+                new \Sylius\SyliusShopApiPlugin\ShopApiPlugin(),
                 new \League\Tactician\Bundle\TacticianBundle(),
             ];
     

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "sylius/shop-api-plugin",
+    "name": "sylius/sylius-shop-api-plugin",
     "type": "sylius-plugin",
     "description": "Shop API for Sylius E-Commerce.",
     "license": "MIT",
@@ -23,12 +23,12 @@
     },
     "autoload": {
         "psr-4": {
-            "Sylius\\ShopApiPlugin\\": "src/"
+            "Sylius\\SyliusShopApiPlugin\\": "src/"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "Tests\\Sylius\\ShopApiPlugin\\": "tests/"
+            "Tests\\Sylius\\SyliusShopApiPlugin\\": "tests/"
         }
     },
     "suggest": {

--- a/phpspec.yml.dist
+++ b/phpspec.yml.dist
@@ -1,4 +1,4 @@
 suites:
     default:
-        namespace: Sylius\ShopApiPlugin
-        psr4_prefix: Sylius\ShopApiPlugin
+        namespace: Sylius\SyliusShopApiPlugin
+        psr4_prefix: Sylius\SyliusShopApiPlugin

--- a/spec/Checker/PromotionCouponEligibilityCheckerSpec.php
+++ b/spec/Checker/PromotionCouponEligibilityCheckerSpec.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\ShopApiPlugin\Checker;
+namespace spec\Sylius\SyliusShopApiPlugin\Checker;
 
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Core\Model\ChannelInterface;

--- a/spec/Command/AddCouponSpec.php
+++ b/spec/Command/AddCouponSpec.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\ShopApiPlugin\Command;
+namespace spec\Sylius\SyliusShopApiPlugin\Command;
 
 use PhpSpec\ObjectBehavior;
 

--- a/spec/Command/AddProductReviewByCodeSpec.php
+++ b/spec/Command/AddProductReviewByCodeSpec.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\ShopApiPlugin\Command;
+namespace spec\Sylius\SyliusShopApiPlugin\Command;
 
 use PhpSpec\ObjectBehavior;
 

--- a/spec/Command/AddProductReviewBySlugSpec.php
+++ b/spec/Command/AddProductReviewBySlugSpec.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\ShopApiPlugin\Command;
+namespace spec\Sylius\SyliusShopApiPlugin\Command;
 
 use PhpSpec\ObjectBehavior;
 

--- a/spec/Command/AddressOrderSpec.php
+++ b/spec/Command/AddressOrderSpec.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\ShopApiPlugin\Command;
+namespace spec\Sylius\SyliusShopApiPlugin\Command;
 
 use PhpSpec\ObjectBehavior;
-use Sylius\ShopApiPlugin\Model\Address;
+use Sylius\SyliusShopApiPlugin\Model\Address;
 
 final class AddressOrderSpec extends ObjectBehavior
 {

--- a/spec/Command/ChangeItemQuantitySpec.php
+++ b/spec/Command/ChangeItemQuantitySpec.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\ShopApiPlugin\Command;
+namespace spec\Sylius\SyliusShopApiPlugin\Command;
 
 use PhpSpec\ObjectBehavior;
 

--- a/spec/Command/ChoosePaymentMethodSpec.php
+++ b/spec/Command/ChoosePaymentMethodSpec.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\ShopApiPlugin\Command;
+namespace spec\Sylius\SyliusShopApiPlugin\Command;
 
 use PhpSpec\ObjectBehavior;
 

--- a/spec/Command/ChooseShippingMethodSpec.php
+++ b/spec/Command/ChooseShippingMethodSpec.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\ShopApiPlugin\Command;
+namespace spec\Sylius\SyliusShopApiPlugin\Command;
 
 use PhpSpec\ObjectBehavior;
 

--- a/spec/Command/CompleteOrderSpec.php
+++ b/spec/Command/CompleteOrderSpec.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\ShopApiPlugin\Command;
+namespace spec\Sylius\SyliusShopApiPlugin\Command;
 
 use PhpSpec\ObjectBehavior;
 

--- a/spec/Command/DropCartSpec.php
+++ b/spec/Command/DropCartSpec.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\ShopApiPlugin\Command;
+namespace spec\Sylius\SyliusShopApiPlugin\Command;
 
 use PhpSpec\ObjectBehavior;
 

--- a/spec/Command/GenerateResetPasswordTokenSpec.php
+++ b/spec/Command/GenerateResetPasswordTokenSpec.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\ShopApiPlugin\Command;
+namespace spec\Sylius\SyliusShopApiPlugin\Command;
 
 use PhpSpec\ObjectBehavior;
-use Sylius\ShopApiPlugin\Command\GenerateResetPasswordToken;
+use Sylius\SyliusShopApiPlugin\Command\GenerateResetPasswordToken;
 
 final class GenerateResetPasswordTokenSpec extends ObjectBehavior
 {

--- a/spec/Command/GenerateVerificationTokenSpec.php
+++ b/spec/Command/GenerateVerificationTokenSpec.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\ShopApiPlugin\Command;
+namespace spec\Sylius\SyliusShopApiPlugin\Command;
 
 use PhpSpec\ObjectBehavior;
-use Sylius\ShopApiPlugin\Command\GenerateVerificationToken;
+use Sylius\SyliusShopApiPlugin\Command\GenerateVerificationToken;
 
 final class GenerateVerificationTokenSpec extends ObjectBehavior
 {

--- a/spec/Command/PickupCartSpec.php
+++ b/spec/Command/PickupCartSpec.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\ShopApiPlugin\Command;
+namespace spec\Sylius\SyliusShopApiPlugin\Command;
 
 use PhpSpec\ObjectBehavior;
 

--- a/spec/Command/PutOptionBasedConfigurableItemToCartSpec.php
+++ b/spec/Command/PutOptionBasedConfigurableItemToCartSpec.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\ShopApiPlugin\Command;
+namespace spec\Sylius\SyliusShopApiPlugin\Command;
 
 use PhpSpec\ObjectBehavior;
 

--- a/spec/Command/PutSimpleItemToCartSpec.php
+++ b/spec/Command/PutSimpleItemToCartSpec.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\ShopApiPlugin\Command;
+namespace spec\Sylius\SyliusShopApiPlugin\Command;
 
 use PhpSpec\ObjectBehavior;
 

--- a/spec/Command/PutVariantBasedConfigurableItemToCartSpec.php
+++ b/spec/Command/PutVariantBasedConfigurableItemToCartSpec.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\ShopApiPlugin\Command;
+namespace spec\Sylius\SyliusShopApiPlugin\Command;
 
 use PhpSpec\ObjectBehavior;
 

--- a/spec/Command/SendResetPasswordTokenSpec.php
+++ b/spec/Command/SendResetPasswordTokenSpec.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\ShopApiPlugin\Command;
+namespace spec\Sylius\SyliusShopApiPlugin\Command;
 
 use PhpSpec\ObjectBehavior;
-use Sylius\ShopApiPlugin\Command\SendResetPasswordToken;
+use Sylius\SyliusShopApiPlugin\Command\SendResetPasswordToken;
 
 final class SendResetPasswordTokenSpec extends ObjectBehavior
 {

--- a/spec/Command/SendVerificationTokenSpec.php
+++ b/spec/Command/SendVerificationTokenSpec.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\ShopApiPlugin\Command;
+namespace spec\Sylius\SyliusShopApiPlugin\Command;
 
 use PhpSpec\ObjectBehavior;
-use Sylius\ShopApiPlugin\Command\SendVerificationToken;
+use Sylius\SyliusShopApiPlugin\Command\SendVerificationToken;
 
 final class SendVerificationTokenSpec extends ObjectBehavior
 {

--- a/spec/Command/UpdateCustomerSpec.php
+++ b/spec/Command/UpdateCustomerSpec.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\ShopApiPlugin\Command;
+namespace spec\Sylius\SyliusShopApiPlugin\Command;
 
 use PhpSpec\ObjectBehavior;
 

--- a/spec/Command/VerifyAccountSpec.php
+++ b/spec/Command/VerifyAccountSpec.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\ShopApiPlugin\Command;
+namespace spec\Sylius\SyliusShopApiPlugin\Command;
 
 use PhpSpec\ObjectBehavior;
-use Sylius\ShopApiPlugin\Command\VerifyAccount;
+use Sylius\SyliusShopApiPlugin\Command\VerifyAccount;
 
 final class VerifyAccountSpec extends ObjectBehavior
 {

--- a/spec/EventListener/RequestLocaleSetterSpec.php
+++ b/spec/EventListener/RequestLocaleSetterSpec.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\ShopApiPlugin\EventListener;
+namespace spec\Sylius\SyliusShopApiPlugin\EventListener;
 
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Locale\Provider\LocaleProviderInterface;
-use Sylius\ShopApiPlugin\EventListener\RequestLocaleSetter;
+use Sylius\SyliusShopApiPlugin\EventListener\RequestLocaleSetter;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 

--- a/spec/EventListener/UserRegistrationListenerSpec.php
+++ b/spec/EventListener/UserRegistrationListenerSpec.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\ShopApiPlugin\EventListener;
+namespace spec\Sylius\SyliusShopApiPlugin\EventListener;
 
 use Doctrine\Common\Persistence\ObjectManager;
 use League\Tactician\CommandBus;
@@ -11,9 +11,9 @@ use Sylius\Component\Channel\Repository\ChannelRepositoryInterface;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\ShopUserInterface;
 use Sylius\Component\User\Repository\UserRepositoryInterface;
-use Sylius\ShopApiPlugin\Command\GenerateVerificationToken;
-use Sylius\ShopApiPlugin\Command\SendVerificationToken;
-use Sylius\ShopApiPlugin\Event\CustomerRegistered;
+use Sylius\SyliusShopApiPlugin\Command\GenerateVerificationToken;
+use Sylius\SyliusShopApiPlugin\Command\SendVerificationToken;
+use Sylius\SyliusShopApiPlugin\Event\CustomerRegistered;
 
 final class UserRegistrationListenerSpec extends ObjectBehavior
 {

--- a/spec/Factory/AddressViewFactorySpec.php
+++ b/spec/Factory/AddressViewFactorySpec.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\ShopApiPlugin\Factory;
+namespace spec\Sylius\SyliusShopApiPlugin\Factory;
 
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Core\Model\AddressInterface;
-use Sylius\ShopApiPlugin\Factory\AddressViewFactoryInterface;
-use Sylius\ShopApiPlugin\View\AddressView;
+use Sylius\SyliusShopApiPlugin\Factory\AddressViewFactoryInterface;
+use Sylius\SyliusShopApiPlugin\View\AddressView;
 
 final class AddressViewFactorySpec extends ObjectBehavior
 {

--- a/spec/Factory/AdjustmentViewFactorySpec.php
+++ b/spec/Factory/AdjustmentViewFactorySpec.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\ShopApiPlugin\Factory;
+namespace spec\Sylius\SyliusShopApiPlugin\Factory;
 
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Core\Model\AdjustmentInterface;
-use Sylius\ShopApiPlugin\Factory\AdjustmentViewFactoryInterface;
-use Sylius\ShopApiPlugin\Factory\PriceViewFactoryInterface;
-use Sylius\ShopApiPlugin\View\AdjustmentView;
-use Sylius\ShopApiPlugin\View\PriceView;
+use Sylius\SyliusShopApiPlugin\Factory\AdjustmentViewFactoryInterface;
+use Sylius\SyliusShopApiPlugin\Factory\PriceViewFactoryInterface;
+use Sylius\SyliusShopApiPlugin\View\AdjustmentView;
+use Sylius\SyliusShopApiPlugin\View\PriceView;
 
 final class AdjustmentViewFactorySpec extends ObjectBehavior
 {

--- a/spec/Factory/CartItemViewFactorySpec.php
+++ b/spec/Factory/CartItemViewFactorySpec.php
@@ -2,19 +2,19 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\ShopApiPlugin\Factory;
+namespace spec\Sylius\SyliusShopApiPlugin\Factory;
 
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\OrderItemInterface;
 use Sylius\Component\Core\Model\ProductInterface;
 use Sylius\Component\Core\Model\ProductVariantInterface;
-use Sylius\ShopApiPlugin\Factory\CartItemViewFactoryInterface;
-use Sylius\ShopApiPlugin\Factory\ProductVariantViewFactoryInterface;
-use Sylius\ShopApiPlugin\Factory\ProductViewFactoryInterface;
-use Sylius\ShopApiPlugin\View\ItemView;
-use Sylius\ShopApiPlugin\View\ProductVariantView;
-use Sylius\ShopApiPlugin\View\ProductView;
+use Sylius\SyliusShopApiPlugin\Factory\CartItemViewFactoryInterface;
+use Sylius\SyliusShopApiPlugin\Factory\ProductVariantViewFactoryInterface;
+use Sylius\SyliusShopApiPlugin\Factory\ProductViewFactoryInterface;
+use Sylius\SyliusShopApiPlugin\View\ItemView;
+use Sylius\SyliusShopApiPlugin\View\ProductVariantView;
+use Sylius\SyliusShopApiPlugin\View\ProductView;
 
 final class CartItemViewFactorySpec extends ObjectBehavior
 {

--- a/spec/Factory/CartViewFactorySpec.php
+++ b/spec/Factory/CartViewFactorySpec.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\ShopApiPlugin\Factory;
+namespace spec\Sylius\SyliusShopApiPlugin\Factory;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use PhpSpec\ObjectBehavior;
@@ -13,20 +13,20 @@ use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\OrderItemInterface;
 use Sylius\Component\Core\Model\PaymentInterface;
 use Sylius\Component\Core\Model\ShipmentInterface;
-use Sylius\ShopApiPlugin\Factory\AddressViewFactoryInterface;
-use Sylius\ShopApiPlugin\Factory\AdjustmentViewFactoryInterface;
-use Sylius\ShopApiPlugin\Factory\CartItemViewFactoryInterface;
-use Sylius\ShopApiPlugin\Factory\CartViewFactoryInterface;
-use Sylius\ShopApiPlugin\Factory\PaymentViewFactoryInterface;
-use Sylius\ShopApiPlugin\Factory\ShipmentViewFactoryInterface;
-use Sylius\ShopApiPlugin\Factory\TotalViewFactoryInterface;
-use Sylius\ShopApiPlugin\View\AddressView;
-use Sylius\ShopApiPlugin\View\AdjustmentView;
-use Sylius\ShopApiPlugin\View\CartSummaryView;
-use Sylius\ShopApiPlugin\View\ItemView;
-use Sylius\ShopApiPlugin\View\PaymentView;
-use Sylius\ShopApiPlugin\View\ShipmentView;
-use Sylius\ShopApiPlugin\View\TotalsView;
+use Sylius\SyliusShopApiPlugin\Factory\AddressViewFactoryInterface;
+use Sylius\SyliusShopApiPlugin\Factory\AdjustmentViewFactoryInterface;
+use Sylius\SyliusShopApiPlugin\Factory\CartItemViewFactoryInterface;
+use Sylius\SyliusShopApiPlugin\Factory\CartViewFactoryInterface;
+use Sylius\SyliusShopApiPlugin\Factory\PaymentViewFactoryInterface;
+use Sylius\SyliusShopApiPlugin\Factory\ShipmentViewFactoryInterface;
+use Sylius\SyliusShopApiPlugin\Factory\TotalViewFactoryInterface;
+use Sylius\SyliusShopApiPlugin\View\AddressView;
+use Sylius\SyliusShopApiPlugin\View\AdjustmentView;
+use Sylius\SyliusShopApiPlugin\View\CartSummaryView;
+use Sylius\SyliusShopApiPlugin\View\ItemView;
+use Sylius\SyliusShopApiPlugin\View\PaymentView;
+use Sylius\SyliusShopApiPlugin\View\ShipmentView;
+use Sylius\SyliusShopApiPlugin\View\TotalsView;
 
 final class CartViewFactorySpec extends ObjectBehavior
 {

--- a/spec/Factory/CustomerViewFactorySpec.php
+++ b/spec/Factory/CustomerViewFactorySpec.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\ShopApiPlugin\Factory;
+namespace spec\Sylius\SyliusShopApiPlugin\Factory;
 
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Core\Model\CustomerInterface;
-use Sylius\ShopApiPlugin\Factory\CustomerViewFactory;
-use Sylius\ShopApiPlugin\View\CustomerView;
+use Sylius\SyliusShopApiPlugin\Factory\CustomerViewFactory;
+use Sylius\SyliusShopApiPlugin\View\CustomerView;
 
 final class CustomerViewFactorySpec extends ObjectBehavior
 {

--- a/spec/Factory/DetailedProductViewFactorySpec.php
+++ b/spec/Factory/DetailedProductViewFactorySpec.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\ShopApiPlugin\Factory;
+namespace spec\Sylius\SyliusShopApiPlugin\Factory;
 
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\ProductInterface;
-use Sylius\ShopApiPlugin\Factory\ProductViewFactoryInterface;
-use Sylius\ShopApiPlugin\Generator\ProductBreadcrumbGeneratorInterface;
-use Sylius\ShopApiPlugin\View\ProductView;
+use Sylius\SyliusShopApiPlugin\Factory\ProductViewFactoryInterface;
+use Sylius\SyliusShopApiPlugin\Generator\ProductBreadcrumbGeneratorInterface;
+use Sylius\SyliusShopApiPlugin\View\ProductView;
 
 final class DetailedProductViewFactorySpec extends ObjectBehavior
 {

--- a/spec/Factory/ImageViewFactorySpec.php
+++ b/spec/Factory/ImageViewFactorySpec.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\ShopApiPlugin\Factory;
+namespace spec\Sylius\SyliusShopApiPlugin\Factory;
 
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Core\Model\ImageInterface;
-use Sylius\ShopApiPlugin\Factory\ImageViewFactoryInterface;
-use Sylius\ShopApiPlugin\View\ImageView;
+use Sylius\SyliusShopApiPlugin\Factory\ImageViewFactoryInterface;
+use Sylius\SyliusShopApiPlugin\View\ImageView;
 
 final class ImageViewFactorySpec extends ObjectBehavior
 {

--- a/spec/Factory/LimitedProductAttributeValuesViewFactorySpec.php
+++ b/spec/Factory/LimitedProductAttributeValuesViewFactorySpec.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\ShopApiPlugin\Factory;
+namespace spec\Sylius\SyliusShopApiPlugin\Factory;
 
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Product\Model\ProductAttributeValueInterface;
-use Sylius\ShopApiPlugin\Factory\ProductAttributeValuesViewFactoryInterface;
-use Sylius\ShopApiPlugin\Factory\ProductAttributeValueViewFactoryInterface;
-use Sylius\ShopApiPlugin\View\ProductAttributeValueView;
+use Sylius\SyliusShopApiPlugin\Factory\ProductAttributeValuesViewFactoryInterface;
+use Sylius\SyliusShopApiPlugin\Factory\ProductAttributeValueViewFactoryInterface;
+use Sylius\SyliusShopApiPlugin\View\ProductAttributeValueView;
 
 final class LimitedProductAttributeValuesViewFactorySpec extends ObjectBehavior
 {

--- a/spec/Factory/ListProductViewFactorySpec.php
+++ b/spec/Factory/ListProductViewFactorySpec.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\ShopApiPlugin\Factory;
+namespace spec\Sylius\SyliusShopApiPlugin\Factory;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use PhpSpec\ObjectBehavior;
@@ -11,12 +11,12 @@ use Sylius\Component\Core\Model\ProductInterface;
 use Sylius\Component\Core\Model\ProductVariantInterface;
 use Sylius\Component\Product\Model\ProductAssociationInterface;
 use Sylius\Component\Product\Model\ProductAssociationTypeInterface;
-use Sylius\ShopApiPlugin\Factory\ImageViewFactoryInterface;
-use Sylius\ShopApiPlugin\Factory\ProductVariantViewFactoryInterface;
-use Sylius\ShopApiPlugin\Factory\ProductViewFactoryInterface;
-use Sylius\ShopApiPlugin\Factory\ViewCreationException;
-use Sylius\ShopApiPlugin\View\ProductVariantView;
-use Sylius\ShopApiPlugin\View\ProductView;
+use Sylius\SyliusShopApiPlugin\Factory\ImageViewFactoryInterface;
+use Sylius\SyliusShopApiPlugin\Factory\ProductVariantViewFactoryInterface;
+use Sylius\SyliusShopApiPlugin\Factory\ProductViewFactoryInterface;
+use Sylius\SyliusShopApiPlugin\Factory\ViewCreationException;
+use Sylius\SyliusShopApiPlugin\View\ProductVariantView;
+use Sylius\SyliusShopApiPlugin\View\ProductView;
 
 final class ListProductViewFactorySpec extends ObjectBehavior
 {

--- a/spec/Factory/PaymentMethodViewFactorySpec.php
+++ b/spec/Factory/PaymentMethodViewFactorySpec.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\ShopApiPlugin\Factory;
+namespace spec\Sylius\SyliusShopApiPlugin\Factory;
 
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Core\Model\PaymentMethodInterface;
 use Sylius\Component\Payment\Model\PaymentMethodTranslationInterface;
-use Sylius\ShopApiPlugin\Factory\PaymentMethodViewFactoryInterface;
-use Sylius\ShopApiPlugin\View\PaymentMethodView;
+use Sylius\SyliusShopApiPlugin\Factory\PaymentMethodViewFactoryInterface;
+use Sylius\SyliusShopApiPlugin\View\PaymentMethodView;
 
 final class PaymentMethodViewFactorySpec extends ObjectBehavior
 {

--- a/spec/Factory/PaymentViewFactorySpec.php
+++ b/spec/Factory/PaymentViewFactorySpec.php
@@ -2,17 +2,17 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\ShopApiPlugin\Factory;
+namespace spec\Sylius\SyliusShopApiPlugin\Factory;
 
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Core\Model\PaymentInterface;
 use Sylius\Component\Core\Model\PaymentMethodInterface;
-use Sylius\ShopApiPlugin\Factory\PaymentMethodViewFactoryInterface;
-use Sylius\ShopApiPlugin\Factory\PaymentViewFactoryInterface;
-use Sylius\ShopApiPlugin\Factory\PriceViewFactoryInterface;
-use Sylius\ShopApiPlugin\View\PaymentMethodView;
-use Sylius\ShopApiPlugin\View\PaymentView;
-use Sylius\ShopApiPlugin\View\PriceView;
+use Sylius\SyliusShopApiPlugin\Factory\PaymentMethodViewFactoryInterface;
+use Sylius\SyliusShopApiPlugin\Factory\PaymentViewFactoryInterface;
+use Sylius\SyliusShopApiPlugin\Factory\PriceViewFactoryInterface;
+use Sylius\SyliusShopApiPlugin\View\PaymentMethodView;
+use Sylius\SyliusShopApiPlugin\View\PaymentView;
+use Sylius\SyliusShopApiPlugin\View\PriceView;
 
 final class PaymentViewFactorySpec extends ObjectBehavior
 {

--- a/spec/Factory/PriceViewFactorySpec.php
+++ b/spec/Factory/PriceViewFactorySpec.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\ShopApiPlugin\Factory;
+namespace spec\Sylius\SyliusShopApiPlugin\Factory;
 
 use PhpSpec\ObjectBehavior;
-use Sylius\ShopApiPlugin\Factory\PriceViewFactoryInterface;
-use Sylius\ShopApiPlugin\View\PriceView;
+use Sylius\SyliusShopApiPlugin\Factory\PriceViewFactoryInterface;
+use Sylius\SyliusShopApiPlugin\View\PriceView;
 
 final class PriceViewFactorySpec extends ObjectBehavior
 {

--- a/spec/Factory/ProductAttributeValueViewFactorySpec.php
+++ b/spec/Factory/ProductAttributeValueViewFactorySpec.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\ShopApiPlugin\Factory;
+namespace spec\Sylius\SyliusShopApiPlugin\Factory;
 
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Product\Model\ProductAttributeInterface;
 use Sylius\Component\Product\Model\ProductAttributeTranslationInterface;
 use Sylius\Component\Product\Model\ProductAttributeValueInterface;
-use Sylius\ShopApiPlugin\Factory\ProductAttributeValueViewFactoryInterface;
-use Sylius\ShopApiPlugin\View\ProductAttributeValueView;
+use Sylius\SyliusShopApiPlugin\Factory\ProductAttributeValueViewFactoryInterface;
+use Sylius\SyliusShopApiPlugin\View\ProductAttributeValueView;
 
 final class ProductAttributeValueViewFactorySpec extends ObjectBehavior
 {

--- a/spec/Factory/ProductReviewViewFactorySpec.php
+++ b/spec/Factory/ProductReviewViewFactorySpec.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\ShopApiPlugin\Factory;
+namespace spec\Sylius\SyliusShopApiPlugin\Factory;
 
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Core\Model\ProductReview;
 use Sylius\Component\Core\Model\ProductReviewerInterface;
-use Sylius\ShopApiPlugin\Factory\ProductReviewViewFactoryInterface;
-use Sylius\ShopApiPlugin\View\ProductReviewView;
+use Sylius\SyliusShopApiPlugin\Factory\ProductReviewViewFactoryInterface;
+use Sylius\SyliusShopApiPlugin\View\ProductReviewView;
 
 final class ProductReviewViewFactorySpec extends ObjectBehavior
 {

--- a/spec/Factory/ProductVariantViewFactorySpec.php
+++ b/spec/Factory/ProductVariantViewFactorySpec.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\ShopApiPlugin\Factory;
+namespace spec\Sylius\SyliusShopApiPlugin\Factory;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use PhpSpec\ObjectBehavior;
@@ -15,11 +15,11 @@ use Sylius\Component\Product\Model\ProductOptionTranslationInterface;
 use Sylius\Component\Product\Model\ProductOptionValueInterface;
 use Sylius\Component\Product\Model\ProductOptionValueTranslationInterface;
 use Sylius\Component\Product\Model\ProductVariantTranslationInterface;
-use Sylius\ShopApiPlugin\Factory\PriceViewFactoryInterface;
-use Sylius\ShopApiPlugin\Factory\ProductVariantViewFactoryInterface;
-use Sylius\ShopApiPlugin\Factory\ViewCreationException;
-use Sylius\ShopApiPlugin\View\PriceView;
-use Sylius\ShopApiPlugin\View\ProductVariantView;
+use Sylius\SyliusShopApiPlugin\Factory\PriceViewFactoryInterface;
+use Sylius\SyliusShopApiPlugin\Factory\ProductVariantViewFactoryInterface;
+use Sylius\SyliusShopApiPlugin\Factory\ViewCreationException;
+use Sylius\SyliusShopApiPlugin\View\PriceView;
+use Sylius\SyliusShopApiPlugin\View\ProductVariantView;
 
 final class ProductVariantViewFactorySpec extends ObjectBehavior
 {

--- a/spec/Factory/ProductViewFactorySpec.php
+++ b/spec/Factory/ProductViewFactorySpec.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\ShopApiPlugin\Factory;
+namespace spec\Sylius\SyliusShopApiPlugin\Factory;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use PhpSpec\ObjectBehavior;
@@ -12,12 +12,12 @@ use Sylius\Component\Core\Model\ProductInterface;
 use Sylius\Component\Core\Model\ProductTranslationInterface;
 use Sylius\Component\Core\Model\TaxonInterface;
 use Sylius\Component\Product\Model\ProductAttributeValueInterface;
-use Sylius\ShopApiPlugin\Factory\ImageViewFactoryInterface;
-use Sylius\ShopApiPlugin\Factory\ProductAttributeValuesViewFactoryInterface;
-use Sylius\ShopApiPlugin\Factory\ProductViewFactoryInterface;
-use Sylius\ShopApiPlugin\View\ImageView;
-use Sylius\ShopApiPlugin\View\ProductTaxonView;
-use Sylius\ShopApiPlugin\View\ProductView;
+use Sylius\SyliusShopApiPlugin\Factory\ImageViewFactoryInterface;
+use Sylius\SyliusShopApiPlugin\Factory\ProductAttributeValuesViewFactoryInterface;
+use Sylius\SyliusShopApiPlugin\Factory\ProductViewFactoryInterface;
+use Sylius\SyliusShopApiPlugin\View\ImageView;
+use Sylius\SyliusShopApiPlugin\View\ProductTaxonView;
+use Sylius\SyliusShopApiPlugin\View\ProductView;
 
 final class ProductViewFactorySpec extends ObjectBehavior
 {

--- a/spec/Factory/ShipmentViewFactorySpec.php
+++ b/spec/Factory/ShipmentViewFactorySpec.php
@@ -2,16 +2,16 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\ShopApiPlugin\Factory;
+namespace spec\Sylius\SyliusShopApiPlugin\Factory;
 
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\ShipmentInterface;
 use Sylius\Component\Core\Model\ShippingMethodInterface;
-use Sylius\ShopApiPlugin\Factory\ShipmentViewFactoryInterface;
-use Sylius\ShopApiPlugin\Factory\ShippingMethodViewFactoryInterface;
-use Sylius\ShopApiPlugin\View\ShipmentView;
-use Sylius\ShopApiPlugin\View\ShippingMethodView;
+use Sylius\SyliusShopApiPlugin\Factory\ShipmentViewFactoryInterface;
+use Sylius\SyliusShopApiPlugin\Factory\ShippingMethodViewFactoryInterface;
+use Sylius\SyliusShopApiPlugin\View\ShipmentView;
+use Sylius\SyliusShopApiPlugin\View\ShippingMethodView;
 
 final class ShipmentViewFactorySpec extends ObjectBehavior
 {

--- a/spec/Factory/ShippingMethodViewFactorySpec.php
+++ b/spec/Factory/ShippingMethodViewFactorySpec.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\ShopApiPlugin\Factory;
+namespace spec\Sylius\SyliusShopApiPlugin\Factory;
 
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Core\Model\ShipmentInterface;
@@ -10,10 +10,10 @@ use Sylius\Component\Core\Model\ShippingMethodInterface;
 use Sylius\Component\Registry\ServiceRegistry;
 use Sylius\Component\Shipping\Calculator\CalculatorInterface;
 use Sylius\Component\Shipping\Model\ShippingMethodTranslationInterface;
-use Sylius\ShopApiPlugin\Factory\PriceViewFactoryInterface;
-use Sylius\ShopApiPlugin\Factory\ShippingMethodViewFactoryInterface;
-use Sylius\ShopApiPlugin\View\PriceView;
-use Sylius\ShopApiPlugin\View\ShippingMethodView;
+use Sylius\SyliusShopApiPlugin\Factory\PriceViewFactoryInterface;
+use Sylius\SyliusShopApiPlugin\Factory\ShippingMethodViewFactoryInterface;
+use Sylius\SyliusShopApiPlugin\View\PriceView;
+use Sylius\SyliusShopApiPlugin\View\ShippingMethodView;
 
 final class ShippingMethodViewFactorySpec extends ObjectBehavior
 {

--- a/spec/Factory/TaxonDetailsViewFactorySpec.php
+++ b/spec/Factory/TaxonDetailsViewFactorySpec.php
@@ -2,15 +2,15 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\ShopApiPlugin\Factory;
+namespace spec\Sylius\SyliusShopApiPlugin\Factory;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Core\Model\TaxonInterface;
-use Sylius\ShopApiPlugin\Factory\TaxonDetailsViewFactoryInterface;
-use Sylius\ShopApiPlugin\Factory\TaxonViewFactoryInterface;
-use Sylius\ShopApiPlugin\View\TaxonDetailsView;
-use Sylius\ShopApiPlugin\View\TaxonView;
+use Sylius\SyliusShopApiPlugin\Factory\TaxonDetailsViewFactoryInterface;
+use Sylius\SyliusShopApiPlugin\Factory\TaxonViewFactoryInterface;
+use Sylius\SyliusShopApiPlugin\View\TaxonDetailsView;
+use Sylius\SyliusShopApiPlugin\View\TaxonView;
 
 final class TaxonDetailsViewFactorySpec extends ObjectBehavior
 {

--- a/spec/Factory/TaxonViewFactorySpec.php
+++ b/spec/Factory/TaxonViewFactorySpec.php
@@ -2,17 +2,17 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\ShopApiPlugin\Factory;
+namespace spec\Sylius\SyliusShopApiPlugin\Factory;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Core\Model\ImageInterface;
 use Sylius\Component\Core\Model\TaxonInterface;
 use Sylius\Component\Taxonomy\Model\TaxonTranslationInterface;
-use Sylius\ShopApiPlugin\Factory\ImageViewFactoryInterface;
-use Sylius\ShopApiPlugin\Factory\TaxonViewFactoryInterface;
-use Sylius\ShopApiPlugin\View\ImageView;
-use Sylius\ShopApiPlugin\View\TaxonView;
+use Sylius\SyliusShopApiPlugin\Factory\ImageViewFactoryInterface;
+use Sylius\SyliusShopApiPlugin\Factory\TaxonViewFactoryInterface;
+use Sylius\SyliusShopApiPlugin\View\ImageView;
+use Sylius\SyliusShopApiPlugin\View\TaxonView;
 
 final class TaxonViewFactorySpec extends ObjectBehavior
 {

--- a/spec/Factory/TotalViewFactorySpec.php
+++ b/spec/Factory/TotalViewFactorySpec.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\ShopApiPlugin\Factory;
+namespace spec\Sylius\SyliusShopApiPlugin\Factory;
 
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Core\Model\Order;
-use Sylius\ShopApiPlugin\Factory\TotalViewFactoryInterface;
-use Sylius\ShopApiPlugin\View\TotalsView;
+use Sylius\SyliusShopApiPlugin\Factory\TotalViewFactoryInterface;
+use Sylius\SyliusShopApiPlugin\View\TotalsView;
 
 final class TotalViewFactorySpec extends ObjectBehavior
 {

--- a/spec/Generator/ProductBreadcrumbGeneratorSpec.php
+++ b/spec/Generator/ProductBreadcrumbGeneratorSpec.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\ShopApiPlugin\Generator;
+namespace spec\Sylius\SyliusShopApiPlugin\Generator;
 
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Core\Model\ProductInterface;
 use Sylius\Component\Core\Model\ProductTranslationInterface;
 use Sylius\Component\Core\Model\TaxonInterface;
 use Sylius\Component\Taxonomy\Model\TaxonTranslationInterface;
-use Sylius\ShopApiPlugin\Generator\ProductBreadcrumbGeneratorInterface;
+use Sylius\SyliusShopApiPlugin\Generator\ProductBreadcrumbGeneratorInterface;
 
 final class ProductBreadcrumbGeneratorSpec extends ObjectBehavior
 {

--- a/spec/Handler/AddCouponHandlerSpec.php
+++ b/spec/Handler/AddCouponHandlerSpec.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\ShopApiPlugin\Handler;
+namespace spec\Sylius\SyliusShopApiPlugin\Handler;
 
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Core\Model\ChannelInterface;
@@ -14,7 +14,7 @@ use Sylius\Component\Order\Processor\OrderProcessorInterface;
 use Sylius\Component\Promotion\Checker\Eligibility\PromotionCouponEligibilityCheckerInterface;
 use Sylius\Component\Promotion\Checker\Eligibility\PromotionEligibilityCheckerInterface;
 use Sylius\Component\Promotion\Repository\PromotionCouponRepositoryInterface;
-use Sylius\ShopApiPlugin\Command\AddCoupon;
+use Sylius\SyliusShopApiPlugin\Command\AddCoupon;
 
 final class AddCouponHandlerSpec extends ObjectBehavior
 {

--- a/spec/Handler/AddProductReviewByCodeHandlerSpec.php
+++ b/spec/Handler/AddProductReviewByCodeHandlerSpec.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\ShopApiPlugin\Handler;
+namespace spec\Sylius\SyliusShopApiPlugin\Handler;
 
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Channel\Repository\ChannelRepositoryInterface;
@@ -13,8 +13,8 @@ use Sylius\Component\Core\Repository\ProductRepositoryInterface;
 use Sylius\Component\Core\Repository\ProductReviewRepositoryInterface;
 use Sylius\Component\Review\Factory\ReviewFactoryInterface;
 use Sylius\Component\Review\Model\ReviewInterface;
-use Sylius\ShopApiPlugin\Command\AddProductReviewByCode;
-use Sylius\ShopApiPlugin\Provider\ProductReviewerProviderInterface;
+use Sylius\SyliusShopApiPlugin\Command\AddProductReviewByCode;
+use Sylius\SyliusShopApiPlugin\Provider\ProductReviewerProviderInterface;
 
 final class AddProductReviewByCodeHandlerSpec extends ObjectBehavior
 {

--- a/spec/Handler/AddProductReviewBySlugHandlerSpec.php
+++ b/spec/Handler/AddProductReviewBySlugHandlerSpec.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\ShopApiPlugin\Handler;
+namespace spec\Sylius\SyliusShopApiPlugin\Handler;
 
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Channel\Repository\ChannelRepositoryInterface;
@@ -14,8 +14,8 @@ use Sylius\Component\Core\Repository\ProductReviewRepositoryInterface;
 use Sylius\Component\Locale\Model\LocaleInterface;
 use Sylius\Component\Review\Factory\ReviewFactoryInterface;
 use Sylius\Component\Review\Model\ReviewInterface;
-use Sylius\ShopApiPlugin\Command\AddProductReviewBySlug;
-use Sylius\ShopApiPlugin\Provider\ProductReviewerProviderInterface;
+use Sylius\SyliusShopApiPlugin\Command\AddProductReviewBySlug;
+use Sylius\SyliusShopApiPlugin\Provider\ProductReviewerProviderInterface;
 
 final class AddProductReviewBySlugHandlerSpec extends ObjectBehavior
 {

--- a/spec/Handler/AddressOrderHandlerSpec.php
+++ b/spec/Handler/AddressOrderHandlerSpec.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\ShopApiPlugin\Handler;
+namespace spec\Sylius\SyliusShopApiPlugin\Handler;
 
 use PhpSpec\ObjectBehavior;
 use SM\Factory\FactoryInterface;
@@ -12,8 +12,8 @@ use Sylius\Component\Core\Model\AddressInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\OrderCheckoutTransitions;
 use Sylius\Component\Core\Repository\OrderRepositoryInterface;
-use Sylius\ShopApiPlugin\Command\AddressOrder as AddressShipmentCommand;
-use Sylius\ShopApiPlugin\Model\Address;
+use Sylius\SyliusShopApiPlugin\Command\AddressOrder as AddressShipmentCommand;
+use Sylius\SyliusShopApiPlugin\Model\Address;
 
 final class AddressOrderHandlerSpec extends ObjectBehavior
 {

--- a/spec/Handler/ChangeItemQuantityHandlerSpec.php
+++ b/spec/Handler/ChangeItemQuantityHandlerSpec.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\ShopApiPlugin\Handler;
+namespace spec\Sylius\SyliusShopApiPlugin\Handler;
 
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Core\Model\OrderInterface;
@@ -11,7 +11,7 @@ use Sylius\Component\Core\Repository\OrderRepositoryInterface;
 use Sylius\Component\Order\Modifier\OrderItemQuantityModifierInterface;
 use Sylius\Component\Order\Processor\OrderProcessorInterface;
 use Sylius\Component\Order\Repository\OrderItemRepositoryInterface;
-use Sylius\ShopApiPlugin\Command\ChangeItemQuantity;
+use Sylius\SyliusShopApiPlugin\Command\ChangeItemQuantity;
 
 final class ChangeItemQuantityHandlerSpec extends ObjectBehavior
 {

--- a/spec/Handler/ChoosePaymentMethodHandlerSpec.php
+++ b/spec/Handler/ChoosePaymentMethodHandlerSpec.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\ShopApiPlugin\Handler;
+namespace spec\Sylius\SyliusShopApiPlugin\Handler;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use PhpSpec\ObjectBehavior;
@@ -15,7 +15,7 @@ use Sylius\Component\Core\Model\PaymentMethodInterface;
 use Sylius\Component\Core\OrderCheckoutTransitions;
 use Sylius\Component\Core\Repository\OrderRepositoryInterface;
 use Sylius\Component\Core\Repository\PaymentMethodRepositoryInterface;
-use Sylius\ShopApiPlugin\Command\ChoosePaymentMethod;
+use Sylius\SyliusShopApiPlugin\Command\ChoosePaymentMethod;
 
 final class ChoosePaymentMethodHandlerSpec extends ObjectBehavior
 {

--- a/spec/Handler/ChooseShippingMethodHandlerSpec.php
+++ b/spec/Handler/ChooseShippingMethodHandlerSpec.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\ShopApiPlugin\Handler;
+namespace spec\Sylius\SyliusShopApiPlugin\Handler;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use PhpSpec\ObjectBehavior;
@@ -16,7 +16,7 @@ use Sylius\Component\Core\OrderCheckoutTransitions;
 use Sylius\Component\Core\Repository\OrderRepositoryInterface;
 use Sylius\Component\Core\Repository\ShippingMethodRepositoryInterface;
 use Sylius\Component\Shipping\Checker\ShippingMethodEligibilityCheckerInterface;
-use Sylius\ShopApiPlugin\Command\ChooseShippingMethod;
+use Sylius\SyliusShopApiPlugin\Command\ChooseShippingMethod;
 
 final class ChooseShippingMethodHandlerSpec extends ObjectBehavior
 {

--- a/spec/Handler/CompleteOrderHandlerSpec.php
+++ b/spec/Handler/CompleteOrderHandlerSpec.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\ShopApiPlugin\Handler;
+namespace spec\Sylius\SyliusShopApiPlugin\Handler;
 
 use PhpSpec\ObjectBehavior;
 use SM\Factory\FactoryInterface as StateMachineFactoryInterface;
@@ -11,8 +11,8 @@ use Sylius\Component\Core\Model\CustomerInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\OrderCheckoutTransitions;
 use Sylius\Component\Core\Repository\OrderRepositoryInterface;
-use Sylius\ShopApiPlugin\Command\CompleteOrder;
-use Sylius\ShopApiPlugin\Provider\CustomerProviderInterface;
+use Sylius\SyliusShopApiPlugin\Command\CompleteOrder;
+use Sylius\SyliusShopApiPlugin\Provider\CustomerProviderInterface;
 
 final class CompleteOrderHandlerSpec extends ObjectBehavior
 {

--- a/spec/Handler/DropCartHandlerSpec.php
+++ b/spec/Handler/DropCartHandlerSpec.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\ShopApiPlugin\Handler;
+namespace spec\Sylius\SyliusShopApiPlugin\Handler;
 
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Repository\OrderRepositoryInterface;
-use Sylius\ShopApiPlugin\Command\DropCart;
+use Sylius\SyliusShopApiPlugin\Command\DropCart;
 
 final class DropCartHandlerSpec extends ObjectBehavior
 {

--- a/spec/Handler/GenerateResetPasswordTokenHandlerSpec.php
+++ b/spec/Handler/GenerateResetPasswordTokenHandlerSpec.php
@@ -2,15 +2,15 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\ShopApiPlugin\Handler;
+namespace spec\Sylius\SyliusShopApiPlugin\Handler;
 
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Sylius\Component\Core\Model\ShopUserInterface;
 use Sylius\Component\User\Repository\UserRepositoryInterface;
 use Sylius\Component\User\Security\Generator\GeneratorInterface;
-use Sylius\ShopApiPlugin\Command\GenerateResetPasswordToken;
-use Sylius\ShopApiPlugin\Handler\GenerateResetPasswordTokenHandler;
+use Sylius\SyliusShopApiPlugin\Command\GenerateResetPasswordToken;
+use Sylius\SyliusShopApiPlugin\Handler\GenerateResetPasswordTokenHandler;
 
 final class GenerateResetPasswordTokenHandlerSpec extends ObjectBehavior
 {

--- a/spec/Handler/GenerateVerificationTokenHandlerSpec.php
+++ b/spec/Handler/GenerateVerificationTokenHandlerSpec.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\ShopApiPlugin\Handler;
+namespace spec\Sylius\SyliusShopApiPlugin\Handler;
 
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Core\Model\ShopUserInterface;
 use Sylius\Component\User\Repository\UserRepositoryInterface;
 use Sylius\Component\User\Security\Generator\GeneratorInterface;
-use Sylius\ShopApiPlugin\Command\GenerateVerificationToken;
-use Sylius\ShopApiPlugin\Handler\GenerateVerificationTokenHandler;
+use Sylius\SyliusShopApiPlugin\Command\GenerateVerificationToken;
+use Sylius\SyliusShopApiPlugin\Handler\GenerateVerificationTokenHandler;
 
 final class GenerateVerificationTokenHandlerSpec extends ObjectBehavior
 {

--- a/spec/Handler/PickupCartHandlerSpec.php
+++ b/spec/Handler/PickupCartHandlerSpec.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\ShopApiPlugin\Handler;
+namespace spec\Sylius\SyliusShopApiPlugin\Handler;
 
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Channel\Repository\ChannelRepositoryInterface;
@@ -12,7 +12,7 @@ use Sylius\Component\Core\Repository\OrderRepositoryInterface;
 use Sylius\Component\Currency\Model\CurrencyInterface;
 use Sylius\Component\Locale\Model\LocaleInterface;
 use Sylius\Component\Resource\Factory\FactoryInterface;
-use Sylius\ShopApiPlugin\Command\PickupCart;
+use Sylius\SyliusShopApiPlugin\Command\PickupCart;
 
 final class PickupCartHandlerSpec extends ObjectBehavior
 {

--- a/spec/Handler/PutOptionBasedConfigurableItemToCartHandlerSpec.php
+++ b/spec/Handler/PutOptionBasedConfigurableItemToCartHandlerSpec.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\ShopApiPlugin\Handler;
+namespace spec\Sylius\SyliusShopApiPlugin\Handler;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use PhpSpec\ObjectBehavior;
@@ -13,8 +13,8 @@ use Sylius\Component\Core\Model\ProductVariantInterface;
 use Sylius\Component\Core\Repository\OrderRepositoryInterface;
 use Sylius\Component\Core\Repository\ProductRepositoryInterface;
 use Sylius\Component\Product\Model\ProductOptionValueInterface;
-use Sylius\ShopApiPlugin\Command\PutOptionBasedConfigurableItemToCart;
-use Sylius\ShopApiPlugin\Modifier\OrderModifierInterface;
+use Sylius\SyliusShopApiPlugin\Command\PutOptionBasedConfigurableItemToCart;
+use Sylius\SyliusShopApiPlugin\Modifier\OrderModifierInterface;
 
 final class PutOptionBasedConfigurableItemToCartHandlerSpec extends ObjectBehavior
 {

--- a/spec/Handler/PutSimpleItemToCartHandlerSpec.php
+++ b/spec/Handler/PutSimpleItemToCartHandlerSpec.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\ShopApiPlugin\Handler;
+namespace spec\Sylius\SyliusShopApiPlugin\Handler;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use PhpSpec\ObjectBehavior;
@@ -11,8 +11,8 @@ use Sylius\Component\Core\Model\ProductInterface;
 use Sylius\Component\Core\Model\ProductVariantInterface;
 use Sylius\Component\Core\Repository\OrderRepositoryInterface;
 use Sylius\Component\Core\Repository\ProductRepositoryInterface;
-use Sylius\ShopApiPlugin\Command\PutSimpleItemToCart;
-use Sylius\ShopApiPlugin\Modifier\OrderModifierInterface;
+use Sylius\SyliusShopApiPlugin\Command\PutSimpleItemToCart;
+use Sylius\SyliusShopApiPlugin\Modifier\OrderModifierInterface;
 
 final class PutSimpleItemToCartHandlerSpec extends ObjectBehavior
 {

--- a/spec/Handler/PutVariantBasedConfigurableItemToCartHandlerSpec.php
+++ b/spec/Handler/PutVariantBasedConfigurableItemToCartHandlerSpec.php
@@ -2,15 +2,15 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\ShopApiPlugin\Handler;
+namespace spec\Sylius\SyliusShopApiPlugin\Handler;
 
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\ProductVariantInterface;
 use Sylius\Component\Core\Repository\OrderRepositoryInterface;
 use Sylius\Component\Core\Repository\ProductVariantRepositoryInterface;
-use Sylius\ShopApiPlugin\Command\PutVariantBasedConfigurableItemToCart;
-use Sylius\ShopApiPlugin\Modifier\OrderModifierInterface;
+use Sylius\SyliusShopApiPlugin\Command\PutVariantBasedConfigurableItemToCart;
+use Sylius\SyliusShopApiPlugin\Modifier\OrderModifierInterface;
 
 final class PutVariantBasedConfigurableItemToCartHandlerSpec extends ObjectBehavior
 {

--- a/spec/Handler/SendResetPasswordTokenHandlerSpec.php
+++ b/spec/Handler/SendResetPasswordTokenHandlerSpec.php
@@ -2,15 +2,15 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\ShopApiPlugin\Handler;
+namespace spec\Sylius\SyliusShopApiPlugin\Handler;
 
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Core\Model\ShopUserInterface;
 use Sylius\Component\Mailer\Sender\SenderInterface;
 use Sylius\Component\User\Repository\UserRepositoryInterface;
-use Sylius\ShopApiPlugin\Command\SendResetPasswordToken;
-use Sylius\ShopApiPlugin\Handler\SendResetPasswordTokenHandler;
-use Sylius\ShopApiPlugin\Mailer\Emails;
+use Sylius\SyliusShopApiPlugin\Command\SendResetPasswordToken;
+use Sylius\SyliusShopApiPlugin\Handler\SendResetPasswordTokenHandler;
+use Sylius\SyliusShopApiPlugin\Mailer\Emails;
 
 final class SendResetPasswordTokenHandlerSpec extends ObjectBehavior
 {

--- a/spec/Handler/SendVerificationTokenHandlerSpec.php
+++ b/spec/Handler/SendVerificationTokenHandlerSpec.php
@@ -2,15 +2,15 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\ShopApiPlugin\Handler;
+namespace spec\Sylius\SyliusShopApiPlugin\Handler;
 
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Core\Model\ShopUserInterface;
 use Sylius\Component\Mailer\Sender\SenderInterface;
 use Sylius\Component\User\Repository\UserRepositoryInterface;
-use Sylius\ShopApiPlugin\Command\SendVerificationToken;
-use Sylius\ShopApiPlugin\Handler\SendVerificationTokenHandler;
-use Sylius\ShopApiPlugin\Mailer\Emails;
+use Sylius\SyliusShopApiPlugin\Command\SendVerificationToken;
+use Sylius\SyliusShopApiPlugin\Handler\SendVerificationTokenHandler;
+use Sylius\SyliusShopApiPlugin\Mailer\Emails;
 
 final class SendVerificationTokenHandlerSpec extends ObjectBehavior
 {

--- a/spec/Handler/UpdateCustomerHandlerSpec.php
+++ b/spec/Handler/UpdateCustomerHandlerSpec.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\ShopApiPlugin\Handler;
+namespace spec\Sylius\SyliusShopApiPlugin\Handler;
 
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Core\Model\CustomerInterface;
 use Sylius\Component\Resource\Repository\RepositoryInterface;
-use Sylius\ShopApiPlugin\Command\UpdateCustomer;
+use Sylius\SyliusShopApiPlugin\Command\UpdateCustomer;
 
 final class UpdateCustomerHandlerSpec extends ObjectBehavior
 {

--- a/spec/Handler/VerifyAccountHandlerSpec.php
+++ b/spec/Handler/VerifyAccountHandlerSpec.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\ShopApiPlugin\Handler;
+namespace spec\Sylius\SyliusShopApiPlugin\Handler;
 
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Sylius\Component\Core\Model\ShopUserInterface;
 use Sylius\Component\User\Repository\UserRepositoryInterface;
-use Sylius\ShopApiPlugin\Command\VerifyAccount;
-use Sylius\ShopApiPlugin\Handler\VerifyAccountHandler;
+use Sylius\SyliusShopApiPlugin\Command\VerifyAccount;
+use Sylius\SyliusShopApiPlugin\Handler\VerifyAccountHandler;
 
 final class VerifyAccountHandlerSpec extends ObjectBehavior
 {

--- a/spec/Model/AddressSpec.php
+++ b/spec/Model/AddressSpec.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\ShopApiPlugin\Model;
+namespace spec\Sylius\SyliusShopApiPlugin\Model;
 
 use PhpSpec\ObjectBehavior;
 

--- a/spec/Modifier/OrderModifierSpec.php
+++ b/spec/Modifier/OrderModifierSpec.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\ShopApiPlugin\Modifier;
+namespace spec\Sylius\SyliusShopApiPlugin\Modifier;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Persistence\ObjectManager;
@@ -14,7 +14,7 @@ use Sylius\Component\Core\Model\OrderItemInterface;
 use Sylius\Component\Core\Model\ProductVariantInterface;
 use Sylius\Component\Order\Modifier\OrderItemQuantityModifierInterface;
 use Sylius\Component\Order\Processor\OrderProcessorInterface;
-use Sylius\ShopApiPlugin\Modifier\OrderModifierInterface;
+use Sylius\SyliusShopApiPlugin\Modifier\OrderModifierInterface;
 
 final class OrderModifierSpec extends ObjectBehavior
 {

--- a/spec/Provider/CustomerProviderSpec.php
+++ b/spec/Provider/CustomerProviderSpec.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\ShopApiPlugin\Provider;
+namespace spec\Sylius\SyliusShopApiPlugin\Provider;
 
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Core\Model\CustomerInterface;
 use Sylius\Component\Core\Repository\CustomerRepositoryInterface;
 use Sylius\Component\Resource\Factory\FactoryInterface;
-use Sylius\ShopApiPlugin\Provider\CustomerProviderInterface;
+use Sylius\SyliusShopApiPlugin\Provider\CustomerProviderInterface;
 
 final class CustomerProviderSpec extends ObjectBehavior
 {

--- a/spec/Provider/ProductReviewerProviderSpec.php
+++ b/spec/Provider/ProductReviewerProviderSpec.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\ShopApiPlugin\Provider;
+namespace spec\Sylius\SyliusShopApiPlugin\Provider;
 
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Core\Model\Customer;
-use Sylius\ShopApiPlugin\Provider\CustomerProviderInterface;
-use Sylius\ShopApiPlugin\Provider\ProductReviewerProviderInterface;
+use Sylius\SyliusShopApiPlugin\Provider\CustomerProviderInterface;
+use Sylius\SyliusShopApiPlugin\Provider\ProductReviewerProviderInterface;
 
 final class ProductReviewerProviderSpec extends ObjectBehavior
 {

--- a/spec/Validator/CartExistsValidatorSpec.php
+++ b/spec/Validator/CartExistsValidatorSpec.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\ShopApiPlugin\Validator;
+namespace spec\Sylius\SyliusShopApiPlugin\Validator;
 
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Repository\OrderRepositoryInterface;
-use Sylius\ShopApiPlugin\Validator\Constraints\CartExists;
+use Sylius\SyliusShopApiPlugin\Validator\Constraints\CartExists;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
 final class CartExistsValidatorSpec extends ObjectBehavior

--- a/spec/Validator/CartItemExistsValidatorSpec.php
+++ b/spec/Validator/CartItemExistsValidatorSpec.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\ShopApiPlugin\Validator;
+namespace spec\Sylius\SyliusShopApiPlugin\Validator;
 
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Sylius\Component\Core\Model\OrderItemInterface;
 use Sylius\Component\Order\Repository\OrderItemRepositoryInterface;
-use Sylius\ShopApiPlugin\Validator\Constraints\CartItemExists;
+use Sylius\SyliusShopApiPlugin\Validator\Constraints\CartItemExists;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
 final class CartItemExistsValidatorSpec extends ObjectBehavior

--- a/spec/Validator/ChannelExistsValidatorSpec.php
+++ b/spec/Validator/ChannelExistsValidatorSpec.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\ShopApiPlugin\Validator;
+namespace spec\Sylius\SyliusShopApiPlugin\Validator;
 
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Sylius\Component\Channel\Repository\ChannelRepositoryInterface;
 use Sylius\Component\Core\Model\ChannelInterface;
-use Sylius\ShopApiPlugin\Validator\Constraints\ChannelExists;
+use Sylius\SyliusShopApiPlugin\Validator\Constraints\ChannelExists;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
 final class ChannelExistsValidatorSpec extends ObjectBehavior

--- a/spec/Validator/ProductExistsValidatorSpec.php
+++ b/spec/Validator/ProductExistsValidatorSpec.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\ShopApiPlugin\Validator;
+namespace spec\Sylius\SyliusShopApiPlugin\Validator;
 
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Sylius\Component\Core\Model\ProductInterface;
 use Sylius\Component\Core\Repository\ProductRepositoryInterface;
-use Sylius\ShopApiPlugin\Validator\Constraints\ProductExists;
+use Sylius\SyliusShopApiPlugin\Validator\Constraints\ProductExists;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
 

--- a/spec/Validator/ShopUserExistsValidatorSpec.php
+++ b/spec/Validator/ShopUserExistsValidatorSpec.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\ShopApiPlugin\Validator;
+namespace spec\Sylius\SyliusShopApiPlugin\Validator;
 
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Sylius\Component\Core\Model\ShopUserInterface;
 use Sylius\Component\User\Repository\UserRepositoryInterface;
-use Sylius\ShopApiPlugin\Validator\Constraints\ShopUserExists;
-use Sylius\ShopApiPlugin\Validator\ShopUserExistsValidator;
+use Sylius\SyliusShopApiPlugin\Validator\Constraints\ShopUserExists;
+use Sylius\SyliusShopApiPlugin\Validator\ShopUserExistsValidator;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
 final class ShopUserExistsValidatorSpec extends ObjectBehavior

--- a/spec/Validator/SimpleProductValidatorSpec.php
+++ b/spec/Validator/SimpleProductValidatorSpec.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\ShopApiPlugin\Validator;
+namespace spec\Sylius\SyliusShopApiPlugin\Validator;
 
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Sylius\Component\Core\Model\ProductInterface;
 use Sylius\Component\Core\Repository\ProductRepositoryInterface;
-use Sylius\ShopApiPlugin\Validator\Constraints\SimpleProduct;
+use Sylius\SyliusShopApiPlugin\Validator\Constraints\SimpleProduct;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
 

--- a/spec/Validator/TokenIsNotUsedValidatorSpec.php
+++ b/spec/Validator/TokenIsNotUsedValidatorSpec.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\ShopApiPlugin\Validator;
+namespace spec\Sylius\SyliusShopApiPlugin\Validator;
 
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Repository\OrderRepositoryInterface;
-use Sylius\ShopApiPlugin\Validator\Constraints\TokenIsNotUsed;
+use Sylius\SyliusShopApiPlugin\Validator\Constraints\TokenIsNotUsed;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
 final class TokenIsNotUsedValidatorSpec extends ObjectBehavior

--- a/spec/ViewRepository/CartViewRepositorySpec.php
+++ b/spec/ViewRepository/CartViewRepositorySpec.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\ShopApiPlugin\ViewRepository;
+namespace spec\Sylius\SyliusShopApiPlugin\ViewRepository;
 
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Repository\OrderRepositoryInterface;
-use Sylius\ShopApiPlugin\Factory\CartViewFactoryInterface;
-use Sylius\ShopApiPlugin\View\CartSummaryView;
-use Sylius\ShopApiPlugin\ViewRepository\CartViewRepositoryInterface;
+use Sylius\SyliusShopApiPlugin\Factory\CartViewFactoryInterface;
+use Sylius\SyliusShopApiPlugin\View\CartSummaryView;
+use Sylius\SyliusShopApiPlugin\ViewRepository\CartViewRepositoryInterface;
 
 final class CartViewRepositorySpec extends ObjectBehavior
 {

--- a/spec/ViewRepository/ProductDetailsViewRepositorySpec.php
+++ b/spec/ViewRepository/ProductDetailsViewRepositorySpec.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\ShopApiPlugin\ViewRepository;
+namespace spec\Sylius\SyliusShopApiPlugin\ViewRepository;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use PhpSpec\ObjectBehavior;
@@ -11,9 +11,9 @@ use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\ProductInterface;
 use Sylius\Component\Core\Repository\ProductRepositoryInterface;
 use Sylius\Component\Locale\Model\LocaleInterface;
-use Sylius\ShopApiPlugin\Factory\ProductViewFactoryInterface;
-use Sylius\ShopApiPlugin\View\ProductView;
-use Sylius\ShopApiPlugin\ViewRepository\ProductDetailsViewRepositoryInterface;
+use Sylius\SyliusShopApiPlugin\Factory\ProductViewFactoryInterface;
+use Sylius\SyliusShopApiPlugin\View\ProductView;
+use Sylius\SyliusShopApiPlugin\ViewRepository\ProductDetailsViewRepositoryInterface;
 
 final class ProductDetailsViewRepositorySpec extends ObjectBehavior
 {

--- a/src/Checker/PromotionCouponEligibilityChecker.php
+++ b/src/Checker/PromotionCouponEligibilityChecker.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Checker;
+namespace Sylius\SyliusShopApiPlugin\Checker;
 
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\PromotionInterface;

--- a/src/Command/AddCoupon.php
+++ b/src/Command/AddCoupon.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Command;
+namespace Sylius\SyliusShopApiPlugin\Command;
 
 use Webmozart\Assert\Assert;
 

--- a/src/Command/AddProductReviewByCode.php
+++ b/src/Command/AddProductReviewByCode.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Command;
+namespace Sylius\SyliusShopApiPlugin\Command;
 
 final class AddProductReviewByCode
 {

--- a/src/Command/AddProductReviewBySlug.php
+++ b/src/Command/AddProductReviewBySlug.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Command;
+namespace Sylius\SyliusShopApiPlugin\Command;
 
 final class AddProductReviewBySlug
 {

--- a/src/Command/AddressOrder.php
+++ b/src/Command/AddressOrder.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Command;
+namespace Sylius\SyliusShopApiPlugin\Command;
 
-use Sylius\ShopApiPlugin\Model\Address;
+use Sylius\SyliusShopApiPlugin\Model\Address;
 use Webmozart\Assert\Assert;
 
 final class AddressOrder

--- a/src/Command/ChangeItemQuantity.php
+++ b/src/Command/ChangeItemQuantity.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Command;
+namespace Sylius\SyliusShopApiPlugin\Command;
 
 use Webmozart\Assert\Assert;
 

--- a/src/Command/ChoosePaymentMethod.php
+++ b/src/Command/ChoosePaymentMethod.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Command;
+namespace Sylius\SyliusShopApiPlugin\Command;
 
 use Webmozart\Assert\Assert;
 

--- a/src/Command/ChooseShippingMethod.php
+++ b/src/Command/ChooseShippingMethod.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Command;
+namespace Sylius\SyliusShopApiPlugin\Command;
 
 use Webmozart\Assert\Assert;
 

--- a/src/Command/CompleteOrder.php
+++ b/src/Command/CompleteOrder.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Command;
+namespace Sylius\SyliusShopApiPlugin\Command;
 
 use Webmozart\Assert\Assert;
 

--- a/src/Command/DropCart.php
+++ b/src/Command/DropCart.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Command;
+namespace Sylius\SyliusShopApiPlugin\Command;
 
 use Webmozart\Assert\Assert;
 

--- a/src/Command/GenerateResetPasswordToken.php
+++ b/src/Command/GenerateResetPasswordToken.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Command;
+namespace Sylius\SyliusShopApiPlugin\Command;
 
 use Webmozart\Assert\Assert;
 

--- a/src/Command/GenerateVerificationToken.php
+++ b/src/Command/GenerateVerificationToken.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Command;
+namespace Sylius\SyliusShopApiPlugin\Command;
 
 use Webmozart\Assert\Assert;
 

--- a/src/Command/PickupCart.php
+++ b/src/Command/PickupCart.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Command;
+namespace Sylius\SyliusShopApiPlugin\Command;
 
 use Webmozart\Assert\Assert;
 

--- a/src/Command/PutOptionBasedConfigurableItemToCart.php
+++ b/src/Command/PutOptionBasedConfigurableItemToCart.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Command;
+namespace Sylius\SyliusShopApiPlugin\Command;
 
 use Webmozart\Assert\Assert;
 

--- a/src/Command/PutSimpleItemToCart.php
+++ b/src/Command/PutSimpleItemToCart.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Command;
+namespace Sylius\SyliusShopApiPlugin\Command;
 
 use Webmozart\Assert\Assert;
 

--- a/src/Command/PutVariantBasedConfigurableItemToCart.php
+++ b/src/Command/PutVariantBasedConfigurableItemToCart.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Command;
+namespace Sylius\SyliusShopApiPlugin\Command;
 
 use Webmozart\Assert\Assert;
 

--- a/src/Command/RegisterCustomer.php
+++ b/src/Command/RegisterCustomer.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Command;
+namespace Sylius\SyliusShopApiPlugin\Command;
 
 final class RegisterCustomer
 {

--- a/src/Command/RemoveCoupon.php
+++ b/src/Command/RemoveCoupon.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Command;
+namespace Sylius\SyliusShopApiPlugin\Command;
 
 use Webmozart\Assert\Assert;
 

--- a/src/Command/RemoveItemFromCart.php
+++ b/src/Command/RemoveItemFromCart.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Command;
+namespace Sylius\SyliusShopApiPlugin\Command;
 
 use Webmozart\Assert\Assert;
 

--- a/src/Command/SendResetPasswordToken.php
+++ b/src/Command/SendResetPasswordToken.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Command;
+namespace Sylius\SyliusShopApiPlugin\Command;
 
 final class SendResetPasswordToken
 {

--- a/src/Command/SendVerificationToken.php
+++ b/src/Command/SendVerificationToken.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Command;
+namespace Sylius\SyliusShopApiPlugin\Command;
 
 final class SendVerificationToken
 {

--- a/src/Command/UpdateCustomer.php
+++ b/src/Command/UpdateCustomer.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Command;
+namespace Sylius\SyliusShopApiPlugin\Command;
 
 final class UpdateCustomer
 {

--- a/src/Command/VerifyAccount.php
+++ b/src/Command/VerifyAccount.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Command;
+namespace Sylius\SyliusShopApiPlugin\Command;
 
 final class VerifyAccount
 {

--- a/src/Controller/Cart/AddCouponAction.php
+++ b/src/Controller/Cart/AddCouponAction.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Controller\Cart;
+namespace Sylius\SyliusShopApiPlugin\Controller\Cart;
 
 use FOS\RestBundle\View\View;
 use FOS\RestBundle\View\ViewHandlerInterface;
 use League\Tactician\CommandBus;
-use Sylius\ShopApiPlugin\Factory\ValidationErrorViewFactoryInterface;
-use Sylius\ShopApiPlugin\Request\AddCouponRequest;
-use Sylius\ShopApiPlugin\ViewRepository\CartViewRepositoryInterface;
+use Sylius\SyliusShopApiPlugin\Factory\ValidationErrorViewFactoryInterface;
+use Sylius\SyliusShopApiPlugin\Request\AddCouponRequest;
+use Sylius\SyliusShopApiPlugin\ViewRepository\CartViewRepositoryInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;

--- a/src/Controller/Cart/ChangeItemQuantityAction.php
+++ b/src/Controller/Cart/ChangeItemQuantityAction.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Controller\Cart;
+namespace Sylius\SyliusShopApiPlugin\Controller\Cart;
 
 use FOS\RestBundle\View\View;
 use FOS\RestBundle\View\ViewHandlerInterface;
 use League\Tactician\CommandBus;
-use Sylius\ShopApiPlugin\Factory\ValidationErrorViewFactoryInterface;
-use Sylius\ShopApiPlugin\Request\ChangeItemQuantityRequest;
-use Sylius\ShopApiPlugin\ViewRepository\CartViewRepositoryInterface;
+use Sylius\SyliusShopApiPlugin\Factory\ValidationErrorViewFactoryInterface;
+use Sylius\SyliusShopApiPlugin\Request\ChangeItemQuantityRequest;
+use Sylius\SyliusShopApiPlugin\ViewRepository\CartViewRepositoryInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;

--- a/src/Controller/Cart/DropCartAction.php
+++ b/src/Controller/Cart/DropCartAction.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Controller\Cart;
+namespace Sylius\SyliusShopApiPlugin\Controller\Cart;
 
 use FOS\RestBundle\View\View;
 use FOS\RestBundle\View\ViewHandlerInterface;
 use League\Tactician\CommandBus;
-use Sylius\ShopApiPlugin\Factory\ValidationErrorViewFactoryInterface;
-use Sylius\ShopApiPlugin\Request\DropCartRequest;
+use Sylius\SyliusShopApiPlugin\Factory\ValidationErrorViewFactoryInterface;
+use Sylius\SyliusShopApiPlugin\Request\DropCartRequest;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Validator\Validator\ValidatorInterface;

--- a/src/Controller/Cart/PickupAction.php
+++ b/src/Controller/Cart/PickupAction.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Controller\Cart;
+namespace Sylius\SyliusShopApiPlugin\Controller\Cart;
 
 use FOS\RestBundle\View\View;
 use FOS\RestBundle\View\ViewHandlerInterface;
 use League\Tactician\CommandBus;
-use Sylius\ShopApiPlugin\Factory\ValidationErrorViewFactoryInterface;
-use Sylius\ShopApiPlugin\Request\PickupCartRequest;
-use Sylius\ShopApiPlugin\ViewRepository\CartViewRepositoryInterface;
+use Sylius\SyliusShopApiPlugin\Factory\ValidationErrorViewFactoryInterface;
+use Sylius\SyliusShopApiPlugin\Request\PickupCartRequest;
+use Sylius\SyliusShopApiPlugin\ViewRepository\CartViewRepositoryInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;

--- a/src/Controller/Cart/PutItemToCartAction.php
+++ b/src/Controller/Cart/PutItemToCartAction.php
@@ -2,16 +2,16 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Controller\Cart;
+namespace Sylius\SyliusShopApiPlugin\Controller\Cart;
 
 use FOS\RestBundle\View\View;
 use FOS\RestBundle\View\ViewHandlerInterface;
 use League\Tactician\CommandBus;
-use Sylius\ShopApiPlugin\Factory\ValidationErrorViewFactoryInterface;
-use Sylius\ShopApiPlugin\Request\PutOptionBasedConfigurableItemToCartRequest;
-use Sylius\ShopApiPlugin\Request\PutSimpleItemToCartRequest;
-use Sylius\ShopApiPlugin\Request\PutVariantBasedConfigurableItemToCartRequest;
-use Sylius\ShopApiPlugin\ViewRepository\CartViewRepositoryInterface;
+use Sylius\SyliusShopApiPlugin\Factory\ValidationErrorViewFactoryInterface;
+use Sylius\SyliusShopApiPlugin\Request\PutOptionBasedConfigurableItemToCartRequest;
+use Sylius\SyliusShopApiPlugin\Request\PutSimpleItemToCartRequest;
+use Sylius\SyliusShopApiPlugin\Request\PutVariantBasedConfigurableItemToCartRequest;
+use Sylius\SyliusShopApiPlugin\ViewRepository\CartViewRepositoryInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;

--- a/src/Controller/Cart/PutItemsToCartAction.php
+++ b/src/Controller/Cart/PutItemsToCartAction.php
@@ -2,16 +2,16 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Controller\Cart;
+namespace Sylius\SyliusShopApiPlugin\Controller\Cart;
 
 use FOS\RestBundle\View\View;
 use FOS\RestBundle\View\ViewHandlerInterface;
 use League\Tactician\CommandBus;
-use Sylius\ShopApiPlugin\Request\PutOptionBasedConfigurableItemToCartRequest;
-use Sylius\ShopApiPlugin\Request\PutSimpleItemToCartRequest;
-use Sylius\ShopApiPlugin\Request\PutVariantBasedConfigurableItemToCartRequest;
-use Sylius\ShopApiPlugin\View\ValidationErrorView;
-use Sylius\ShopApiPlugin\ViewRepository\CartViewRepositoryInterface;
+use Sylius\SyliusShopApiPlugin\Request\PutOptionBasedConfigurableItemToCartRequest;
+use Sylius\SyliusShopApiPlugin\Request\PutSimpleItemToCartRequest;
+use Sylius\SyliusShopApiPlugin\Request\PutVariantBasedConfigurableItemToCartRequest;
+use Sylius\SyliusShopApiPlugin\View\ValidationErrorView;
+use Sylius\SyliusShopApiPlugin\ViewRepository\CartViewRepositoryInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;

--- a/src/Controller/Cart/RemoveCouponAction.php
+++ b/src/Controller/Cart/RemoveCouponAction.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Controller\Cart;
+namespace Sylius\SyliusShopApiPlugin\Controller\Cart;
 
 use FOS\RestBundle\View\View;
 use FOS\RestBundle\View\ViewHandlerInterface;
 use League\Tactician\CommandBus;
-use Sylius\ShopApiPlugin\Factory\ValidationErrorViewFactoryInterface;
-use Sylius\ShopApiPlugin\Request\RemoveCouponRequest;
-use Sylius\ShopApiPlugin\ViewRepository\CartViewRepositoryInterface;
+use Sylius\SyliusShopApiPlugin\Factory\ValidationErrorViewFactoryInterface;
+use Sylius\SyliusShopApiPlugin\Request\RemoveCouponRequest;
+use Sylius\SyliusShopApiPlugin\ViewRepository\CartViewRepositoryInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;

--- a/src/Controller/Cart/RemoveItemFromCartAction.php
+++ b/src/Controller/Cart/RemoveItemFromCartAction.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Controller\Cart;
+namespace Sylius\SyliusShopApiPlugin\Controller\Cart;
 
 use FOS\RestBundle\View\View;
 use FOS\RestBundle\View\ViewHandlerInterface;
 use League\Tactician\CommandBus;
-use Sylius\ShopApiPlugin\Factory\ValidationErrorViewFactoryInterface;
-use Sylius\ShopApiPlugin\Request\RemoveItemFromCartRequest;
-use Sylius\ShopApiPlugin\ViewRepository\CartViewRepositoryInterface;
+use Sylius\SyliusShopApiPlugin\Factory\ValidationErrorViewFactoryInterface;
+use Sylius\SyliusShopApiPlugin\Request\RemoveItemFromCartRequest;
+use Sylius\SyliusShopApiPlugin\ViewRepository\CartViewRepositoryInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;

--- a/src/Controller/Cart/SummarizeAction.php
+++ b/src/Controller/Cart/SummarizeAction.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Controller\Cart;
+namespace Sylius\SyliusShopApiPlugin\Controller\Cart;
 
 use FOS\RestBundle\View\View;
 use FOS\RestBundle\View\ViewHandlerInterface;
-use Sylius\ShopApiPlugin\ViewRepository\CartViewRepositoryInterface;
+use Sylius\SyliusShopApiPlugin\ViewRepository\CartViewRepositoryInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;

--- a/src/Controller/CartController.php
+++ b/src/Controller/CartController.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Controller;
+namespace Sylius\SyliusShopApiPlugin\Controller;
 
 use FOS\RestBundle\View\View;
 use FOS\RestBundle\View\ViewHandlerInterface;
@@ -16,8 +16,8 @@ use Sylius\Component\Registry\ServiceRegistryInterface;
 use Sylius\Component\Resource\Factory\FactoryInterface;
 use Sylius\Component\Shipping\Exception\UnresolvedDefaultShippingMethodException;
 use Sylius\Component\Shipping\Resolver\ShippingMethodsResolverInterface;
-use Sylius\ShopApiPlugin\Factory\PriceViewFactoryInterface;
-use Sylius\ShopApiPlugin\View\EstimatedShippingCostView;
+use Sylius\SyliusShopApiPlugin\Factory\PriceViewFactoryInterface;
+use Sylius\SyliusShopApiPlugin\View\EstimatedShippingCostView;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;

--- a/src/Controller/Checkout/AddressAction.php
+++ b/src/Controller/Checkout/AddressAction.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Controller\Checkout;
+namespace Sylius\SyliusShopApiPlugin\Controller\Checkout;
 
 use FOS\RestBundle\View\View;
 use FOS\RestBundle\View\ViewHandlerInterface;
 use League\Tactician\CommandBus;
-use Sylius\ShopApiPlugin\Command\AddressOrder;
-use Sylius\ShopApiPlugin\Model\Address;
+use Sylius\SyliusShopApiPlugin\Command\AddressOrder;
+use Sylius\SyliusShopApiPlugin\Model\Address;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 

--- a/src/Controller/Checkout/ChoosePaymentMethodAction.php
+++ b/src/Controller/Checkout/ChoosePaymentMethodAction.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Controller\Checkout;
+namespace Sylius\SyliusShopApiPlugin\Controller\Checkout;
 
 use FOS\RestBundle\View\View;
 use FOS\RestBundle\View\ViewHandlerInterface;
 use League\Tactician\CommandBus;
-use Sylius\ShopApiPlugin\Command\ChoosePaymentMethod;
+use Sylius\SyliusShopApiPlugin\Command\ChoosePaymentMethod;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 

--- a/src/Controller/Checkout/ChooseShippingMethodAction.php
+++ b/src/Controller/Checkout/ChooseShippingMethodAction.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Controller\Checkout;
+namespace Sylius\SyliusShopApiPlugin\Controller\Checkout;
 
 use FOS\RestBundle\View\View;
 use FOS\RestBundle\View\ViewHandlerInterface;
 use League\Tactician\CommandBus;
-use Sylius\ShopApiPlugin\Command\ChooseShippingMethod;
+use Sylius\SyliusShopApiPlugin\Command\ChooseShippingMethod;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 

--- a/src/Controller/Checkout/CompleteOrderAction.php
+++ b/src/Controller/Checkout/CompleteOrderAction.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Controller\Checkout;
+namespace Sylius\SyliusShopApiPlugin\Controller\Checkout;
 
 use FOS\RestBundle\View\View;
 use FOS\RestBundle\View\ViewHandlerInterface;
 use League\Tactician\CommandBus;
 use Sylius\Component\Core\Model\ShopUserInterface;
-use Sylius\ShopApiPlugin\Command\CompleteOrder;
+use Sylius\SyliusShopApiPlugin\Command\CompleteOrder;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;

--- a/src/Controller/Checkout/ShowAvailablePaymentMethodsAction.php
+++ b/src/Controller/Checkout/ShowAvailablePaymentMethodsAction.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Controller\Checkout;
+namespace Sylius\SyliusShopApiPlugin\Controller\Checkout;
 
 use FOS\RestBundle\View\View;
 use FOS\RestBundle\View\ViewHandlerInterface;
@@ -11,7 +11,7 @@ use Sylius\Component\Core\Model\PaymentInterface;
 use Sylius\Component\Core\Model\PaymentMethodInterface;
 use Sylius\Component\Core\Repository\OrderRepositoryInterface;
 use Sylius\Component\Payment\Resolver\PaymentMethodsResolverInterface;
-use Sylius\ShopApiPlugin\Factory\PaymentMethodViewFactoryInterface;
+use Sylius\SyliusShopApiPlugin\Factory\PaymentMethodViewFactoryInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 

--- a/src/Controller/Checkout/ShowAvailableShippingMethodsAction.php
+++ b/src/Controller/Checkout/ShowAvailableShippingMethodsAction.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Controller\Checkout;
+namespace Sylius\SyliusShopApiPlugin\Controller\Checkout;
 
 use FOS\RestBundle\View\View;
 use FOS\RestBundle\View\ViewHandlerInterface;
@@ -11,7 +11,7 @@ use Sylius\Component\Core\Model\ShipmentInterface;
 use Sylius\Component\Core\Model\ShippingMethodInterface;
 use Sylius\Component\Core\Repository\OrderRepositoryInterface;
 use Sylius\Component\Shipping\Resolver\ShippingMethodsResolverInterface;
-use Sylius\ShopApiPlugin\Factory\ShippingMethodViewFactoryInterface;
+use Sylius\SyliusShopApiPlugin\Factory\ShippingMethodViewFactoryInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 

--- a/src/Controller/Customer/CustomerController.php
+++ b/src/Controller/Customer/CustomerController.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Controller\Customer;
+namespace Sylius\SyliusShopApiPlugin\Controller\Customer;
 
 use FOS\RestBundle\View\View;
 use Sylius\Bundle\ResourceBundle\Controller\ResourceController;
-use Sylius\ShopApiPlugin\View\ValidationErrorView;
+use Sylius\SyliusShopApiPlugin\View\ValidationErrorView;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 

--- a/src/Controller/Customer/LoggedInCustomerDetailsAction.php
+++ b/src/Controller/Customer/LoggedInCustomerDetailsAction.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Controller\Customer;
+namespace Sylius\SyliusShopApiPlugin\Controller\Customer;
 
 use FOS\RestBundle\View\View;
 use FOS\RestBundle\View\ViewHandlerInterface;

--- a/src/Controller/Customer/RegisterCustomerAction.php
+++ b/src/Controller/Customer/RegisterCustomerAction.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Controller\Customer;
+namespace Sylius\SyliusShopApiPlugin\Controller\Customer;
 
 use FOS\RestBundle\View\View;
 use FOS\RestBundle\View\ViewHandlerInterface;
 use League\Tactician\CommandBus;
-use Sylius\ShopApiPlugin\Factory\ValidationErrorViewFactoryInterface;
-use Sylius\ShopApiPlugin\Request\RegisterCustomerRequest;
+use Sylius\SyliusShopApiPlugin\Factory\ValidationErrorViewFactoryInterface;
+use Sylius\SyliusShopApiPlugin\Request\RegisterCustomerRequest;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Validator\Validator\ValidatorInterface;

--- a/src/Controller/Customer/RequestPasswordResettingAction.php
+++ b/src/Controller/Customer/RequestPasswordResettingAction.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Controller\Customer;
+namespace Sylius\SyliusShopApiPlugin\Controller\Customer;
 
 use FOS\RestBundle\View\View;
 use FOS\RestBundle\View\ViewHandlerInterface;
 use League\Tactician\CommandBus;
-use Sylius\ShopApiPlugin\Command\GenerateResetPasswordToken;
-use Sylius\ShopApiPlugin\Command\SendResetPasswordToken;
+use Sylius\SyliusShopApiPlugin\Command\GenerateResetPasswordToken;
+use Sylius\SyliusShopApiPlugin\Command\SendResetPasswordToken;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 

--- a/src/Controller/Customer/ResendVerificationTokenAction.php
+++ b/src/Controller/Customer/ResendVerificationTokenAction.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Controller\Customer;
+namespace Sylius\SyliusShopApiPlugin\Controller\Customer;
 
 use FOS\RestBundle\View\View;
 use FOS\RestBundle\View\ViewHandlerInterface;
 use League\Tactician\CommandBus;
-use Sylius\ShopApiPlugin\Factory\ValidationErrorViewFactoryInterface;
-use Sylius\ShopApiPlugin\Request\ResendVerificationTokenRequest;
+use Sylius\SyliusShopApiPlugin\Factory\ValidationErrorViewFactoryInterface;
+use Sylius\SyliusShopApiPlugin\Request\ResendVerificationTokenRequest;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Validator\Validator\ValidatorInterface;

--- a/src/Controller/Customer/UpdateCustomerAction.php
+++ b/src/Controller/Customer/UpdateCustomerAction.php
@@ -2,15 +2,15 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Controller\Customer;
+namespace Sylius\SyliusShopApiPlugin\Controller\Customer;
 
 use FOS\RestBundle\View\View;
 use FOS\RestBundle\View\ViewHandlerInterface;
 use League\Tactician\CommandBus;
 use Sylius\Component\Core\Model\ShopUserInterface;
-use Sylius\ShopApiPlugin\Factory\CustomerViewFactoryInterface;
-use Sylius\ShopApiPlugin\Factory\ValidationErrorViewFactoryInterface;
-use Sylius\ShopApiPlugin\Request\UpdateCustomerRequest;
+use Sylius\SyliusShopApiPlugin\Factory\CustomerViewFactoryInterface;
+use Sylius\SyliusShopApiPlugin\Factory\ValidationErrorViewFactoryInterface;
+use Sylius\SyliusShopApiPlugin\Request\UpdateCustomerRequest;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;

--- a/src/Controller/Customer/VerifyAccountAction.php
+++ b/src/Controller/Customer/VerifyAccountAction.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Controller\Customer;
+namespace Sylius\SyliusShopApiPlugin\Controller\Customer;
 
 use FOS\RestBundle\View\View;
 use FOS\RestBundle\View\ViewHandlerInterface;
 use League\Tactician\CommandBus;
-use Sylius\ShopApiPlugin\Factory\ValidationErrorViewFactoryInterface;
-use Sylius\ShopApiPlugin\Request\VerifyAccountRequest;
+use Sylius\SyliusShopApiPlugin\Factory\ValidationErrorViewFactoryInterface;
+use Sylius\SyliusShopApiPlugin\Request\VerifyAccountRequest;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Validator\Validator\ValidatorInterface;

--- a/src/Controller/Product/AddReviewByCodeAction.php
+++ b/src/Controller/Product/AddReviewByCodeAction.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Controller\Product;
+namespace Sylius\SyliusShopApiPlugin\Controller\Product;
 
 use FOS\RestBundle\View\View;
 use FOS\RestBundle\View\ViewHandlerInterface;
 use League\Tactician\CommandBus;
-use Sylius\ShopApiPlugin\Factory\ValidationErrorViewFactoryInterface;
-use Sylius\ShopApiPlugin\Request\AddProductReviewByCodeRequest;
+use Sylius\SyliusShopApiPlugin\Factory\ValidationErrorViewFactoryInterface;
+use Sylius\SyliusShopApiPlugin\Request\AddProductReviewByCodeRequest;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Validator\Validator\ValidatorInterface;

--- a/src/Controller/Product/AddReviewBySlugAction.php
+++ b/src/Controller/Product/AddReviewBySlugAction.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Controller\Product;
+namespace Sylius\SyliusShopApiPlugin\Controller\Product;
 
 use FOS\RestBundle\View\View;
 use FOS\RestBundle\View\ViewHandlerInterface;
 use League\Tactician\CommandBus;
-use Sylius\ShopApiPlugin\Factory\ValidationErrorViewFactoryInterface;
-use Sylius\ShopApiPlugin\Request\AddProductReviewBySlugRequest;
+use Sylius\SyliusShopApiPlugin\Factory\ValidationErrorViewFactoryInterface;
+use Sylius\SyliusShopApiPlugin\Request\AddProductReviewBySlugRequest;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Validator\Validator\ValidatorInterface;

--- a/src/Controller/Product/ShowLatestProductAction.php
+++ b/src/Controller/Product/ShowLatestProductAction.php
@@ -1,11 +1,11 @@
 <?php
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Controller\Product;
+namespace Sylius\SyliusShopApiPlugin\Controller\Product;
 
 use FOS\RestBundle\View\View;
 use FOS\RestBundle\View\ViewHandlerInterface;
-use Sylius\ShopApiPlugin\ViewRepository\ProductLatestViewRepositoryInterface;
+use Sylius\SyliusShopApiPlugin\ViewRepository\ProductLatestViewRepositoryInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;

--- a/src/Controller/Product/ShowProductCatalogByTaxonCodeAction.php
+++ b/src/Controller/Product/ShowProductCatalogByTaxonCodeAction.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Controller\Product;
+namespace Sylius\SyliusShopApiPlugin\Controller\Product;
 
 use FOS\RestBundle\View\View;
 use FOS\RestBundle\View\ViewHandlerInterface;
-use Sylius\ShopApiPlugin\Model\PaginatorDetails;
-use Sylius\ShopApiPlugin\ViewRepository\ProductCatalogViewRepositoryInterface;
+use Sylius\SyliusShopApiPlugin\Model\PaginatorDetails;
+use Sylius\SyliusShopApiPlugin\ViewRepository\ProductCatalogViewRepositoryInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;

--- a/src/Controller/Product/ShowProductCatalogByTaxonSlugAction.php
+++ b/src/Controller/Product/ShowProductCatalogByTaxonSlugAction.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Controller\Product;
+namespace Sylius\SyliusShopApiPlugin\Controller\Product;
 
 use FOS\RestBundle\View\View;
 use FOS\RestBundle\View\ViewHandlerInterface;
-use Sylius\ShopApiPlugin\Model\PaginatorDetails;
-use Sylius\ShopApiPlugin\ViewRepository\ProductCatalogViewRepositoryInterface;
+use Sylius\SyliusShopApiPlugin\Model\PaginatorDetails;
+use Sylius\SyliusShopApiPlugin\ViewRepository\ProductCatalogViewRepositoryInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;

--- a/src/Controller/Product/ShowProductDetailsByCodeAction.php
+++ b/src/Controller/Product/ShowProductDetailsByCodeAction.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Controller\Product;
+namespace Sylius\SyliusShopApiPlugin\Controller\Product;
 
 use FOS\RestBundle\View\View;
 use FOS\RestBundle\View\ViewHandlerInterface;
-use Sylius\ShopApiPlugin\ViewRepository\ProductDetailsViewRepositoryInterface;
+use Sylius\SyliusShopApiPlugin\ViewRepository\ProductDetailsViewRepositoryInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;

--- a/src/Controller/Product/ShowProductDetailsBySlugAction.php
+++ b/src/Controller/Product/ShowProductDetailsBySlugAction.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Controller\Product;
+namespace Sylius\SyliusShopApiPlugin\Controller\Product;
 
 use FOS\RestBundle\View\View;
 use FOS\RestBundle\View\ViewHandlerInterface;
-use Sylius\ShopApiPlugin\ViewRepository\ProductDetailsViewRepositoryInterface;
+use Sylius\SyliusShopApiPlugin\ViewRepository\ProductDetailsViewRepositoryInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;

--- a/src/Controller/Product/ShowProductReviewsByCodeAction.php
+++ b/src/Controller/Product/ShowProductReviewsByCodeAction.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Controller\Product;
+namespace Sylius\SyliusShopApiPlugin\Controller\Product;
 
 use FOS\RestBundle\View\View;
 use FOS\RestBundle\View\ViewHandlerInterface;
-use Sylius\ShopApiPlugin\Model\PaginatorDetails;
-use Sylius\ShopApiPlugin\ViewRepository\ProductReviewsViewRepositoryInterface;
+use Sylius\SyliusShopApiPlugin\Model\PaginatorDetails;
+use Sylius\SyliusShopApiPlugin\ViewRepository\ProductReviewsViewRepositoryInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;

--- a/src/Controller/Product/ShowProductReviewsBySlugAction.php
+++ b/src/Controller/Product/ShowProductReviewsBySlugAction.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Controller\Product;
+namespace Sylius\SyliusShopApiPlugin\Controller\Product;
 
 use FOS\RestBundle\View\View;
 use FOS\RestBundle\View\ViewHandlerInterface;
-use Sylius\ShopApiPlugin\Model\PaginatorDetails;
-use Sylius\ShopApiPlugin\ViewRepository\ProductReviewsViewRepositoryInterface;
+use Sylius\SyliusShopApiPlugin\Model\PaginatorDetails;
+use Sylius\SyliusShopApiPlugin\ViewRepository\ProductReviewsViewRepositoryInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;

--- a/src/Controller/Taxon/ShowTaxonDetailsAction.php
+++ b/src/Controller/Taxon/ShowTaxonDetailsAction.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Controller\Taxon;
+namespace Sylius\SyliusShopApiPlugin\Controller\Taxon;
 
 use FOS\RestBundle\View\View;
 use FOS\RestBundle\View\ViewHandlerInterface;
 use Sylius\Component\Taxonomy\Repository\TaxonRepositoryInterface;
-use Sylius\ShopApiPlugin\Factory\TaxonDetailsViewFactoryInterface;
+use Sylius\SyliusShopApiPlugin\Factory\TaxonDetailsViewFactoryInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;

--- a/src/Controller/Taxon/ShowTaxonTreeAction.php
+++ b/src/Controller/Taxon/ShowTaxonTreeAction.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Controller\Taxon;
+namespace Sylius\SyliusShopApiPlugin\Controller\Taxon;
 
 use FOS\RestBundle\View\View;
 use FOS\RestBundle\View\ViewHandlerInterface;
 use Sylius\Component\Core\Model\TaxonInterface;
 use Sylius\Component\Taxonomy\Repository\TaxonRepositoryInterface;
-use Sylius\ShopApiPlugin\Factory\TaxonViewFactoryInterface;
-use Sylius\ShopApiPlugin\View\TaxonView;
+use Sylius\SyliusShopApiPlugin\Factory\TaxonViewFactoryInterface;
+use Sylius\SyliusShopApiPlugin\View\TaxonView;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\DependencyInjection;
+namespace Sylius\SyliusShopApiPlugin\DependencyInjection;
 
-use Sylius\ShopApiPlugin\View;
+use Sylius\SyliusShopApiPlugin\View;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;

--- a/src/DependencyInjection/ShopApiExtension.php
+++ b/src/DependencyInjection/ShopApiExtension.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\DependencyInjection;
+namespace Sylius\SyliusShopApiPlugin\DependencyInjection;
 
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;

--- a/src/Event/CustomerRegistered.php
+++ b/src/Event/CustomerRegistered.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Event;
+namespace Sylius\SyliusShopApiPlugin\Event;
 
 use Symfony\Component\EventDispatcher\Event;
 

--- a/src/EventListener/RequestLocaleSetter.php
+++ b/src/EventListener/RequestLocaleSetter.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\EventListener;
+namespace Sylius\SyliusShopApiPlugin\EventListener;
 
 use Sylius\Component\Locale\Provider\LocaleProviderInterface;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;

--- a/src/EventListener/UserRegistrationListener.php
+++ b/src/EventListener/UserRegistrationListener.php
@@ -2,16 +2,16 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\EventListener;
+namespace Sylius\SyliusShopApiPlugin\EventListener;
 
 use Doctrine\Common\Persistence\ObjectManager;
 use League\Tactician\CommandBus;
 use Sylius\Component\Channel\Repository\ChannelRepositoryInterface;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\User\Repository\UserRepositoryInterface;
-use Sylius\ShopApiPlugin\Command\GenerateVerificationToken;
-use Sylius\ShopApiPlugin\Command\SendVerificationToken;
-use Sylius\ShopApiPlugin\Event\CustomerRegistered;
+use Sylius\SyliusShopApiPlugin\Command\GenerateVerificationToken;
+use Sylius\SyliusShopApiPlugin\Command\SendVerificationToken;
+use Sylius\SyliusShopApiPlugin\Event\CustomerRegistered;
 use Webmozart\Assert\Assert;
 
 final class UserRegistrationListener

--- a/src/Factory/AddressViewFactory.php
+++ b/src/Factory/AddressViewFactory.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Factory;
+namespace Sylius\SyliusShopApiPlugin\Factory;
 
 use Sylius\Component\Core\Model\AddressInterface;
-use Sylius\ShopApiPlugin\View\AddressView;
+use Sylius\SyliusShopApiPlugin\View\AddressView;
 
 final class AddressViewFactory implements AddressViewFactoryInterface
 {

--- a/src/Factory/AddressViewFactoryInterface.php
+++ b/src/Factory/AddressViewFactoryInterface.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Factory;
+namespace Sylius\SyliusShopApiPlugin\Factory;
 
 use Sylius\Component\Core\Model\AddressInterface;
-use Sylius\ShopApiPlugin\View\AddressView;
+use Sylius\SyliusShopApiPlugin\View\AddressView;
 
 interface AddressViewFactoryInterface
 {

--- a/src/Factory/AdjustmentViewFactory.php
+++ b/src/Factory/AdjustmentViewFactory.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Factory;
+namespace Sylius\SyliusShopApiPlugin\Factory;
 
 use Sylius\Component\Order\Model\AdjustmentInterface;
-use Sylius\ShopApiPlugin\View\AdjustmentView;
+use Sylius\SyliusShopApiPlugin\View\AdjustmentView;
 
 final class AdjustmentViewFactory implements AdjustmentViewFactoryInterface
 {

--- a/src/Factory/AdjustmentViewFactoryInterface.php
+++ b/src/Factory/AdjustmentViewFactoryInterface.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Factory;
+namespace Sylius\SyliusShopApiPlugin\Factory;
 
 use Sylius\Component\Order\Model\AdjustmentInterface;
-use Sylius\ShopApiPlugin\View\AdjustmentView;
+use Sylius\SyliusShopApiPlugin\View\AdjustmentView;
 
 interface AdjustmentViewFactoryInterface
 {

--- a/src/Factory/CartItemViewFactory.php
+++ b/src/Factory/CartItemViewFactory.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Factory;
+namespace Sylius\SyliusShopApiPlugin\Factory;
 
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\OrderItemInterface;
-use Sylius\ShopApiPlugin\View\ItemView;
+use Sylius\SyliusShopApiPlugin\View\ItemView;
 
 final class CartItemViewFactory implements CartItemViewFactoryInterface
 {

--- a/src/Factory/CartItemViewFactoryInterface.php
+++ b/src/Factory/CartItemViewFactoryInterface.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Factory;
+namespace Sylius\SyliusShopApiPlugin\Factory;
 
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\OrderItemInterface;
-use Sylius\ShopApiPlugin\View\ItemView;
+use Sylius\SyliusShopApiPlugin\View\ItemView;
 
 interface CartItemViewFactoryInterface
 {

--- a/src/Factory/CartViewFactory.php
+++ b/src/Factory/CartViewFactory.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Factory;
+namespace Sylius\SyliusShopApiPlugin\Factory;
 
 use Sylius\Component\Core\Model\AdjustmentInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\OrderItemInterface;
-use Sylius\ShopApiPlugin\View\AdjustmentView;
-use Sylius\ShopApiPlugin\View\CartSummaryView;
+use Sylius\SyliusShopApiPlugin\View\AdjustmentView;
+use Sylius\SyliusShopApiPlugin\View\CartSummaryView;
 
 final class CartViewFactory implements CartViewFactoryInterface
 {

--- a/src/Factory/CartViewFactoryInterface.php
+++ b/src/Factory/CartViewFactoryInterface.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Factory;
+namespace Sylius\SyliusShopApiPlugin\Factory;
 
 use Sylius\Component\Core\Model\OrderInterface;
-use Sylius\ShopApiPlugin\View\CartSummaryView;
+use Sylius\SyliusShopApiPlugin\View\CartSummaryView;
 
 interface CartViewFactoryInterface
 {

--- a/src/Factory/CustomerViewFactory.php
+++ b/src/Factory/CustomerViewFactory.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Factory;
+namespace Sylius\SyliusShopApiPlugin\Factory;
 
 use Sylius\Component\Core\Model\CustomerInterface;
-use Sylius\ShopApiPlugin\View\CustomerView;
+use Sylius\SyliusShopApiPlugin\View\CustomerView;
 
 final class CustomerViewFactory implements CustomerViewFactoryInterface
 {

--- a/src/Factory/CustomerViewFactoryInterface.php
+++ b/src/Factory/CustomerViewFactoryInterface.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Factory;
+namespace Sylius\SyliusShopApiPlugin\Factory;
 
 use Sylius\Component\Core\Model\CustomerInterface;
 

--- a/src/Factory/DetailedProductViewFactory.php
+++ b/src/Factory/DetailedProductViewFactory.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Factory;
+namespace Sylius\SyliusShopApiPlugin\Factory;
 
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\ProductInterface;
-use Sylius\ShopApiPlugin\Generator\ProductBreadcrumbGeneratorInterface;
-use Sylius\ShopApiPlugin\View\ProductView;
+use Sylius\SyliusShopApiPlugin\Generator\ProductBreadcrumbGeneratorInterface;
+use Sylius\SyliusShopApiPlugin\View\ProductView;
 
 final class DetailedProductViewFactory implements ProductViewFactoryInterface
 {

--- a/src/Factory/ImageViewFactory.php
+++ b/src/Factory/ImageViewFactory.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Factory;
+namespace Sylius\SyliusShopApiPlugin\Factory;
 
 use Sylius\Component\Core\Model\ImageInterface;
-use Sylius\ShopApiPlugin\View\ImageView;
+use Sylius\SyliusShopApiPlugin\View\ImageView;
 
 final class ImageViewFactory implements ImageViewFactoryInterface
 {

--- a/src/Factory/ImageViewFactoryInterface.php
+++ b/src/Factory/ImageViewFactoryInterface.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Factory;
+namespace Sylius\SyliusShopApiPlugin\Factory;
 
 use Sylius\Component\Core\Model\ImageInterface;
-use Sylius\ShopApiPlugin\View\ImageView;
+use Sylius\SyliusShopApiPlugin\View\ImageView;
 
 interface ImageViewFactoryInterface
 {

--- a/src/Factory/LimitedProductAttributeValuesViewFactory.php
+++ b/src/Factory/LimitedProductAttributeValuesViewFactory.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Factory;
+namespace Sylius\SyliusShopApiPlugin\Factory;
 
 use Sylius\Component\Product\Model\ProductAttributeValueInterface;
 

--- a/src/Factory/ListProductViewFactory.php
+++ b/src/Factory/ListProductViewFactory.php
@@ -2,15 +2,15 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Factory;
+namespace Sylius\SyliusShopApiPlugin\Factory;
 
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\ProductImageInterface;
 use Sylius\Component\Core\Model\ProductInterface;
 use Sylius\Component\Core\Model\ProductVariantInterface;
 use Sylius\Component\Product\Model\ProductAssociationInterface;
-use Sylius\ShopApiPlugin\View\ProductVariantView;
-use Sylius\ShopApiPlugin\View\ProductView;
+use Sylius\SyliusShopApiPlugin\View\ProductVariantView;
+use Sylius\SyliusShopApiPlugin\View\ProductView;
 
 final class ListProductViewFactory implements ProductViewFactoryInterface
 {

--- a/src/Factory/PageViewFactory.php
+++ b/src/Factory/PageViewFactory.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Factory;
+namespace Sylius\SyliusShopApiPlugin\Factory;
 
 use Pagerfanta\Pagerfanta;
-use Sylius\ShopApiPlugin\View\PageView;
+use Sylius\SyliusShopApiPlugin\View\PageView;
 use Symfony\Component\Routing\RouterInterface;
 
 final class PageViewFactory implements PageViewFactoryInterface

--- a/src/Factory/PageViewFactoryInterface.php
+++ b/src/Factory/PageViewFactoryInterface.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Factory;
+namespace Sylius\SyliusShopApiPlugin\Factory;
 
 use Pagerfanta\Pagerfanta;
-use Sylius\ShopApiPlugin\View\PageView;
+use Sylius\SyliusShopApiPlugin\View\PageView;
 
 interface PageViewFactoryInterface
 {

--- a/src/Factory/PaymentMethodViewFactory.php
+++ b/src/Factory/PaymentMethodViewFactory.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Factory;
+namespace Sylius\SyliusShopApiPlugin\Factory;
 
 use Sylius\Component\Core\Model\PaymentMethodInterface;
-use Sylius\ShopApiPlugin\View\PaymentMethodView;
+use Sylius\SyliusShopApiPlugin\View\PaymentMethodView;
 
 final class PaymentMethodViewFactory implements PaymentMethodViewFactoryInterface
 {

--- a/src/Factory/PaymentMethodViewFactoryInterface.php
+++ b/src/Factory/PaymentMethodViewFactoryInterface.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Factory;
+namespace Sylius\SyliusShopApiPlugin\Factory;
 
 use Sylius\Component\Core\Model\PaymentMethodInterface;
-use Sylius\ShopApiPlugin\View\PaymentMethodView;
+use Sylius\SyliusShopApiPlugin\View\PaymentMethodView;
 
 interface PaymentMethodViewFactoryInterface
 {

--- a/src/Factory/PaymentViewFactory.php
+++ b/src/Factory/PaymentViewFactory.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Factory;
+namespace Sylius\SyliusShopApiPlugin\Factory;
 
 use Sylius\Component\Core\Model\PaymentInterface;
-use Sylius\ShopApiPlugin\View\PaymentView;
+use Sylius\SyliusShopApiPlugin\View\PaymentView;
 
 final class PaymentViewFactory implements PaymentViewFactoryInterface
 {

--- a/src/Factory/PaymentViewFactoryInterface.php
+++ b/src/Factory/PaymentViewFactoryInterface.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Factory;
+namespace Sylius\SyliusShopApiPlugin\Factory;
 
 use Sylius\Component\Core\Model\PaymentInterface;
-use Sylius\ShopApiPlugin\View\PaymentView;
+use Sylius\SyliusShopApiPlugin\View\PaymentView;
 
 interface PaymentViewFactoryInterface
 {

--- a/src/Factory/PriceViewFactory.php
+++ b/src/Factory/PriceViewFactory.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Factory;
+namespace Sylius\SyliusShopApiPlugin\Factory;
 
-use Sylius\ShopApiPlugin\View\PriceView;
+use Sylius\SyliusShopApiPlugin\View\PriceView;
 
 final class PriceViewFactory implements PriceViewFactoryInterface
 {

--- a/src/Factory/PriceViewFactoryInterface.php
+++ b/src/Factory/PriceViewFactoryInterface.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Factory;
+namespace Sylius\SyliusShopApiPlugin\Factory;
 
-use Sylius\ShopApiPlugin\View\PriceView;
+use Sylius\SyliusShopApiPlugin\View\PriceView;
 
 interface PriceViewFactoryInterface
 {

--- a/src/Factory/ProductAttributeValueViewFactory.php
+++ b/src/Factory/ProductAttributeValueViewFactory.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Factory;
+namespace Sylius\SyliusShopApiPlugin\Factory;
 
 use Sylius\Component\Product\Model\ProductAttributeTranslationInterface;
 use Sylius\Component\Product\Model\ProductAttributeValueInterface;
-use Sylius\ShopApiPlugin\View\ProductAttributeValueView;
+use Sylius\SyliusShopApiPlugin\View\ProductAttributeValueView;
 
 final class ProductAttributeValueViewFactory implements ProductAttributeValueViewFactoryInterface
 {

--- a/src/Factory/ProductAttributeValueViewFactoryInterface.php
+++ b/src/Factory/ProductAttributeValueViewFactoryInterface.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Factory;
+namespace Sylius\SyliusShopApiPlugin\Factory;
 
 use Sylius\Component\Product\Model\ProductAttributeValueInterface;
-use Sylius\ShopApiPlugin\View\ProductAttributeValueView;
+use Sylius\SyliusShopApiPlugin\View\ProductAttributeValueView;
 
 interface ProductAttributeValueViewFactoryInterface
 {

--- a/src/Factory/ProductAttributeValuesViewFactoryInterface.php
+++ b/src/Factory/ProductAttributeValuesViewFactoryInterface.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Factory;
+namespace Sylius\SyliusShopApiPlugin\Factory;
 
 use Sylius\Component\Attribute\Model\AttributeValueInterface;
-use Sylius\ShopApiPlugin\View\ProductAttributeValueView;
+use Sylius\SyliusShopApiPlugin\View\ProductAttributeValueView;
 
 interface ProductAttributeValuesViewFactoryInterface
 {

--- a/src/Factory/ProductReviewViewFactory.php
+++ b/src/Factory/ProductReviewViewFactory.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Factory;
+namespace Sylius\SyliusShopApiPlugin\Factory;
 
 use Sylius\Component\Core\Model\ProductReview;
-use Sylius\ShopApiPlugin\View\ProductReviewView;
+use Sylius\SyliusShopApiPlugin\View\ProductReviewView;
 
 final class ProductReviewViewFactory implements ProductReviewViewFactoryInterface
 {

--- a/src/Factory/ProductReviewViewFactoryInterface.php
+++ b/src/Factory/ProductReviewViewFactoryInterface.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Factory;
+namespace Sylius\SyliusShopApiPlugin\Factory;
 
 use Sylius\Component\Core\Model\ProductReview;
-use Sylius\ShopApiPlugin\View\ProductReviewView;
+use Sylius\SyliusShopApiPlugin\View\ProductReviewView;
 
 interface ProductReviewViewFactoryInterface
 {

--- a/src/Factory/ProductVariantViewFactory.php
+++ b/src/Factory/ProductVariantViewFactory.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Factory;
+namespace Sylius\SyliusShopApiPlugin\Factory;
 
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\ProductVariantInterface;
-use Sylius\ShopApiPlugin\View\ProductVariantView;
+use Sylius\SyliusShopApiPlugin\View\ProductVariantView;
 
 final class ProductVariantViewFactory implements ProductVariantViewFactoryInterface
 {

--- a/src/Factory/ProductVariantViewFactoryInterface.php
+++ b/src/Factory/ProductVariantViewFactoryInterface.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Factory;
+namespace Sylius\SyliusShopApiPlugin\Factory;
 
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\ProductVariantInterface;
-use Sylius\ShopApiPlugin\View\ProductVariantView;
+use Sylius\SyliusShopApiPlugin\View\ProductVariantView;
 
 interface ProductVariantViewFactoryInterface
 {

--- a/src/Factory/ProductViewFactory.php
+++ b/src/Factory/ProductViewFactory.php
@@ -2,15 +2,15 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Factory;
+namespace Sylius\SyliusShopApiPlugin\Factory;
 
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\ProductImageInterface;
 use Sylius\Component\Core\Model\ProductInterface;
 use Sylius\Component\Core\Model\ProductTranslationInterface;
 use Sylius\Component\Core\Model\TaxonInterface;
-use Sylius\ShopApiPlugin\View\ProductTaxonView;
-use Sylius\ShopApiPlugin\View\ProductView;
+use Sylius\SyliusShopApiPlugin\View\ProductTaxonView;
+use Sylius\SyliusShopApiPlugin\View\ProductView;
 
 final class ProductViewFactory implements ProductViewFactoryInterface
 {

--- a/src/Factory/ProductViewFactoryInterface.php
+++ b/src/Factory/ProductViewFactoryInterface.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Factory;
+namespace Sylius\SyliusShopApiPlugin\Factory;
 
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\ProductInterface;
-use Sylius\ShopApiPlugin\View\ProductView;
+use Sylius\SyliusShopApiPlugin\View\ProductView;
 
 interface ProductViewFactoryInterface
 {

--- a/src/Factory/ShipmentViewFactory.php
+++ b/src/Factory/ShipmentViewFactory.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Factory;
+namespace Sylius\SyliusShopApiPlugin\Factory;
 
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\ShipmentInterface;
-use Sylius\ShopApiPlugin\View\ShipmentView;
+use Sylius\SyliusShopApiPlugin\View\ShipmentView;
 
 final class ShipmentViewFactory implements ShipmentViewFactoryInterface
 {

--- a/src/Factory/ShipmentViewFactoryInterface.php
+++ b/src/Factory/ShipmentViewFactoryInterface.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Factory;
+namespace Sylius\SyliusShopApiPlugin\Factory;
 
 use Sylius\Component\Core\Model\ShipmentInterface;
-use Sylius\ShopApiPlugin\View\ShipmentView;
+use Sylius\SyliusShopApiPlugin\View\ShipmentView;
 
 interface ShipmentViewFactoryInterface
 {

--- a/src/Factory/ShippingMethodViewFactory.php
+++ b/src/Factory/ShippingMethodViewFactory.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Factory;
+namespace Sylius\SyliusShopApiPlugin\Factory;
 
 use Sylius\Component\Core\Model\ShipmentInterface;
 use Sylius\Component\Core\Model\ShippingMethodInterface;
 use Sylius\Component\Registry\ServiceRegistry;
 use Sylius\Component\Shipping\Calculator\CalculatorInterface;
-use Sylius\ShopApiPlugin\View\ShippingMethodView;
+use Sylius\SyliusShopApiPlugin\View\ShippingMethodView;
 
 final class ShippingMethodViewFactory implements ShippingMethodViewFactoryInterface
 {

--- a/src/Factory/ShippingMethodViewFactoryInterface.php
+++ b/src/Factory/ShippingMethodViewFactoryInterface.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Factory;
+namespace Sylius\SyliusShopApiPlugin\Factory;
 
 use Sylius\Component\Core\Model\ShipmentInterface;
 use Sylius\Component\Core\Model\ShippingMethodInterface;
-use Sylius\ShopApiPlugin\View\ShippingMethodView;
+use Sylius\SyliusShopApiPlugin\View\ShippingMethodView;
 
 interface ShippingMethodViewFactoryInterface
 {

--- a/src/Factory/TaxonDetailsViewFactory.php
+++ b/src/Factory/TaxonDetailsViewFactory.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Factory;
+namespace Sylius\SyliusShopApiPlugin\Factory;
 
 use Sylius\Component\Core\Model\TaxonInterface;
-use Sylius\ShopApiPlugin\View\TaxonDetailsView;
-use Sylius\ShopApiPlugin\View\TaxonView;
+use Sylius\SyliusShopApiPlugin\View\TaxonDetailsView;
+use Sylius\SyliusShopApiPlugin\View\TaxonView;
 
 final class TaxonDetailsViewFactory implements TaxonDetailsViewFactoryInterface
 {

--- a/src/Factory/TaxonDetailsViewFactoryInterface.php
+++ b/src/Factory/TaxonDetailsViewFactoryInterface.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Factory;
+namespace Sylius\SyliusShopApiPlugin\Factory;
 
 use Sylius\Component\Core\Model\TaxonInterface;
-use Sylius\ShopApiPlugin\View\TaxonDetailsView;
+use Sylius\SyliusShopApiPlugin\View\TaxonDetailsView;
 
 interface TaxonDetailsViewFactoryInterface
 {

--- a/src/Factory/TaxonViewFactory.php
+++ b/src/Factory/TaxonViewFactory.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Factory;
+namespace Sylius\SyliusShopApiPlugin\Factory;
 
 use Sylius\Component\Core\Model\ImageInterface;
 use Sylius\Component\Core\Model\TaxonInterface;
 use Sylius\Component\Taxonomy\Model\TaxonTranslationInterface;
-use Sylius\ShopApiPlugin\View\TaxonView;
+use Sylius\SyliusShopApiPlugin\View\TaxonView;
 
 final class TaxonViewFactory implements TaxonViewFactoryInterface
 {

--- a/src/Factory/TaxonViewFactoryInterface.php
+++ b/src/Factory/TaxonViewFactoryInterface.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Factory;
+namespace Sylius\SyliusShopApiPlugin\Factory;
 
 use Sylius\Component\Core\Model\TaxonInterface;
-use Sylius\ShopApiPlugin\View\TaxonView;
+use Sylius\SyliusShopApiPlugin\View\TaxonView;
 
 interface TaxonViewFactoryInterface
 {

--- a/src/Factory/TotalViewFactory.php
+++ b/src/Factory/TotalViewFactory.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Factory;
+namespace Sylius\SyliusShopApiPlugin\Factory;
 
 use Sylius\Component\Core\Model\OrderInterface;
-use Sylius\ShopApiPlugin\View\TotalsView;
+use Sylius\SyliusShopApiPlugin\View\TotalsView;
 
 final class TotalViewFactory implements TotalViewFactoryInterface
 {

--- a/src/Factory/TotalViewFactoryInterface.php
+++ b/src/Factory/TotalViewFactoryInterface.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Factory;
+namespace Sylius\SyliusShopApiPlugin\Factory;
 
 use Sylius\Component\Core\Model\OrderInterface;
-use Sylius\ShopApiPlugin\View\TotalsView;
+use Sylius\SyliusShopApiPlugin\View\TotalsView;
 
 interface TotalViewFactoryInterface
 {

--- a/src/Factory/ValidationErrorViewFactory.php
+++ b/src/Factory/ValidationErrorViewFactory.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Factory;
+namespace Sylius\SyliusShopApiPlugin\Factory;
 
-use Sylius\ShopApiPlugin\View\ValidationErrorView;
+use Sylius\SyliusShopApiPlugin\View\ValidationErrorView;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Validator\ConstraintViolationInterface;
 use Symfony\Component\Validator\ConstraintViolationListInterface;

--- a/src/Factory/ValidationErrorViewFactoryInterface.php
+++ b/src/Factory/ValidationErrorViewFactoryInterface.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Factory;
+namespace Sylius\SyliusShopApiPlugin\Factory;
 
-use Sylius\ShopApiPlugin\View\ValidationErrorView;
+use Sylius\SyliusShopApiPlugin\View\ValidationErrorView;
 use Symfony\Component\Validator\ConstraintViolationListInterface;
 
 interface ValidationErrorViewFactoryInterface

--- a/src/Factory/ViewCreationException.php
+++ b/src/Factory/ViewCreationException.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Factory;
+namespace Sylius\SyliusShopApiPlugin\Factory;
 
 final class ViewCreationException extends \DomainException
 {

--- a/src/Generator/ProductBreadcrumbGenerator.php
+++ b/src/Generator/ProductBreadcrumbGenerator.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Generator;
+namespace Sylius\SyliusShopApiPlugin\Generator;
 
 use Sylius\Component\Core\Model\ProductInterface;
 

--- a/src/Generator/ProductBreadcrumbGeneratorInterface.php
+++ b/src/Generator/ProductBreadcrumbGeneratorInterface.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Generator;
+namespace Sylius\SyliusShopApiPlugin\Generator;
 
 use Sylius\Component\Core\Model\ProductInterface;
 

--- a/src/Handler/AddCouponHandler.php
+++ b/src/Handler/AddCouponHandler.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Handler;
+namespace Sylius\SyliusShopApiPlugin\Handler;
 
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\PromotionCouponInterface;
@@ -10,7 +10,7 @@ use Sylius\Component\Core\Repository\OrderRepositoryInterface;
 use Sylius\Component\Order\Processor\OrderProcessorInterface;
 use Sylius\Component\Promotion\Checker\Eligibility\PromotionCouponEligibilityCheckerInterface;
 use Sylius\Component\Promotion\Repository\PromotionCouponRepositoryInterface;
-use Sylius\ShopApiPlugin\Command\AddCoupon;
+use Sylius\SyliusShopApiPlugin\Command\AddCoupon;
 use Webmozart\Assert\Assert;
 
 final class AddCouponHandler

--- a/src/Handler/AddProductReviewByCodeHandler.php
+++ b/src/Handler/AddProductReviewByCodeHandler.php
@@ -2,15 +2,15 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Handler;
+namespace Sylius\SyliusShopApiPlugin\Handler;
 
 use Sylius\Component\Channel\Repository\ChannelRepositoryInterface;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Repository\ProductRepositoryInterface;
 use Sylius\Component\Core\Repository\ProductReviewRepositoryInterface;
 use Sylius\Component\Review\Factory\ReviewFactoryInterface;
-use Sylius\ShopApiPlugin\Command\AddProductReviewByCode;
-use Sylius\ShopApiPlugin\Provider\ProductReviewerProviderInterface;
+use Sylius\SyliusShopApiPlugin\Command\AddProductReviewByCode;
+use Sylius\SyliusShopApiPlugin\Provider\ProductReviewerProviderInterface;
 use Webmozart\Assert\Assert;
 
 final class AddProductReviewByCodeHandler

--- a/src/Handler/AddProductReviewBySlugHandler.php
+++ b/src/Handler/AddProductReviewBySlugHandler.php
@@ -2,15 +2,15 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Handler;
+namespace Sylius\SyliusShopApiPlugin\Handler;
 
 use Sylius\Component\Channel\Repository\ChannelRepositoryInterface;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Repository\ProductRepositoryInterface;
 use Sylius\Component\Core\Repository\ProductReviewRepositoryInterface;
 use Sylius\Component\Review\Factory\ReviewFactoryInterface;
-use Sylius\ShopApiPlugin\Command\AddProductReviewBySlug;
-use Sylius\ShopApiPlugin\Provider\ProductReviewerProviderInterface;
+use Sylius\SyliusShopApiPlugin\Command\AddProductReviewBySlug;
+use Sylius\SyliusShopApiPlugin\Provider\ProductReviewerProviderInterface;
 use Webmozart\Assert\Assert;
 
 final class AddProductReviewBySlugHandler

--- a/src/Handler/AddressOrderHandler.php
+++ b/src/Handler/AddressOrderHandler.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Handler;
+namespace Sylius\SyliusShopApiPlugin\Handler;
 
 use SM\Factory\FactoryInterface;
 use Sylius\Component\Core\Factory\AddressFactoryInterface;
@@ -10,7 +10,7 @@ use Sylius\Component\Core\Model\AddressInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\OrderCheckoutTransitions;
 use Sylius\Component\Core\Repository\OrderRepositoryInterface;
-use Sylius\ShopApiPlugin\Command\AddressOrder;
+use Sylius\SyliusShopApiPlugin\Command\AddressOrder;
 use Webmozart\Assert\Assert;
 
 final class AddressOrderHandler

--- a/src/Handler/ChangeItemQuantityHandler.php
+++ b/src/Handler/ChangeItemQuantityHandler.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Handler;
+namespace Sylius\SyliusShopApiPlugin\Handler;
 
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\OrderItemInterface;
@@ -10,7 +10,7 @@ use Sylius\Component\Core\Repository\OrderRepositoryInterface;
 use Sylius\Component\Order\Modifier\OrderItemQuantityModifierInterface;
 use Sylius\Component\Order\Processor\OrderProcessorInterface;
 use Sylius\Component\Order\Repository\OrderItemRepositoryInterface;
-use Sylius\ShopApiPlugin\Command\ChangeItemQuantity;
+use Sylius\SyliusShopApiPlugin\Command\ChangeItemQuantity;
 use Webmozart\Assert\Assert;
 
 final class ChangeItemQuantityHandler

--- a/src/Handler/ChoosePaymentMethodHandler.php
+++ b/src/Handler/ChoosePaymentMethodHandler.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Handler;
+namespace Sylius\SyliusShopApiPlugin\Handler;
 
 use SM\Factory\FactoryInterface;
 use Sylius\Component\Core\Model\OrderInterface;
@@ -10,7 +10,7 @@ use Sylius\Component\Core\Model\PaymentMethodInterface;
 use Sylius\Component\Core\OrderCheckoutTransitions;
 use Sylius\Component\Core\Repository\OrderRepositoryInterface;
 use Sylius\Component\Core\Repository\PaymentMethodRepositoryInterface;
-use Sylius\ShopApiPlugin\Command\ChoosePaymentMethod;
+use Sylius\SyliusShopApiPlugin\Command\ChoosePaymentMethod;
 use Webmozart\Assert\Assert;
 
 final class ChoosePaymentMethodHandler

--- a/src/Handler/ChooseShippingMethodHandler.php
+++ b/src/Handler/ChooseShippingMethodHandler.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Handler;
+namespace Sylius\SyliusShopApiPlugin\Handler;
 
 use SM\Factory\FactoryInterface;
 use Sylius\Component\Core\Model\OrderInterface;
@@ -11,7 +11,7 @@ use Sylius\Component\Core\OrderCheckoutTransitions;
 use Sylius\Component\Core\Repository\OrderRepositoryInterface;
 use Sylius\Component\Core\Repository\ShippingMethodRepositoryInterface;
 use Sylius\Component\Shipping\Checker\ShippingMethodEligibilityCheckerInterface;
-use Sylius\ShopApiPlugin\Command\ChooseShippingMethod;
+use Sylius\SyliusShopApiPlugin\Command\ChooseShippingMethod;
 use Webmozart\Assert\Assert;
 
 final class ChooseShippingMethodHandler

--- a/src/Handler/CompleteOrderHandler.php
+++ b/src/Handler/CompleteOrderHandler.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Handler;
+namespace Sylius\SyliusShopApiPlugin\Handler;
 
 use SM\Factory\FactoryInterface as StateMachineFactory;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\OrderCheckoutTransitions;
 use Sylius\Component\Core\Repository\OrderRepositoryInterface;
-use Sylius\ShopApiPlugin\Command\CompleteOrder;
-use Sylius\ShopApiPlugin\Provider\CustomerProviderInterface;
+use Sylius\SyliusShopApiPlugin\Command\CompleteOrder;
+use Sylius\SyliusShopApiPlugin\Provider\CustomerProviderInterface;
 use Webmozart\Assert\Assert;
 
 final class CompleteOrderHandler

--- a/src/Handler/DropCartHandler.php
+++ b/src/Handler/DropCartHandler.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Handler;
+namespace Sylius\SyliusShopApiPlugin\Handler;
 
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Repository\OrderRepositoryInterface;
-use Sylius\ShopApiPlugin\Command\DropCart;
+use Sylius\SyliusShopApiPlugin\Command\DropCart;
 use Webmozart\Assert\Assert;
 
 final class DropCartHandler

--- a/src/Handler/GenerateResetPasswordTokenHandler.php
+++ b/src/Handler/GenerateResetPasswordTokenHandler.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Handler;
+namespace Sylius\SyliusShopApiPlugin\Handler;
 
 use Sylius\Component\Core\Model\ShopUserInterface;
 use Sylius\Component\User\Repository\UserRepositoryInterface;
 use Sylius\Component\User\Security\Generator\GeneratorInterface;
-use Sylius\ShopApiPlugin\Command\GenerateResetPasswordToken;
+use Sylius\SyliusShopApiPlugin\Command\GenerateResetPasswordToken;
 use Webmozart\Assert\Assert;
 
 final class GenerateResetPasswordTokenHandler

--- a/src/Handler/GenerateVerificationTokenHandler.php
+++ b/src/Handler/GenerateVerificationTokenHandler.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Handler;
+namespace Sylius\SyliusShopApiPlugin\Handler;
 
 use Sylius\Component\Core\Model\ShopUserInterface;
 use Sylius\Component\User\Repository\UserRepositoryInterface;
 use Sylius\Component\User\Security\Generator\GeneratorInterface;
-use Sylius\ShopApiPlugin\Command\GenerateVerificationToken;
+use Sylius\SyliusShopApiPlugin\Command\GenerateVerificationToken;
 use Webmozart\Assert\Assert;
 
 final class GenerateVerificationTokenHandler

--- a/src/Handler/PickupCartHandler.php
+++ b/src/Handler/PickupCartHandler.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Handler;
+namespace Sylius\SyliusShopApiPlugin\Handler;
 
 use Sylius\Component\Channel\Repository\ChannelRepositoryInterface;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Repository\OrderRepositoryInterface;
 use Sylius\Component\Resource\Factory\FactoryInterface;
-use Sylius\ShopApiPlugin\Command\PickupCart;
+use Sylius\SyliusShopApiPlugin\Command\PickupCart;
 use Webmozart\Assert\Assert;
 
 final class PickupCartHandler

--- a/src/Handler/PutOptionBasedConfigurableItemToCartHandler.php
+++ b/src/Handler/PutOptionBasedConfigurableItemToCartHandler.php
@@ -2,15 +2,15 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Handler;
+namespace Sylius\SyliusShopApiPlugin\Handler;
 
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\ProductVariantInterface;
 use Sylius\Component\Core\Repository\OrderRepositoryInterface;
 use Sylius\Component\Core\Repository\ProductRepositoryInterface;
 use Sylius\Component\Product\Model\ProductInterface;
-use Sylius\ShopApiPlugin\Command\PutOptionBasedConfigurableItemToCart;
-use Sylius\ShopApiPlugin\Modifier\OrderModifierInterface;
+use Sylius\SyliusShopApiPlugin\Command\PutOptionBasedConfigurableItemToCart;
+use Sylius\SyliusShopApiPlugin\Modifier\OrderModifierInterface;
 use Webmozart\Assert\Assert;
 
 final class PutOptionBasedConfigurableItemToCartHandler

--- a/src/Handler/PutSimpleItemToCartHandler.php
+++ b/src/Handler/PutSimpleItemToCartHandler.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Handler;
+namespace Sylius\SyliusShopApiPlugin\Handler;
 
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\ProductInterface;
 use Sylius\Component\Core\Repository\OrderRepositoryInterface;
 use Sylius\Component\Core\Repository\ProductRepositoryInterface;
-use Sylius\ShopApiPlugin\Command\PutSimpleItemToCart;
-use Sylius\ShopApiPlugin\Modifier\OrderModifierInterface;
+use Sylius\SyliusShopApiPlugin\Command\PutSimpleItemToCart;
+use Sylius\SyliusShopApiPlugin\Modifier\OrderModifierInterface;
 use Webmozart\Assert\Assert;
 
 final class PutSimpleItemToCartHandler

--- a/src/Handler/PutVariantBasedConfigurableItemToCartHandler.php
+++ b/src/Handler/PutVariantBasedConfigurableItemToCartHandler.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Handler;
+namespace Sylius\SyliusShopApiPlugin\Handler;
 
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\ProductVariantInterface;
 use Sylius\Component\Core\Repository\OrderRepositoryInterface;
 use Sylius\Component\Core\Repository\ProductVariantRepositoryInterface;
-use Sylius\ShopApiPlugin\Command\PutVariantBasedConfigurableItemToCart;
-use Sylius\ShopApiPlugin\Modifier\OrderModifierInterface;
+use Sylius\SyliusShopApiPlugin\Command\PutVariantBasedConfigurableItemToCart;
+use Sylius\SyliusShopApiPlugin\Modifier\OrderModifierInterface;
 use Webmozart\Assert\Assert;
 
 final class PutVariantBasedConfigurableItemToCartHandler

--- a/src/Handler/RegisterCustomerHandler.php
+++ b/src/Handler/RegisterCustomerHandler.php
@@ -2,15 +2,15 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Handler;
+namespace Sylius\SyliusShopApiPlugin\Handler;
 
 use Sylius\Component\Channel\Repository\ChannelRepositoryInterface;
 use Sylius\Component\Core\Model\CustomerInterface;
 use Sylius\Component\Core\Model\ShopUserInterface;
 use Sylius\Component\Resource\Factory\FactoryInterface;
 use Sylius\Component\User\Repository\UserRepositoryInterface;
-use Sylius\ShopApiPlugin\Command\RegisterCustomer;
-use Sylius\ShopApiPlugin\Event\CustomerRegistered;
+use Sylius\SyliusShopApiPlugin\Command\RegisterCustomer;
+use Sylius\SyliusShopApiPlugin\Event\CustomerRegistered;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Webmozart\Assert\Assert;
 

--- a/src/Handler/RemoveCouponHandler.php
+++ b/src/Handler/RemoveCouponHandler.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Handler;
+namespace Sylius\SyliusShopApiPlugin\Handler;
 
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Repository\OrderRepositoryInterface;
 use Sylius\Component\Order\Processor\OrderProcessorInterface;
-use Sylius\ShopApiPlugin\Command\RemoveCoupon;
+use Sylius\SyliusShopApiPlugin\Command\RemoveCoupon;
 use Webmozart\Assert\Assert;
 
 final class RemoveCouponHandler

--- a/src/Handler/RemoveItemFromCartHandler.php
+++ b/src/Handler/RemoveItemFromCartHandler.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Handler;
+namespace Sylius\SyliusShopApiPlugin\Handler;
 
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\OrderItemInterface;
 use Sylius\Component\Core\Repository\OrderRepositoryInterface;
 use Sylius\Component\Order\Processor\OrderProcessorInterface;
 use Sylius\Component\Order\Repository\OrderItemRepositoryInterface;
-use Sylius\ShopApiPlugin\Command\RemoveItemFromCart;
+use Sylius\SyliusShopApiPlugin\Command\RemoveItemFromCart;
 use Webmozart\Assert\Assert;
 
 final class RemoveItemFromCartHandler

--- a/src/Handler/SendResetPasswordTokenHandler.php
+++ b/src/Handler/SendResetPasswordTokenHandler.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Handler;
+namespace Sylius\SyliusShopApiPlugin\Handler;
 
 use Sylius\Component\Core\Model\ShopUserInterface;
 use Sylius\Component\Mailer\Sender\SenderInterface;
 use Sylius\Component\User\Repository\UserRepositoryInterface;
-use Sylius\ShopApiPlugin\Command\SendResetPasswordToken;
-use Sylius\ShopApiPlugin\Mailer\Emails;
+use Sylius\SyliusShopApiPlugin\Command\SendResetPasswordToken;
+use Sylius\SyliusShopApiPlugin\Mailer\Emails;
 use Webmozart\Assert\Assert;
 
 final class SendResetPasswordTokenHandler

--- a/src/Handler/SendVerificationTokenHandler.php
+++ b/src/Handler/SendVerificationTokenHandler.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Handler;
+namespace Sylius\SyliusShopApiPlugin\Handler;
 
 use Sylius\Component\Core\Model\ShopUserInterface;
 use Sylius\Component\Mailer\Sender\SenderInterface;
 use Sylius\Component\User\Repository\UserRepositoryInterface;
-use Sylius\ShopApiPlugin\Command\SendVerificationToken;
-use Sylius\ShopApiPlugin\Mailer\Emails;
+use Sylius\SyliusShopApiPlugin\Command\SendVerificationToken;
+use Sylius\SyliusShopApiPlugin\Mailer\Emails;
 use Webmozart\Assert\Assert;
 
 final class SendVerificationTokenHandler

--- a/src/Handler/UpdateCustomerHandler.php
+++ b/src/Handler/UpdateCustomerHandler.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Handler;
+namespace Sylius\SyliusShopApiPlugin\Handler;
 
 use Sylius\Component\Core\Model\CustomerInterface;
 use Sylius\Component\Resource\Repository\RepositoryInterface;
-use Sylius\ShopApiPlugin\Command\UpdateCustomer;
+use Sylius\SyliusShopApiPlugin\Command\UpdateCustomer;
 
 final class UpdateCustomerHandler
 {

--- a/src/Handler/VerifyAccountHandler.php
+++ b/src/Handler/VerifyAccountHandler.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Handler;
+namespace Sylius\SyliusShopApiPlugin\Handler;
 
 use Sylius\Component\Core\Model\ShopUserInterface;
 use Sylius\Component\User\Repository\UserRepositoryInterface;
-use Sylius\ShopApiPlugin\Command\VerifyAccount;
+use Sylius\SyliusShopApiPlugin\Command\VerifyAccount;
 use Webmozart\Assert\Assert;
 
 final class VerifyAccountHandler

--- a/src/Mailer/Emails.php
+++ b/src/Mailer/Emails.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Mailer;
+namespace Sylius\SyliusShopApiPlugin\Mailer;
 
 final class Emails
 {

--- a/src/Model/Address.php
+++ b/src/Model/Address.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Model;
+namespace Sylius\SyliusShopApiPlugin\Model;
 
 use Webmozart\Assert\Assert;
 

--- a/src/Model/PaginatorDetails.php
+++ b/src/Model/PaginatorDetails.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Model;
+namespace Sylius\SyliusShopApiPlugin\Model;
 
 use Webmozart\Assert\Assert;
 

--- a/src/Modifier/OrderModifier.php
+++ b/src/Modifier/OrderModifier.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Modifier;
+namespace Sylius\SyliusShopApiPlugin\Modifier;
 
 use Doctrine\Common\Persistence\ObjectManager;
 use Sylius\Component\Core\Factory\CartItemFactoryInterface;

--- a/src/Modifier/OrderModifierInterface.php
+++ b/src/Modifier/OrderModifierInterface.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Modifier;
+namespace Sylius\SyliusShopApiPlugin\Modifier;
 
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\ProductVariantInterface;

--- a/src/Provider/CustomerProvider.php
+++ b/src/Provider/CustomerProvider.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Provider;
+namespace Sylius\SyliusShopApiPlugin\Provider;
 
 use Sylius\Component\Core\Model\CustomerInterface;
 use Sylius\Component\Core\Repository\CustomerRepositoryInterface;

--- a/src/Provider/CustomerProviderInterface.php
+++ b/src/Provider/CustomerProviderInterface.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Provider;
+namespace Sylius\SyliusShopApiPlugin\Provider;
 
 use Sylius\Component\Core\Model\CustomerInterface;
 

--- a/src/Provider/ProductReviewerProvider.php
+++ b/src/Provider/ProductReviewerProvider.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Provider;
+namespace Sylius\SyliusShopApiPlugin\Provider;
 
 use Sylius\Component\Core\Model\ProductReviewerInterface;
 

--- a/src/Provider/ProductReviewerProviderInterface.php
+++ b/src/Provider/ProductReviewerProviderInterface.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Provider;
+namespace Sylius\SyliusShopApiPlugin\Provider;
 
 use Sylius\Component\Core\Model\ProductReviewerInterface;
 

--- a/src/Request/AddCouponRequest.php
+++ b/src/Request/AddCouponRequest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Request;
+namespace Sylius\SyliusShopApiPlugin\Request;
 
-use Sylius\ShopApiPlugin\Command\AddCoupon;
+use Sylius\SyliusShopApiPlugin\Command\AddCoupon;
 use Symfony\Component\HttpFoundation\Request;
 
 final class AddCouponRequest

--- a/src/Request/AddProductReviewByCodeRequest.php
+++ b/src/Request/AddProductReviewByCodeRequest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Request;
+namespace Sylius\SyliusShopApiPlugin\Request;
 
-use Sylius\ShopApiPlugin\Command\AddProductReviewByCode;
+use Sylius\SyliusShopApiPlugin\Command\AddProductReviewByCode;
 use Symfony\Component\HttpFoundation\Request;
 
 final class AddProductReviewByCodeRequest

--- a/src/Request/AddProductReviewBySlugRequest.php
+++ b/src/Request/AddProductReviewBySlugRequest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Request;
+namespace Sylius\SyliusShopApiPlugin\Request;
 
-use Sylius\ShopApiPlugin\Command\AddProductReviewBySlug;
+use Sylius\SyliusShopApiPlugin\Command\AddProductReviewBySlug;
 use Symfony\Component\HttpFoundation\Request;
 
 final class AddProductReviewBySlugRequest

--- a/src/Request/ChangeItemQuantityRequest.php
+++ b/src/Request/ChangeItemQuantityRequest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Request;
+namespace Sylius\SyliusShopApiPlugin\Request;
 
-use Sylius\ShopApiPlugin\Command\ChangeItemQuantity;
+use Sylius\SyliusShopApiPlugin\Command\ChangeItemQuantity;
 use Symfony\Component\HttpFoundation\Request;
 
 final class ChangeItemQuantityRequest

--- a/src/Request/DropCartRequest.php
+++ b/src/Request/DropCartRequest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Request;
+namespace Sylius\SyliusShopApiPlugin\Request;
 
-use Sylius\ShopApiPlugin\Command\DropCart;
+use Sylius\SyliusShopApiPlugin\Command\DropCart;
 use Symfony\Component\HttpFoundation\Request;
 
 final class DropCartRequest

--- a/src/Request/PickupCartRequest.php
+++ b/src/Request/PickupCartRequest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Request;
+namespace Sylius\SyliusShopApiPlugin\Request;
 
-use Sylius\ShopApiPlugin\Command\PickupCart;
+use Sylius\SyliusShopApiPlugin\Command\PickupCart;
 use Symfony\Component\HttpFoundation\Request;
 
 final class PickupCartRequest

--- a/src/Request/PutOptionBasedConfigurableItemToCartRequest.php
+++ b/src/Request/PutOptionBasedConfigurableItemToCartRequest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Request;
+namespace Sylius\SyliusShopApiPlugin\Request;
 
-use Sylius\ShopApiPlugin\Command\PutOptionBasedConfigurableItemToCart;
+use Sylius\SyliusShopApiPlugin\Command\PutOptionBasedConfigurableItemToCart;
 use Symfony\Component\HttpFoundation\Request;
 
 final class PutOptionBasedConfigurableItemToCartRequest

--- a/src/Request/PutSimpleItemToCartRequest.php
+++ b/src/Request/PutSimpleItemToCartRequest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Request;
+namespace Sylius\SyliusShopApiPlugin\Request;
 
-use Sylius\ShopApiPlugin\Command\PutSimpleItemToCart;
+use Sylius\SyliusShopApiPlugin\Command\PutSimpleItemToCart;
 use Symfony\Component\HttpFoundation\Request;
 
 final class PutSimpleItemToCartRequest

--- a/src/Request/PutVariantBasedConfigurableItemToCartRequest.php
+++ b/src/Request/PutVariantBasedConfigurableItemToCartRequest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Request;
+namespace Sylius\SyliusShopApiPlugin\Request;
 
-use Sylius\ShopApiPlugin\Command\PutVariantBasedConfigurableItemToCart;
+use Sylius\SyliusShopApiPlugin\Command\PutVariantBasedConfigurableItemToCart;
 use Symfony\Component\HttpFoundation\Request;
 
 final class PutVariantBasedConfigurableItemToCartRequest

--- a/src/Request/RegisterCustomerRequest.php
+++ b/src/Request/RegisterCustomerRequest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Request;
+namespace Sylius\SyliusShopApiPlugin\Request;
 
-use Sylius\ShopApiPlugin\Command\RegisterCustomer;
+use Sylius\SyliusShopApiPlugin\Command\RegisterCustomer;
 use Symfony\Component\HttpFoundation\Request;
 
 final class RegisterCustomerRequest

--- a/src/Request/RemoveCouponRequest.php
+++ b/src/Request/RemoveCouponRequest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Request;
+namespace Sylius\SyliusShopApiPlugin\Request;
 
-use Sylius\ShopApiPlugin\Command\RemoveCoupon;
+use Sylius\SyliusShopApiPlugin\Command\RemoveCoupon;
 use Symfony\Component\HttpFoundation\Request;
 
 final class RemoveCouponRequest

--- a/src/Request/RemoveItemFromCartRequest.php
+++ b/src/Request/RemoveItemFromCartRequest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Request;
+namespace Sylius\SyliusShopApiPlugin\Request;
 
-use Sylius\ShopApiPlugin\Command\RemoveItemFromCart;
+use Sylius\SyliusShopApiPlugin\Command\RemoveItemFromCart;
 use Symfony\Component\HttpFoundation\Request;
 
 final class RemoveItemFromCartRequest

--- a/src/Request/ResendVerificationTokenRequest.php
+++ b/src/Request/ResendVerificationTokenRequest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Request;
+namespace Sylius\SyliusShopApiPlugin\Request;
 
-use Sylius\ShopApiPlugin\Command\SendVerificationToken;
+use Sylius\SyliusShopApiPlugin\Command\SendVerificationToken;
 use Symfony\Component\HttpFoundation\Request;
 
 final class ResendVerificationTokenRequest

--- a/src/Request/UpdateCustomerRequest.php
+++ b/src/Request/UpdateCustomerRequest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Request;
+namespace Sylius\SyliusShopApiPlugin\Request;
 
 use DateTimeInterface;
-use Sylius\ShopApiPlugin\Command\UpdateCustomer;
+use Sylius\SyliusShopApiPlugin\Command\UpdateCustomer;
 use Symfony\Component\HttpFoundation\Request;
 
 final class UpdateCustomerRequest

--- a/src/Request/VerifyAccountRequest.php
+++ b/src/Request/VerifyAccountRequest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Request;
+namespace Sylius\SyliusShopApiPlugin\Request;
 
-use Sylius\ShopApiPlugin\Command\VerifyAccount;
+use Sylius\SyliusShopApiPlugin\Command\VerifyAccount;
 use Symfony\Component\HttpFoundation\Request;
 
 final class VerifyAccountRequest

--- a/src/Resources/config/app/config.yml
+++ b/src/Resources/config/app/config.yml
@@ -15,4 +15,4 @@ sylius_customer:
     resources:
         customer:
             classes:
-                controller: Sylius\ShopApiPlugin\Controller\Customer\CustomerController
+                controller: Sylius\SyliusShopApiPlugin\Controller\Customer\CustomerController

--- a/src/Resources/config/serializer/ImageView.yml
+++ b/src/Resources/config/serializer/ImageView.yml
@@ -1,4 +1,4 @@
-Sylius\ShopApiPlugin\View\ImageView:
+Sylius\SyliusShopApiPlugin\View\ImageView:
     exclusion_policy: ALL
     xml_root_name: image_view
     properties:

--- a/src/Resources/config/serializer/PageView.yml
+++ b/src/Resources/config/serializer/PageView.yml
@@ -1,4 +1,4 @@
-Sylius\ShopApiPlugin\View\PageView:
+Sylius\SyliusShopApiPlugin\View\PageView:
     exclusion_policy: ALL
     xml_root_name: page_view
     properties:

--- a/src/Resources/config/serializer/ProductVariantView.yml
+++ b/src/Resources/config/serializer/ProductVariantView.yml
@@ -1,4 +1,4 @@
-Sylius\ShopApiPlugin\View\ProductVariantView:
+Sylius\SyliusShopApiPlugin\View\ProductVariantView:
     exclusion_policy: ALL
     xml_root_name: product_variant_view
     properties:
@@ -16,7 +16,7 @@ Sylius\ShopApiPlugin\View\ProductVariantView:
             type: array<string, string>
         price:
             expose: true
-            type: Sylius\ShopApiPlugin\View\PriceView
+            type: Sylius\SyliusShopApiPlugin\View\PriceView
         images:
             expose: true
             type: array

--- a/src/Resources/config/serializer/ProductView.yml
+++ b/src/Resources/config/serializer/ProductView.yml
@@ -1,4 +1,4 @@
-Sylius\ShopApiPlugin\View\ProductView:
+Sylius\SyliusShopApiPlugin\View\ProductView:
     exclusion_policy: ALL
     xml_root_name: product_view
     properties:

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -20,21 +20,21 @@
         <import resource="services/queries.xml"/>
     </imports>
     <services>
-        <service id="sylius.shop_api_plugin.checker.promotion_coupon_eligibility_checker" class="Sylius\ShopApiPlugin\Checker\PromotionCouponEligibilityChecker">
+        <service id="sylius.shop_api_plugin.checker.promotion_coupon_eligibility_checker" class="Sylius\SyliusShopApiPlugin\Checker\PromotionCouponEligibilityChecker">
             <argument type="service" id="sylius.promotion_eligibility_checker"/>
             <argument type="service" id="sylius.promotion_coupon_eligibility_checker"/>
         </service>
 
-        <service id="sylius.shop_api_plugin.provider.customer_provider" class="Sylius\ShopApiPlugin\Provider\CustomerProvider">
+        <service id="sylius.shop_api_plugin.provider.customer_provider" class="Sylius\SyliusShopApiPlugin\Provider\CustomerProvider">
             <argument type="service" id="sylius.repository.customer"/>
             <argument type="service" id="sylius.factory.customer"/>
         </service>
 
-        <service id="sylius.shop_api_plugin.provider.product_reviewer_provider" class="Sylius\ShopApiPlugin\Provider\ProductReviewerProvider">
+        <service id="sylius.shop_api_plugin.provider.product_reviewer_provider" class="Sylius\SyliusShopApiPlugin\Provider\ProductReviewerProvider">
             <argument type="service" id="sylius.shop_api_plugin.provider.customer_provider"/>
         </service>
 
-        <service id="sylius.shop_api_plugin.event_listener.user_registration_listener" class="Sylius\ShopApiPlugin\EventListener\UserRegistrationListener">
+        <service id="sylius.shop_api_plugin.event_listener.user_registration_listener" class="Sylius\SyliusShopApiPlugin\EventListener\UserRegistrationListener">
             <argument type="service" id="tactician.commandbus" />
             <argument type="service" id="sylius.repository.channel"/>
             <argument type="service" id="sylius.repository.shop_user"/>
@@ -42,14 +42,14 @@
             <tag name="kernel.event_listener" event="sylius.customer.post_api_registered" method="handleUserVerification" />
         </service>
 
-        <service id="sylius.shop_api_plugin.generator.product_breadcrumb_generator" class="Sylius\ShopApiPlugin\Generator\ProductBreadcrumbGenerator" />
+        <service id="sylius.shop_api_plugin.generator.product_breadcrumb_generator" class="Sylius\SyliusShopApiPlugin\Generator\ProductBreadcrumbGenerator" />
 
-        <service id="sylius.shop_api_plugin.event_listener.request_locale_setter" class="Sylius\ShopApiPlugin\EventListener\RequestLocaleSetter" >
+        <service id="sylius.shop_api_plugin.event_listener.request_locale_setter" class="Sylius\SyliusShopApiPlugin\EventListener\RequestLocaleSetter" >
             <argument type="service" id="sylius.locale_provider" />
             <tag name="kernel.event_listener" event="kernel.request" priority="3" />
         </service>
 
-        <service id="sylius.shop_api_plugin.modifier.order_modifier" class="Sylius\ShopApiPlugin\Modifier\OrderModifier">
+        <service id="sylius.shop_api_plugin.modifier.order_modifier" class="Sylius\SyliusShopApiPlugin\Modifier\OrderModifier">
             <argument type="service" id="sylius.custom_factory.order_item" />
             <argument type="service" id="sylius.order_item_quantity_modifier" />
             <argument type="service" id="sylius.order_processing.order_processor.composite" />

--- a/src/Resources/config/services/actions/cart.xml
+++ b/src/Resources/config/services/actions/cart.xml
@@ -3,14 +3,14 @@
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
         <service id="sylius.shop_api_plugin.controller.cart.summarize_action"
-                 class="Sylius\ShopApiPlugin\Controller\Cart\SummarizeAction"
+                 class="Sylius\SyliusShopApiPlugin\Controller\Cart\SummarizeAction"
         >
             <argument type="service" id="sylius.shop_api_plugin.view_repository.cart_view_repository" />
             <argument type="service" id="fos_rest.view_handler" />
         </service>
 
         <service id="sylius.shop_api_plugin.controller.cart.drop_cart_action"
-                 class="Sylius\ShopApiPlugin\Controller\Cart\DropCartAction"
+                 class="Sylius\SyliusShopApiPlugin\Controller\Cart\DropCartAction"
         >
             <argument type="service" id="fos_rest.view_handler" />
             <argument type="service" id="tactician.commandbus" />
@@ -19,7 +19,7 @@
         </service>
 
         <service id="sylius.shop_api_plugin.controller.cart.pickup_action"
-                 class="Sylius\ShopApiPlugin\Controller\Cart\PickupAction"
+                 class="Sylius\SyliusShopApiPlugin\Controller\Cart\PickupAction"
         >
             <argument type="service" id="fos_rest.view_handler" />
             <argument type="service" id="tactician.commandbus" />
@@ -29,7 +29,7 @@
         </service>
 
         <service id="sylius.shop_api_plugin.controller.cart.change_item_quantity_action"
-                 class="Sylius\ShopApiPlugin\Controller\Cart\ChangeItemQuantityAction"
+                 class="Sylius\SyliusShopApiPlugin\Controller\Cart\ChangeItemQuantityAction"
         >
             <argument type="service" id="fos_rest.view_handler" />
             <argument type="service" id="tactician.commandbus" />
@@ -39,7 +39,7 @@
         </service>
 
         <service id="sylius.shop_api_plugin.controller.cart.remove_item_from_cart_action"
-                 class="Sylius\ShopApiPlugin\Controller\Cart\RemoveItemFromCartAction"
+                 class="Sylius\SyliusShopApiPlugin\Controller\Cart\RemoveItemFromCartAction"
         >
             <argument type="service" id="fos_rest.view_handler" />
             <argument type="service" id="tactician.commandbus" />
@@ -49,7 +49,7 @@
         </service>
 
         <service id="sylius.shop_api_plugin.controller.cart.add_coupon_action"
-                 class="Sylius\ShopApiPlugin\Controller\Cart\AddCouponAction"
+                 class="Sylius\SyliusShopApiPlugin\Controller\Cart\AddCouponAction"
         >
             <argument type="service" id="fos_rest.view_handler" />
             <argument type="service" id="tactician.commandbus" />
@@ -59,7 +59,7 @@
         </service>
 
         <service id="sylius.shop_api_plugin.controller.cart.remove_coupon_action"
-                 class="Sylius\ShopApiPlugin\Controller\Cart\RemoveCouponAction"
+                 class="Sylius\SyliusShopApiPlugin\Controller\Cart\RemoveCouponAction"
         >
             <argument type="service" id="fos_rest.view_handler" />
             <argument type="service" id="tactician.commandbus" />
@@ -69,7 +69,7 @@
         </service>
 
         <service id="sylius.shop_api_plugin.controller.cart.put_item_to_cart_action"
-                 class="Sylius\ShopApiPlugin\Controller\Cart\PutItemToCartAction"
+                 class="Sylius\SyliusShopApiPlugin\Controller\Cart\PutItemToCartAction"
         >
             <argument type="service" id="fos_rest.view_handler" />
             <argument type="service" id="tactician.commandbus" />
@@ -79,7 +79,7 @@
         </service>
 
         <service id="sylius.shop_api_plugin.controller.cart.put_items_to_cart_action"
-                 class="Sylius\ShopApiPlugin\Controller\Cart\PutItemsToCartAction"
+                 class="Sylius\SyliusShopApiPlugin\Controller\Cart\PutItemsToCartAction"
         >
             <argument type="service" id="fos_rest.view_handler" />
             <argument type="service" id="tactician.commandbus" />

--- a/src/Resources/config/services/actions/checkout.xml
+++ b/src/Resources/config/services/actions/checkout.xml
@@ -3,13 +3,13 @@
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
         <service id="sylius.shop_api_plugin.controller.checkout.address_action"
-                 class="Sylius\ShopApiPlugin\Controller\Checkout\AddressAction"
+                 class="Sylius\SyliusShopApiPlugin\Controller\Checkout\AddressAction"
         >
             <argument type="service" id="fos_rest.view_handler" />
             <argument type="service" id="tactician.commandbus" />
         </service>
         <service id="sylius.shop_api_plugin.controller.checkout.show_available_shipping_methods_action"
-                 class="Sylius\ShopApiPlugin\Controller\Checkout\ShowAvailableShippingMethodsAction"
+                 class="Sylius\SyliusShopApiPlugin\Controller\Checkout\ShowAvailableShippingMethodsAction"
         >
             <argument type="service" id="sylius.repository.order" />
             <argument type="service" id="fos_rest.view_handler" />
@@ -17,13 +17,13 @@
             <argument type="service" id="sylius.shop_api_plugin.factory.shipping_method_view_factory" />
         </service>
         <service id="sylius.shop_api_plugin.controller.checkout.choose_shipping_method_action"
-                 class="Sylius\ShopApiPlugin\Controller\Checkout\ChooseShippingMethodAction"
+                 class="Sylius\SyliusShopApiPlugin\Controller\Checkout\ChooseShippingMethodAction"
         >
             <argument type="service" id="fos_rest.view_handler" />
             <argument type="service" id="tactician.commandbus" />
         </service>
         <service id="sylius.shop_api_plugin.controller.checkout.show_available_payment_methods_action"
-                 class="Sylius\ShopApiPlugin\Controller\Checkout\ShowAvailablePaymentMethodsAction"
+                 class="Sylius\SyliusShopApiPlugin\Controller\Checkout\ShowAvailablePaymentMethodsAction"
         >
             <argument type="service" id="sylius.repository.order" />
             <argument type="service" id="fos_rest.view_handler" />
@@ -31,13 +31,13 @@
             <argument type="service" id="sylius.shop_api_plugin.factory.payment_method_view_factory" />
         </service>
         <service id="sylius.shop_api_plugin.controller.checkout.choose_payment_method_action"
-                 class="Sylius\ShopApiPlugin\Controller\Checkout\ChoosePaymentMethodAction"
+                 class="Sylius\SyliusShopApiPlugin\Controller\Checkout\ChoosePaymentMethodAction"
         >
             <argument type="service" id="fos_rest.view_handler" />
             <argument type="service" id="tactician.commandbus" />
         </service>
         <service id="sylius.shop_api_plugin.controller.checkout.complete_order_action"
-                 class="Sylius\ShopApiPlugin\Controller\Checkout\CompleteOrderAction"
+                 class="Sylius\SyliusShopApiPlugin\Controller\Checkout\CompleteOrderAction"
         >
             <argument type="service" id="fos_rest.view_handler" />
             <argument type="service" id="tactician.commandbus" />

--- a/src/Resources/config/services/actions/customer.xml
+++ b/src/Resources/config/services/actions/customer.xml
@@ -3,7 +3,7 @@
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
         <service id="sylius.shop_api_plugin.controller.customer.resend_verification_token_action"
-                 class="Sylius\ShopApiPlugin\Controller\Customer\ResendVerificationTokenAction"
+                 class="Sylius\SyliusShopApiPlugin\Controller\Customer\ResendVerificationTokenAction"
         >
             <argument type="service" id="fos_rest.view_handler" />
             <argument type="service" id="tactician.commandbus" />
@@ -12,7 +12,7 @@
         </service>
 
         <service id="sylius.shop_api_plugin.controller.customer.verify_account_action"
-                 class="Sylius\ShopApiPlugin\Controller\Customer\VerifyAccountAction"
+                 class="Sylius\SyliusShopApiPlugin\Controller\Customer\VerifyAccountAction"
         >
             <argument type="service" id="fos_rest.view_handler" />
             <argument type="service" id="tactician.commandbus" />
@@ -21,7 +21,7 @@
         </service>
 
         <service id="sylius.shop_api_plugin.controller.customer.register_customer_action"
-                 class="Sylius\ShopApiPlugin\Controller\Customer\RegisterCustomerAction"
+                 class="Sylius\SyliusShopApiPlugin\Controller\Customer\RegisterCustomerAction"
         >
             <argument type="service" id="fos_rest.view_handler" />
             <argument type="service" id="tactician.commandbus" />
@@ -30,21 +30,21 @@
         </service>
 
         <service id="sylius.shop_api_plugin.controller.customer.request_password_resetting_action"
-                 class="Sylius\ShopApiPlugin\Controller\Customer\RequestPasswordResettingAction"
+                 class="Sylius\SyliusShopApiPlugin\Controller\Customer\RequestPasswordResettingAction"
         >
             <argument type="service" id="fos_rest.view_handler" />
             <argument type="service" id="tactician.commandbus" />
         </service>
 
         <service id="sylius.shop_api_plugin.controller.customer.logged_in_customer_details_action"
-                 class="Sylius\ShopApiPlugin\Controller\Customer\LoggedInCustomerDetailsAction"
+                 class="Sylius\SyliusShopApiPlugin\Controller\Customer\LoggedInCustomerDetailsAction"
         >
             <argument type="service" id="fos_rest.view_handler" />
             <argument type="service" id="security.token_storage" />
         </service>
 
         <service id="sylius.shop_api_plugin.controller.customer.update_customer_action"
-                 class="Sylius\ShopApiPlugin\Controller\Customer\UpdateCustomerAction"
+                 class="Sylius\SyliusShopApiPlugin\Controller\Customer\UpdateCustomerAction"
         >
             <argument type="service" id="fos_rest.view_handler" />
             <argument type="service" id="validator" />

--- a/src/Resources/config/services/actions/product.xml
+++ b/src/Resources/config/services/actions/product.xml
@@ -3,48 +3,48 @@
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
         <service id="sylius.shop_api_plugin.controller.product.show_product_details_by_slug_action"
-                 class="Sylius\ShopApiPlugin\Controller\Product\ShowProductDetailsBySlugAction"
+                 class="Sylius\SyliusShopApiPlugin\Controller\Product\ShowProductDetailsBySlugAction"
         >
             <argument type="service" id="sylius.shop_api_plugin.view_repository.product_details_view_repository" />
             <argument type="service" id="fos_rest.view_handler" />
         </service>
         <service id="sylius.shop_api_plugin.controller.product.show_product_details_by_code_action"
-                 class="Sylius\ShopApiPlugin\Controller\Product\ShowProductDetailsByCodeAction"
+                 class="Sylius\SyliusShopApiPlugin\Controller\Product\ShowProductDetailsByCodeAction"
         >
             <argument type="service" id="sylius.shop_api_plugin.view_repository.product_details_view_repository" />
             <argument type="service" id="fos_rest.view_handler" />
         </service>
 
         <service id="sylius.shop_api_plugin.controller.product.show_product_catalog_by_taxon_slug_action"
-                 class="Sylius\ShopApiPlugin\Controller\Product\ShowProductCatalogByTaxonSlugAction"
+                 class="Sylius\SyliusShopApiPlugin\Controller\Product\ShowProductCatalogByTaxonSlugAction"
         >
             <argument type="service" id="fos_rest.view_handler" />
             <argument type="service" id="sylius.shop_api_plugin.view_repository.product_catalog_view_repository" />
         </service>
 
         <service id="sylius.shop_api_plugin.controller.product.show_product_catalog_by_taxon_code_action"
-                 class="Sylius\ShopApiPlugin\Controller\Product\ShowProductCatalogByTaxonCodeAction"
+                 class="Sylius\SyliusShopApiPlugin\Controller\Product\ShowProductCatalogByTaxonCodeAction"
         >
             <argument type="service" id="fos_rest.view_handler" />
             <argument type="service" id="sylius.shop_api_plugin.view_repository.product_catalog_view_repository" />
         </service>
 
         <service id="sylius.shop_api_plugin.controller.product.show_product_reviews_by_slug_action"
-                 class="Sylius\ShopApiPlugin\Controller\Product\ShowProductReviewsBySlugAction"
+                 class="Sylius\SyliusShopApiPlugin\Controller\Product\ShowProductReviewsBySlugAction"
         >
             <argument type="service" id="fos_rest.view_handler" />
             <argument type="service" id="sylius.shop_api_plugin.view_repository.product_reviews_view_repository" />
         </service>
 
         <service id="sylius.shop_api_plugin.controller.product.show_product_reviews_by_code_action"
-                 class="Sylius\ShopApiPlugin\Controller\Product\ShowProductReviewsByCodeAction"
+                 class="Sylius\SyliusShopApiPlugin\Controller\Product\ShowProductReviewsByCodeAction"
         >
             <argument type="service" id="fos_rest.view_handler" />
             <argument type="service" id="sylius.shop_api_plugin.view_repository.product_reviews_view_repository" />
         </service>
 
         <service id="sylius.shop_api_plugin.controller.product.add_review_by_slug_action"
-                 class="Sylius\ShopApiPlugin\Controller\Product\AddReviewBySlugAction"
+                 class="Sylius\SyliusShopApiPlugin\Controller\Product\AddReviewBySlugAction"
         >
             <argument type="service" id="fos_rest.view_handler" />
             <argument type="service" id="tactician.commandbus" />
@@ -53,7 +53,7 @@
         </service>
 
         <service id="sylius.shop_api_plugin.controller.product.add_review_by_code_action"
-                 class="Sylius\ShopApiPlugin\Controller\Product\AddReviewByCodeAction"
+                 class="Sylius\SyliusShopApiPlugin\Controller\Product\AddReviewByCodeAction"
         >
             <argument type="service" id="fos_rest.view_handler" />
             <argument type="service" id="tactician.commandbus" />
@@ -61,7 +61,7 @@
             <argument type="service" id="sylius.shop_api_plugin.factory.validation_error_view_factory" />
         </service>
         <service id="sylius.shop_api_plugin.controller.product.show_latest_product_action"
-                 class="Sylius\ShopApiPlugin\Controller\Product\ShowLatestProductAction"
+                 class="Sylius\SyliusShopApiPlugin\Controller\Product\ShowLatestProductAction"
         >
             <argument type="service" id="fos_rest.view_handler" />
             <argument type="service" id="sylius.shop_api_plugin.view_repository.product_latest_view_repository" />

--- a/src/Resources/config/services/actions/taxon.xml
+++ b/src/Resources/config/services/actions/taxon.xml
@@ -3,7 +3,7 @@
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
         <service id="sylius.shop_api_plugin.controller.taxon.show_taxon_tree_action"
-                 class="Sylius\ShopApiPlugin\Controller\Taxon\ShowTaxonTreeAction"
+                 class="Sylius\SyliusShopApiPlugin\Controller\Taxon\ShowTaxonTreeAction"
         >
             <argument type="service" id="sylius.repository.taxon" />
             <argument type="service" id="fos_rest.view_handler" />
@@ -11,7 +11,7 @@
             <argument>%locale%</argument>
         </service>
         <service id="sylius.shop_api_plugin.controller.taxon.show_taxon_details_action"
-                 class="Sylius\ShopApiPlugin\Controller\Taxon\ShowTaxonDetailsAction"
+                 class="Sylius\SyliusShopApiPlugin\Controller\Taxon\ShowTaxonDetailsAction"
         >
             <argument type="service" id="sylius.repository.taxon" />
             <argument type="service" id="fos_rest.view_handler" />

--- a/src/Resources/config/services/factories.xml
+++ b/src/Resources/config/services/factories.xml
@@ -2,30 +2,30 @@
 
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
-        <service id="sylius.shop_api_plugin.factory.image_view_factory" class="Sylius\ShopApiPlugin\Factory\ImageViewFactory">
+        <service id="sylius.shop_api_plugin.factory.image_view_factory" class="Sylius\SyliusShopApiPlugin\Factory\ImageViewFactory">
             <argument type="string">%sylius.shop_api.view.image.class%</argument>
         </service>
 
-        <service id="sylius.shop_api_plugin.factory.taxon_view_factory" class="Sylius\ShopApiPlugin\Factory\TaxonViewFactory">
+        <service id="sylius.shop_api_plugin.factory.taxon_view_factory" class="Sylius\SyliusShopApiPlugin\Factory\TaxonViewFactory">
             <argument type="service" id="sylius.shop_api_plugin.factory.image_view_factory" />
             <argument type="string">%sylius.shop_api.view.taxon.class%</argument>
         </service>
 
-        <service id="sylius.shop_api_plugin.factory.taxon_details_view_factory" class="Sylius\ShopApiPlugin\Factory\TaxonDetailsViewFactory">
+        <service id="sylius.shop_api_plugin.factory.taxon_details_view_factory" class="Sylius\SyliusShopApiPlugin\Factory\TaxonDetailsViewFactory">
             <argument type="service" id="sylius.shop_api_plugin.factory.taxon_view_factory" />
             <argument type="string">%sylius.shop_api.view.taxon_details.class%</argument>
         </service>
 
-        <service id="sylius.shop_api_plugin.factory.price_view_factory" class="Sylius\ShopApiPlugin\Factory\PriceViewFactory">
+        <service id="sylius.shop_api_plugin.factory.price_view_factory" class="Sylius\SyliusShopApiPlugin\Factory\PriceViewFactory">
             <argument type="string">%sylius.shop_api.view.price.class%</argument>
         </service>
 
-        <service id="sylius.shop_api_plugin.factory.product_variant_view_factory" class="Sylius\ShopApiPlugin\Factory\ProductVariantViewFactory">
+        <service id="sylius.shop_api_plugin.factory.product_variant_view_factory" class="Sylius\SyliusShopApiPlugin\Factory\ProductVariantViewFactory">
             <argument type="service" id="sylius.shop_api_plugin.factory.price_view_factory" />
             <argument type="string">%sylius.shop_api.view.product_variant.class%</argument>
         </service>
 
-        <service id="sylius.shop_api_plugin.factory.product_view_factory" class="Sylius\ShopApiPlugin\Factory\ProductViewFactory">
+        <service id="sylius.shop_api_plugin.factory.product_view_factory" class="Sylius\SyliusShopApiPlugin\Factory\ProductViewFactory">
             <argument type="service" id="sylius.shop_api_plugin.factory.image_view_factory" />
             <argument type="service" id="sylius.shop_api_plugin.factory.limited_product_attribute_values_view_factory" />
             <argument type="string">%sylius.shop_api.view.product.class%</argument>
@@ -33,18 +33,18 @@
             <argument>%locale%</argument>
         </service>
 
-        <service id="sylius.shop_api_plugin.factory.detailed_product_view_factory" class="Sylius\ShopApiPlugin\Factory\DetailedProductViewFactory">
+        <service id="sylius.shop_api_plugin.factory.detailed_product_view_factory" class="Sylius\SyliusShopApiPlugin\Factory\DetailedProductViewFactory">
             <argument type="service" id="sylius.shop_api_plugin.factory.list_product_view_factory" />
             <argument type="service" id="sylius.shop_api_plugin.generator.product_breadcrumb_generator" />
         </service>
 
-        <service id="sylius.shop_api_plugin.factory.list_product_view_factory" class="Sylius\ShopApiPlugin\Factory\ListProductViewFactory">
+        <service id="sylius.shop_api_plugin.factory.list_product_view_factory" class="Sylius\SyliusShopApiPlugin\Factory\ListProductViewFactory">
             <argument type="service" id="sylius.shop_api_plugin.factory.image_view_factory" />
             <argument type="service" id="sylius.shop_api_plugin.factory.product_view_factory" />
             <argument type="service" id="sylius.shop_api_plugin.factory.product_variant_view_factory" />
         </service>
 
-        <service id="sylius.shop_api_plugin.factory.cart_view_factory" class="Sylius\ShopApiPlugin\Factory\CartViewFactory">
+        <service id="sylius.shop_api_plugin.factory.cart_view_factory" class="Sylius\SyliusShopApiPlugin\Factory\CartViewFactory">
             <argument type="service" id="sylius.shop_api_plugin.factory.cart_item_view_factory" />
             <argument type="service" id="sylius.shop_api_plugin.factory.address_view_factory" />
             <argument type="service" id="sylius.shop_api_plugin.factory.total_view_factory" />
@@ -54,70 +54,70 @@
             <argument type="string">%sylius.shop_api.view.cart_summary.class%</argument>
         </service>
 
-        <service id="sylius.shop_api_plugin.factory.adjustment_view_factory" class="Sylius\ShopApiPlugin\Factory\AdjustmentViewFactory">
+        <service id="sylius.shop_api_plugin.factory.adjustment_view_factory" class="Sylius\SyliusShopApiPlugin\Factory\AdjustmentViewFactory">
             <argument type="service" id="sylius.shop_api_plugin.factory.price_view_factory" />
             <argument type="string">%sylius.shop_api.view.adjustment.class%</argument>
         </service>
 
-        <service id="sylius.shop_api_plugin.factory.cart_item_view_factory" class="Sylius\ShopApiPlugin\Factory\CartItemViewFactory">
+        <service id="sylius.shop_api_plugin.factory.cart_item_view_factory" class="Sylius\SyliusShopApiPlugin\Factory\CartItemViewFactory">
             <argument type="service" id="sylius.shop_api_plugin.factory.product_view_factory" />
             <argument type="service" id="sylius.shop_api_plugin.factory.product_variant_view_factory" />
             <argument type="string">%sylius.shop_api.view.cart_item.class%</argument>
         </service>
 
-        <service id="sylius.shop_api_plugin.factory.address_view_factory" class="Sylius\ShopApiPlugin\Factory\AddressViewFactory">
+        <service id="sylius.shop_api_plugin.factory.address_view_factory" class="Sylius\SyliusShopApiPlugin\Factory\AddressViewFactory">
             <argument type="string">%sylius.shop_api.view.address.class%</argument>
         </service>
 
-        <service id="sylius.shop_api_plugin.factory.total_view_factory" class="Sylius\ShopApiPlugin\Factory\TotalViewFactory">
+        <service id="sylius.shop_api_plugin.factory.total_view_factory" class="Sylius\SyliusShopApiPlugin\Factory\TotalViewFactory">
             <argument type="string">%sylius.shop_api.view.totals.class%</argument>
         </service>
 
-        <service id="sylius.shop_api_plugin.factory.validation_error_view_factory" class="Sylius\ShopApiPlugin\Factory\ValidationErrorViewFactory">
+        <service id="sylius.shop_api_plugin.factory.validation_error_view_factory" class="Sylius\SyliusShopApiPlugin\Factory\ValidationErrorViewFactory">
             <argument type="string">%sylius.shop_api.view.validation_error.class%</argument>
         </service>
 
-        <service id="sylius.shop_api_plugin.factory.shipping_method_view_factory" class="Sylius\ShopApiPlugin\Factory\ShippingMethodViewFactory">
+        <service id="sylius.shop_api_plugin.factory.shipping_method_view_factory" class="Sylius\SyliusShopApiPlugin\Factory\ShippingMethodViewFactory">
             <argument type="service" id="sylius.registry.shipping_calculator" />
             <argument type="service" id="sylius.shop_api_plugin.factory.price_view_factory" />
             <argument type="string">%sylius.shop_api.view.shipping_method.class%</argument>
         </service>
 
-        <service id="sylius.shop_api_plugin.factory.shipment_view_factory" class="Sylius\ShopApiPlugin\Factory\ShipmentViewFactory">
+        <service id="sylius.shop_api_plugin.factory.shipment_view_factory" class="Sylius\SyliusShopApiPlugin\Factory\ShipmentViewFactory">
             <argument type="service" id="sylius.shop_api_plugin.factory.shipping_method_view_factory" />
             <argument type="string">%sylius.shop_api.view.shipment.class%</argument>
         </service>
 
-        <service id="sylius.shop_api_plugin.factory.page_view_factory" class="Sylius\ShopApiPlugin\Factory\PageViewFactory">
+        <service id="sylius.shop_api_plugin.factory.page_view_factory" class="Sylius\SyliusShopApiPlugin\Factory\PageViewFactory">
             <argument type="service" id="router" />
             <argument type="string">%sylius.shop_api.view.page.class%</argument>
             <argument type="string">%sylius.shop_api.view.page_links.class%</argument>
         </service>
 
-        <service id="sylius.shop_api_plugin.factory.payment_view_factory" class="Sylius\ShopApiPlugin\Factory\PaymentViewFactory">
+        <service id="sylius.shop_api_plugin.factory.payment_view_factory" class="Sylius\SyliusShopApiPlugin\Factory\PaymentViewFactory">
             <argument type="service" id="sylius.shop_api_plugin.factory.payment_method_view_factory" />
             <argument type="service" id="sylius.shop_api_plugin.factory.price_view_factory" />
             <argument type="string">%sylius.shop_api.view.payment.class%</argument>
         </service>
 
-        <service id="sylius.shop_api_plugin.factory.payment_method_view_factory" class="Sylius\ShopApiPlugin\Factory\PaymentMethodViewFactory">
+        <service id="sylius.shop_api_plugin.factory.payment_method_view_factory" class="Sylius\SyliusShopApiPlugin\Factory\PaymentMethodViewFactory">
             <argument type="string">%sylius.shop_api.view.payment_method.class%</argument>
         </service>
 
-        <service id="sylius.shop_api_plugin.factory.product_attribute_value_view_factory" class="Sylius\ShopApiPlugin\Factory\ProductAttributeValueViewFactory">
+        <service id="sylius.shop_api_plugin.factory.product_attribute_value_view_factory" class="Sylius\SyliusShopApiPlugin\Factory\ProductAttributeValueViewFactory">
             <argument type="string">%sylius.shop_api.view.product_attribute_value.class%</argument>
         </service>
 
-        <service id="sylius.shop_api_plugin.factory.product_review_view_factory" class="Sylius\ShopApiPlugin\Factory\ProductReviewViewFactory">
+        <service id="sylius.shop_api_plugin.factory.product_review_view_factory" class="Sylius\SyliusShopApiPlugin\Factory\ProductReviewViewFactory">
             <argument type="string">%sylius.shop_api.view.product_review.class%</argument>
         </service>
 
-        <service id="sylius.shop_api_plugin.factory.limited_product_attribute_values_view_factory" class="Sylius\ShopApiPlugin\Factory\LimitedProductAttributeValuesViewFactory" >
+        <service id="sylius.shop_api_plugin.factory.limited_product_attribute_values_view_factory" class="Sylius\SyliusShopApiPlugin\Factory\LimitedProductAttributeValuesViewFactory" >
             <argument type="service" id="sylius.shop_api_plugin.factory.product_attribute_value_view_factory" />
             <argument>%sylius.shop_api.included_attributes%</argument>
         </service>
 
-        <service id="sylius.shop_api_plugin.factory.customer_view_factory" class="Sylius\ShopApiPlugin\Factory\CustomerViewFactory" >
+        <service id="sylius.shop_api_plugin.factory.customer_view_factory" class="Sylius\SyliusShopApiPlugin\Factory\CustomerViewFactory" >
             <argument type="string">%sylius.shop_api.view.customer.class%</argument>
         </service>
     </services>

--- a/src/Resources/config/services/handlers.xml
+++ b/src/Resources/config/services/handlers.xml
@@ -2,156 +2,156 @@
 
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
-        <service id="sylius.shop_api_plugin.handler.address_shipment" class="Sylius\ShopApiPlugin\Handler\AddressOrderHandler">
+        <service id="sylius.shop_api_plugin.handler.address_shipment" class="Sylius\SyliusShopApiPlugin\Handler\AddressOrderHandler">
             <argument type="service" id="sylius.repository.order"/>
             <argument type="service" id="sylius.factory.address"/>
             <argument type="service" id="sm.factory"/>
-            <tag name="tactician.handler" command="Sylius\ShopApiPlugin\Command\AddressOrder"/>
+            <tag name="tactician.handler" command="Sylius\SyliusShopApiPlugin\Command\AddressOrder"/>
         </service>
 
-        <service id="sylius.shop_api_plugin.handler.pickup_cart_handler" class="Sylius\ShopApiPlugin\Handler\PickupCartHandler">
+        <service id="sylius.shop_api_plugin.handler.pickup_cart_handler" class="Sylius\SyliusShopApiPlugin\Handler\PickupCartHandler">
             <argument type="service" id="sylius.factory.order"/>
             <argument type="service" id="sylius.repository.order"/>
             <argument type="service" id="sylius.repository.channel"/>
-            <tag name="tactician.handler" command="Sylius\ShopApiPlugin\Command\PickupCart"/>
+            <tag name="tactician.handler" command="Sylius\SyliusShopApiPlugin\Command\PickupCart"/>
         </service>
 
-        <service id="sylius.shop_api_plugin.handler.drop_cart_handler" class="Sylius\ShopApiPlugin\Handler\DropCartHandler">
+        <service id="sylius.shop_api_plugin.handler.drop_cart_handler" class="Sylius\SyliusShopApiPlugin\Handler\DropCartHandler">
             <argument type="service" id="sylius.repository.order"/>
-            <tag name="tactician.handler" command="Sylius\ShopApiPlugin\Command\DropCart"/>
+            <tag name="tactician.handler" command="Sylius\SyliusShopApiPlugin\Command\DropCart"/>
         </service>
 
-        <service id="sylius.shop_api_plugin.handler.put_simple_item_to_cart_handler" class="Sylius\ShopApiPlugin\Handler\PutSimpleItemToCartHandler">
+        <service id="sylius.shop_api_plugin.handler.put_simple_item_to_cart_handler" class="Sylius\SyliusShopApiPlugin\Handler\PutSimpleItemToCartHandler">
             <argument type="service" id="sylius.repository.order"/>
             <argument type="service" id="sylius.repository.product"/>
             <argument type="service" id="sylius.shop_api_plugin.modifier.order_modifier"/>
-            <tag name="tactician.handler" command="Sylius\ShopApiPlugin\Command\PutSimpleItemToCart"/>
+            <tag name="tactician.handler" command="Sylius\SyliusShopApiPlugin\Command\PutSimpleItemToCart"/>
         </service>
 
-        <service id="sylius.shop_api_plugin.handler.put_variant_based_configurable_item_to_cart_handler" class="Sylius\ShopApiPlugin\Handler\PutVariantBasedConfigurableItemToCartHandler">
+        <service id="sylius.shop_api_plugin.handler.put_variant_based_configurable_item_to_cart_handler" class="Sylius\SyliusShopApiPlugin\Handler\PutVariantBasedConfigurableItemToCartHandler">
             <argument type="service" id="sylius.repository.order"/>
             <argument type="service" id="sylius.repository.product_variant"/>
             <argument type="service" id="sylius.shop_api_plugin.modifier.order_modifier"/>
-            <tag name="tactician.handler" command="Sylius\ShopApiPlugin\Command\PutVariantBasedConfigurableItemToCart"/>
+            <tag name="tactician.handler" command="Sylius\SyliusShopApiPlugin\Command\PutVariantBasedConfigurableItemToCart"/>
         </service>
 
-        <service id="sylius.shop_api_plugin.handler.put_option_based_configurable_item_to_cart_handler" class="Sylius\ShopApiPlugin\Handler\PutOptionBasedConfigurableItemToCartHandler">
+        <service id="sylius.shop_api_plugin.handler.put_option_based_configurable_item_to_cart_handler" class="Sylius\SyliusShopApiPlugin\Handler\PutOptionBasedConfigurableItemToCartHandler">
             <argument type="service" id="sylius.repository.order"/>
             <argument type="service" id="sylius.repository.product"/>
             <argument type="service" id="sylius.shop_api_plugin.modifier.order_modifier"/>
-            <tag name="tactician.handler" command="Sylius\ShopApiPlugin\Command\PutOptionBasedConfigurableItemToCart"/>
+            <tag name="tactician.handler" command="Sylius\SyliusShopApiPlugin\Command\PutOptionBasedConfigurableItemToCart"/>
         </service>
 
-        <service id="sylius.shop_api_plugin.handler.change_item_quantity_handler" class="Sylius\ShopApiPlugin\Handler\ChangeItemQuantityHandler">
+        <service id="sylius.shop_api_plugin.handler.change_item_quantity_handler" class="Sylius\SyliusShopApiPlugin\Handler\ChangeItemQuantityHandler">
             <argument type="service" id="sylius.repository.order_item" />
             <argument type="service" id="sylius.repository.order" />
             <argument type="service" id="sylius.order_item_quantity_modifier" />
             <argument type="service" id="sylius.order_processing.order_processor" />
-            <tag name="tactician.handler" command="Sylius\ShopApiPlugin\Command\ChangeItemQuantity"/>
+            <tag name="tactician.handler" command="Sylius\SyliusShopApiPlugin\Command\ChangeItemQuantity"/>
         </service>
 
-        <service id="sylius.shop_api_plugin.handler.remove_item_from_cart_handler" class="Sylius\ShopApiPlugin\Handler\RemoveItemFromCartHandler">
+        <service id="sylius.shop_api_plugin.handler.remove_item_from_cart_handler" class="Sylius\SyliusShopApiPlugin\Handler\RemoveItemFromCartHandler">
             <argument type="service" id="sylius.repository.order_item" />
             <argument type="service" id="sylius.repository.order" />
             <argument type="service" id="sylius.order_processing.order_processor" />
-            <tag name="tactician.handler" command="Sylius\ShopApiPlugin\Command\RemoveItemFromCart"/>
+            <tag name="tactician.handler" command="Sylius\SyliusShopApiPlugin\Command\RemoveItemFromCart"/>
         </service>
 
-        <service id="sylius.shop_api_plugin.handler.choose_shipping_method_handler" class="Sylius\ShopApiPlugin\Handler\ChooseShippingMethodHandler">
+        <service id="sylius.shop_api_plugin.handler.choose_shipping_method_handler" class="Sylius\SyliusShopApiPlugin\Handler\ChooseShippingMethodHandler">
             <argument type="service" id="sylius.repository.order"/>
             <argument type="service" id="sylius.repository.shipping_method"/>
             <argument type="service" id="sylius.shipping_eligibility_checker"/>
             <argument type="service" id="sm.factory"/>
-            <tag name="tactician.handler" command="Sylius\ShopApiPlugin\Command\ChooseShippingMethod"/>
+            <tag name="tactician.handler" command="Sylius\SyliusShopApiPlugin\Command\ChooseShippingMethod"/>
         </service>
 
-        <service id="sylius.shop_api_plugin.handler.choose_payment_method_handler" class="Sylius\ShopApiPlugin\Handler\ChoosePaymentMethodHandler">
+        <service id="sylius.shop_api_plugin.handler.choose_payment_method_handler" class="Sylius\SyliusShopApiPlugin\Handler\ChoosePaymentMethodHandler">
             <argument type="service" id="sylius.repository.order"/>
             <argument type="service" id="sylius.repository.payment_method"/>
             <argument type="service" id="sm.factory"/>
-            <tag name="tactician.handler" command="Sylius\ShopApiPlugin\Command\ChoosePaymentMethod"/>
+            <tag name="tactician.handler" command="Sylius\SyliusShopApiPlugin\Command\ChoosePaymentMethod"/>
         </service>
 
-        <service id="sylius.shop_api_plugin.handler.add_coupon_handler" class="Sylius\ShopApiPlugin\Handler\AddCouponHandler">
+        <service id="sylius.shop_api_plugin.handler.add_coupon_handler" class="Sylius\SyliusShopApiPlugin\Handler\AddCouponHandler">
             <argument type="service" id="sylius.repository.order"/>
             <argument type="service" id="sylius.repository.promotion_coupon"/>
             <argument type="service" id="sylius.order_processing.order_processor"/>
             <argument type="service" id="sylius.shop_api_plugin.checker.promotion_coupon_eligibility_checker"/>
-            <tag name="tactician.handler" command="Sylius\ShopApiPlugin\Command\AddCoupon"/>
+            <tag name="tactician.handler" command="Sylius\SyliusShopApiPlugin\Command\AddCoupon"/>
         </service>
 
-        <service id="sylius.shop_api_plugin.handler.remove_coupon_handler" class="Sylius\ShopApiPlugin\Handler\RemoveCouponHandler">
+        <service id="sylius.shop_api_plugin.handler.remove_coupon_handler" class="Sylius\SyliusShopApiPlugin\Handler\RemoveCouponHandler">
             <argument type="service" id="sylius.repository.order"/>
             <argument type="service" id="sylius.order_processing.order_processor"/>
-            <tag name="tactician.handler" command="Sylius\ShopApiPlugin\Command\RemoveCoupon"/>
+            <tag name="tactician.handler" command="Sylius\SyliusShopApiPlugin\Command\RemoveCoupon"/>
         </service>
 
-        <service id="sylius.shop_api_plugin.handler.complete_order_handler" class="Sylius\ShopApiPlugin\Handler\CompleteOrderHandler">
+        <service id="sylius.shop_api_plugin.handler.complete_order_handler" class="Sylius\SyliusShopApiPlugin\Handler\CompleteOrderHandler">
             <argument type="service" id="sylius.repository.order"/>
             <argument type="service" id="sylius.shop_api_plugin.provider.customer_provider"/>
             <argument type="service" id="sm.factory"/>
-            <tag name="tactician.handler" command="Sylius\ShopApiPlugin\Command\CompleteOrder"/>
+            <tag name="tactician.handler" command="Sylius\SyliusShopApiPlugin\Command\CompleteOrder"/>
         </service>
 
-        <service id="sylius.shop_api_plugin.handler.add_product_review_by_slug_handler" class="Sylius\ShopApiPlugin\Handler\AddProductReviewBySlugHandler">
+        <service id="sylius.shop_api_plugin.handler.add_product_review_by_slug_handler" class="Sylius\SyliusShopApiPlugin\Handler\AddProductReviewBySlugHandler">
             <argument type="service" id="sylius.repository.product_review"/>
             <argument type="service" id="sylius.repository.channel"/>
             <argument type="service" id="sylius.repository.product"/>
             <argument type="service" id="sylius.shop_api_plugin.provider.product_reviewer_provider"/>
             <argument type="service" id="sylius.factory.product_review"/>
-            <tag name="tactician.handler" command="Sylius\ShopApiPlugin\Command\AddProductReviewBySlug"/>
+            <tag name="tactician.handler" command="Sylius\SyliusShopApiPlugin\Command\AddProductReviewBySlug"/>
         </service>
 
-        <service id="sylius.shop_api_plugin.handler.add_product_review_by_code_handler" class="Sylius\ShopApiPlugin\Handler\AddProductReviewByCodeHandler">
+        <service id="sylius.shop_api_plugin.handler.add_product_review_by_code_handler" class="Sylius\SyliusShopApiPlugin\Handler\AddProductReviewByCodeHandler">
             <argument type="service" id="sylius.repository.product_review"/>
             <argument type="service" id="sylius.repository.channel"/>
             <argument type="service" id="sylius.repository.product"/>
             <argument type="service" id="sylius.shop_api_plugin.provider.product_reviewer_provider"/>
             <argument type="service" id="sylius.factory.product_review"/>
-            <tag name="tactician.handler" command="Sylius\ShopApiPlugin\Command\AddProductReviewByCode"/>
+            <tag name="tactician.handler" command="Sylius\SyliusShopApiPlugin\Command\AddProductReviewByCode"/>
         </service>
 
-        <service id="sylius.shop_api_plugin.handler.register_customer" class="Sylius\ShopApiPlugin\Handler\RegisterCustomerHandler">
+        <service id="sylius.shop_api_plugin.handler.register_customer" class="Sylius\SyliusShopApiPlugin\Handler\RegisterCustomerHandler">
             <argument type="service" id="sylius.repository.shop_user" />
             <argument type="service" id="sylius.repository.channel" />
             <argument type="service" id="sylius.factory.shop_user" />
             <argument type="service" id="sylius.factory.customer" />
             <argument type="service" id="event_dispatcher" />
-            <tag name="tactician.handler" command="Sylius\ShopApiPlugin\Command\RegisterCustomer" />
+            <tag name="tactician.handler" command="Sylius\SyliusShopApiPlugin\Command\RegisterCustomer" />
         </service>
 
-        <service id="sylius.shop_api_plugin.handler.update_customer" class="Sylius\ShopApiPlugin\Handler\UpdateCustomerHandler">
+        <service id="sylius.shop_api_plugin.handler.update_customer" class="Sylius\SyliusShopApiPlugin\Handler\UpdateCustomerHandler">
             <argument type="service" id="sylius.repository.customer" />
-            <tag name="tactician.handler" command="Sylius\ShopApiPlugin\Command\UpdateCustomer" />
+            <tag name="tactician.handler" command="Sylius\SyliusShopApiPlugin\Command\UpdateCustomer" />
         </service>
 
-        <service id="sylius.shop_api_plugin.handler.send_verification_token_handler" class="Sylius\ShopApiPlugin\Handler\SendVerificationTokenHandler">
+        <service id="sylius.shop_api_plugin.handler.send_verification_token_handler" class="Sylius\SyliusShopApiPlugin\Handler\SendVerificationTokenHandler">
             <argument type="service" id="sylius.repository.shop_user" />
             <argument type="service" id="sylius.email_sender" />
-            <tag name="tactician.handler" command="Sylius\ShopApiPlugin\Command\SendVerificationToken" />
+            <tag name="tactician.handler" command="Sylius\SyliusShopApiPlugin\Command\SendVerificationToken" />
         </service>
 
-        <service id="sylius.shop_api_plugin.handler.verify_account_handler" class="Sylius\ShopApiPlugin\Handler\VerifyAccountHandler">
+        <service id="sylius.shop_api_plugin.handler.verify_account_handler" class="Sylius\SyliusShopApiPlugin\Handler\VerifyAccountHandler">
             <argument type="service" id="sylius.repository.shop_user" />
-            <tag name="tactician.handler" command="Sylius\ShopApiPlugin\Command\VerifyAccount" />
+            <tag name="tactician.handler" command="Sylius\SyliusShopApiPlugin\Command\VerifyAccount" />
         </service>
 
-        <service id="sylius.shop_api_plugin.handler.generate_verification_token_handler" class="Sylius\ShopApiPlugin\Handler\GenerateVerificationTokenHandler">
+        <service id="sylius.shop_api_plugin.handler.generate_verification_token_handler" class="Sylius\SyliusShopApiPlugin\Handler\GenerateVerificationTokenHandler">
             <argument type="service" id="sylius.repository.shop_user" />
             <argument type="service" id="sylius.shop_user.token_generator.email_verification" />
-            <tag name="tactician.handler" command="Sylius\ShopApiPlugin\Command\GenerateVerificationToken" />
+            <tag name="tactician.handler" command="Sylius\SyliusShopApiPlugin\Command\GenerateVerificationToken" />
         </service>
 
-        <service id="sylius.shop_api_plugin.handler.send_reset_password_token_handler" class="Sylius\ShopApiPlugin\Handler\SendResetPasswordTokenHandler">
+        <service id="sylius.shop_api_plugin.handler.send_reset_password_token_handler" class="Sylius\SyliusShopApiPlugin\Handler\SendResetPasswordTokenHandler">
             <argument type="service" id="sylius.repository.shop_user" />
             <argument type="service" id="sylius.email_sender" />
-            <tag name="tactician.handler" command="Sylius\ShopApiPlugin\Command\SendResetPasswordToken" />
+            <tag name="tactician.handler" command="Sylius\SyliusShopApiPlugin\Command\SendResetPasswordToken" />
         </service>
 
-        <service id="sylius.shop_api_plugin.handler.generate_reset_password_token_handler" class="Sylius\ShopApiPlugin\Handler\GenerateResetPasswordTokenHandler">
+        <service id="sylius.shop_api_plugin.handler.generate_reset_password_token_handler" class="Sylius\SyliusShopApiPlugin\Handler\GenerateResetPasswordTokenHandler">
             <argument type="service" id="sylius.repository.shop_user" />
             <argument type="service" id="sylius.shop_user.token_generator.email_verification" />
-            <tag name="tactician.handler" command="Sylius\ShopApiPlugin\Command\GenerateResetPasswordToken" />
+            <tag name="tactician.handler" command="Sylius\SyliusShopApiPlugin\Command\GenerateResetPasswordToken" />
         </service>
     </services>
 </container>

--- a/src/Resources/config/services/queries.xml
+++ b/src/Resources/config/services/queries.xml
@@ -2,18 +2,18 @@
 
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
-        <service id="sylius.shop_api_plugin.view_repository.cart_view_repository" class="Sylius\ShopApiPlugin\ViewRepository\CartViewRepository">
+        <service id="sylius.shop_api_plugin.view_repository.cart_view_repository" class="Sylius\SyliusShopApiPlugin\ViewRepository\CartViewRepository">
             <argument type="service" id="sylius.repository.order" />
             <argument type="service" id="sylius.shop_api_plugin.factory.cart_view_factory" />
         </service>
 
-        <service id="sylius.shop_api_plugin.view_repository.product_details_view_repository" class="Sylius\ShopApiPlugin\ViewRepository\ProductDetailsViewRepository">
+        <service id="sylius.shop_api_plugin.view_repository.product_details_view_repository" class="Sylius\SyliusShopApiPlugin\ViewRepository\ProductDetailsViewRepository">
             <argument type="service" id="sylius.repository.channel" />
             <argument type="service" id="sylius.repository.product" />
             <argument type="service" id="sylius.shop_api_plugin.factory.detailed_product_view_factory" />
         </service>
 
-        <service id="sylius.shop_api_plugin.view_repository.product_catalog_view_repository" class="Sylius\ShopApiPlugin\ViewRepository\ProductCatalogViewRepository">
+        <service id="sylius.shop_api_plugin.view_repository.product_catalog_view_repository" class="Sylius\SyliusShopApiPlugin\ViewRepository\ProductCatalogViewRepository">
             <argument type="service" id="sylius.repository.channel" />
             <argument type="service" id="sylius.repository.product" />
             <argument type="service" id="sylius.repository.taxon" />
@@ -21,7 +21,7 @@
             <argument type="service" id="sylius.shop_api_plugin.factory.page_view_factory" />
         </service>
 
-        <service id="sylius.shop_api_plugin.view_repository.product_reviews_view_repository" class="Sylius\ShopApiPlugin\ViewRepository\ProductReviewsViewRepository">
+        <service id="sylius.shop_api_plugin.view_repository.product_reviews_view_repository" class="Sylius\SyliusShopApiPlugin\ViewRepository\ProductReviewsViewRepository">
             <argument type="service" id="sylius.repository.channel" />
             <argument type="service" id="sylius.repository.product_review" />
             <argument type="service" id="sylius.repository.product" />
@@ -29,7 +29,7 @@
             <argument type="service" id="sylius.shop_api_plugin.factory.page_view_factory" />
         </service>
 
-        <service id="sylius.shop_api_plugin.view_repository.product_latest_view_repository" class="Sylius\ShopApiPlugin\ViewRepository\ProductLatestViewRepository">
+        <service id="sylius.shop_api_plugin.view_repository.product_latest_view_repository" class="Sylius\SyliusShopApiPlugin\ViewRepository\ProductLatestViewRepository">
             <argument type="service" id="sylius.repository.channel" />
             <argument type="service" id="sylius.repository.product" />
             <argument type="service" id="sylius.shop_api_plugin.factory.list_product_view_factory" />

--- a/src/Resources/config/services/validators.xml
+++ b/src/Resources/config/services/validators.xml
@@ -3,43 +3,43 @@
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
         <service id="sylius.shop_api_plugin.validator.channel_exists_validator"
-                 class="Sylius\ShopApiPlugin\Validator\ChannelExistsValidator"
+                 class="Sylius\SyliusShopApiPlugin\Validator\ChannelExistsValidator"
         >
             <argument type="service" id="sylius.repository.channel" />
             <tag name="validator.constraint_validator" alias="sylius_shop_api_channel_exists_validator" />
         </service>
         <service id="sylius.shop_api_plugin.validator.token_is_not_used_validator"
-                 class="Sylius\ShopApiPlugin\Validator\TokenIsNotUsedValidator"
+                 class="Sylius\SyliusShopApiPlugin\Validator\TokenIsNotUsedValidator"
         >
             <argument type="service" id="sylius.repository.order" />
             <tag name="validator.constraint_validator" alias="sylius_shop_api_token_is_not_used_validator" />
         </service>
         <service id="sylius.shop_api_plugin.validator.cart_exists_validator"
-                 class="Sylius\ShopApiPlugin\Validator\CartExistsValidator"
+                 class="Sylius\SyliusShopApiPlugin\Validator\CartExistsValidator"
         >
             <argument type="service" id="sylius.repository.order" />
             <tag name="validator.constraint_validator" alias="sylius_shop_api_cart_exists_validator" />
         </service>
         <service id="sylius.shop_api_plugin.validator.cart_item_exists_validator"
-                 class="Sylius\ShopApiPlugin\Validator\CartItemExistsValidator"
+                 class="Sylius\SyliusShopApiPlugin\Validator\CartItemExistsValidator"
         >
             <argument type="service" id="sylius.repository.order_item" />
             <tag name="validator.constraint_validator" alias="sylius_shop_api_cart_item_exists_validator" />
         </service>
         <service id="sylius.shop_api_plugin.validator.shop_user_exists_validator"
-                 class="Sylius\ShopApiPlugin\Validator\ShopUserExistsValidator"
+                 class="Sylius\SyliusShopApiPlugin\Validator\ShopUserExistsValidator"
         >
             <argument type="service" id="sylius.repository.shop_user" />
             <tag name="validator.constraint_validator" alias="sylius_shop_api_shop_user_exists_validator" />
         </service>
         <service id="sylius.shop_api_plugin.validator.shop_user_does_not_exist_validator"
-                 class="Sylius\ShopApiPlugin\Validator\ShopUserDoesNotExistValidator"
+                 class="Sylius\SyliusShopApiPlugin\Validator\ShopUserDoesNotExistValidator"
         >
             <argument type="service" id="sylius.repository.shop_user" />
             <tag name="validator.constraint_validator" alias="sylius_shop_api_shop_user_does_not_exist_validator" />
         </service>
         <service id="sylius.shop_api_plugin.validator.valid_promotion_coupon_code_validator"
-                 class="Sylius\ShopApiPlugin\Validator\ValidPromotionCouponCodeValidator"
+                 class="Sylius\SyliusShopApiPlugin\Validator\ValidPromotionCouponCodeValidator"
         >
             <argument type="service" id="sylius.repository.order" />
             <argument type="service" id="sylius.repository.promotion_coupon" />
@@ -47,25 +47,25 @@
             <tag name="validator.constraint_validator" alias="sylius_shop_api_valid_coupon_code_validator" />
         </service>
         <service id="sylius.shop_api_plugin.validator.simple_product_validator"
-                 class="Sylius\ShopApiPlugin\Validator\SimpleProductValidator"
+                 class="Sylius\SyliusShopApiPlugin\Validator\SimpleProductValidator"
         >
             <argument type="service" id="sylius.repository.product" />
             <tag name="validator.constraint_validator" alias="sylius_shop_api_simple_product_validator" />
         </service>
         <service id="sylius.shop_api_plugin.validator.configurable_product_validator"
-                 class="Sylius\ShopApiPlugin\Validator\ConfigurableProductValidator"
+                 class="Sylius\SyliusShopApiPlugin\Validator\ConfigurableProductValidator"
         >
             <argument type="service" id="sylius.repository.product" />
             <tag name="validator.constraint_validator" alias="sylius_shop_api_configurable_product_validator" />
         </service>
         <service id="sylius.shop_api_plugin.validator.product_variant_exists_validator"
-                 class="Sylius\ShopApiPlugin\Validator\ProductVariantExistsValidator"
+                 class="Sylius\SyliusShopApiPlugin\Validator\ProductVariantExistsValidator"
         >
             <argument type="service" id="sylius.repository.product_variant" />
             <tag name="validator.constraint_validator" alias="sylius_shop_api_product_variant_exists_validator" />
         </service>
         <service id="sylius.shop_api_plugin.validator.product_exists_validator"
-                 class="Sylius\ShopApiPlugin\Validator\ProductExistsValidator"
+                 class="Sylius\SyliusShopApiPlugin\Validator\ProductExistsValidator"
         >
             <argument type="service" id="sylius.repository.product" />
             <tag name="validator.constraint_validator" alias="sylius_shop_api_product_exists_validator" />

--- a/src/Resources/config/validation/AddCouponRequest.xml
+++ b/src/Resources/config/validation/AddCouponRequest.xml
@@ -12,8 +12,8 @@
 -->
 
 <constraint-mapping xmlns="http://symfony.com/schema/dic/constraint-mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/constraint-mapping http://symfony.com/schema/dic/services/constraint-mapping-1.0.xsd">
-    <class name="Sylius\ShopApiPlugin\Request\AddCouponRequest">
-        <constraint name="Sylius\ShopApiPlugin\Validator\Constraints\ValidPromotionCouponCode" />
+    <class name="Sylius\SyliusShopApiPlugin\Request\AddCouponRequest">
+        <constraint name="Sylius\SyliusShopApiPlugin\Validator\Constraints\ValidPromotionCouponCode" />
         <property name="coupon">
             <constraint name="NotNull">
                 <option name="message">sylius.shop_api.coupon.not_null</option>
@@ -23,7 +23,7 @@
             <constraint name="NotNull">
                 <option name="message">sylius.shop_api.token.not_null</option>
             </constraint>
-            <constraint name="Sylius\ShopApiPlugin\Validator\Constraints\CartExists" />
+            <constraint name="Sylius\SyliusShopApiPlugin\Validator\Constraints\CartExists" />
         </property>
     </class>
 </constraint-mapping>

--- a/src/Resources/config/validation/ChangeItemQuantityRequest.xml
+++ b/src/Resources/config/validation/ChangeItemQuantityRequest.xml
@@ -12,12 +12,12 @@
 -->
 
 <constraint-mapping xmlns="http://symfony.com/schema/dic/constraint-mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/constraint-mapping http://symfony.com/schema/dic/services/constraint-mapping-1.0.xsd">
-    <class name="Sylius\ShopApiPlugin\Request\ChangeItemQuantityRequest">
+    <class name="Sylius\SyliusShopApiPlugin\Request\ChangeItemQuantityRequest">
         <property name="token">
             <constraint name="NotNull">
                 <option name="message">sylius.shop_api.token.not_null</option>
             </constraint>
-            <constraint name="Sylius\ShopApiPlugin\Validator\Constraints\CartExists" />
+            <constraint name="Sylius\SyliusShopApiPlugin\Validator\Constraints\CartExists" />
         </property>
         <property name="quantity">
             <constraint name="Type">
@@ -38,7 +38,7 @@
             <constraint name="NotNull">
                 <option name="message">sylius.shop_api.cart_item.not_null</option>
             </constraint>
-            <constraint name="Sylius\ShopApiPlugin\Validator\Constraints\CartItemExists" />
+            <constraint name="Sylius\SyliusShopApiPlugin\Validator\Constraints\CartItemExists" />
         </property>
     </class>
 </constraint-mapping>

--- a/src/Resources/config/validation/CustomerRequest.xml
+++ b/src/Resources/config/validation/CustomerRequest.xml
@@ -2,7 +2,7 @@
 <constraint-mapping xmlns="http://symfony.com/schema/dic/constraint-mapping"
                     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                     xsi:schemaLocation="http://symfony.com/schema/dic/constraint-mapping http://symfony.com/schema/dic/services/constraint-mapping-1.0.xsd">
-    <class name="Sylius\ShopApiPlugin\Request\UpdateCustomerRequest">
+    <class name="Sylius\SyliusShopApiPlugin\Request\UpdateCustomerRequest">
         <property name="firstName">
             <constraint name="NotBlank">
                 <option name="message">sylius.customer.first_name.not_blank</option>

--- a/src/Resources/config/validation/DropCartRequest.xml
+++ b/src/Resources/config/validation/DropCartRequest.xml
@@ -12,12 +12,12 @@
 -->
 
 <constraint-mapping xmlns="http://symfony.com/schema/dic/constraint-mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/constraint-mapping http://symfony.com/schema/dic/services/constraint-mapping-1.0.xsd">
-    <class name="Sylius\ShopApiPlugin\Request\DropCartRequest">
+    <class name="Sylius\SyliusShopApiPlugin\Request\DropCartRequest">
         <property name="token">
             <constraint name="NotNull">
                 <option name="message">sylius.shop_api.token.not_null</option>
             </constraint>
-            <constraint name="Sylius\ShopApiPlugin\Validator\Constraints\CartExists" />
+            <constraint name="Sylius\SyliusShopApiPlugin\Validator\Constraints\CartExists" />
         </property>
     </class>
 </constraint-mapping>

--- a/src/Resources/config/validation/PickupCartRequest.xml
+++ b/src/Resources/config/validation/PickupCartRequest.xml
@@ -12,18 +12,18 @@
 -->
 
 <constraint-mapping xmlns="http://symfony.com/schema/dic/constraint-mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/constraint-mapping http://symfony.com/schema/dic/services/constraint-mapping-1.0.xsd">
-    <class name="Sylius\ShopApiPlugin\Request\PickupCartRequest">
+    <class name="Sylius\SyliusShopApiPlugin\Request\PickupCartRequest">
         <property name="channel">
             <constraint name="NotNull">
                 <option name="message">sylius.shop_api.channel.not_null</option>
             </constraint>
-            <constraint name="Sylius\ShopApiPlugin\Validator\Constraints\ChannelExists" />
+            <constraint name="Sylius\SyliusShopApiPlugin\Validator\Constraints\ChannelExists" />
         </property>
         <property name="token">
             <constraint name="NotNull">
                 <option name="message">sylius.shop_api.token.not_null</option>
             </constraint>
-            <constraint name="Sylius\ShopApiPlugin\Validator\Constraints\TokenIsNotUsed" />
+            <constraint name="Sylius\SyliusShopApiPlugin\Validator\Constraints\TokenIsNotUsed" />
         </property>
     </class>
 </constraint-mapping>

--- a/src/Resources/config/validation/PutOptionBasedConfigutableItemToCartRequest.xml
+++ b/src/Resources/config/validation/PutOptionBasedConfigutableItemToCartRequest.xml
@@ -12,12 +12,12 @@
 -->
 
 <constraint-mapping xmlns="http://symfony.com/schema/dic/constraint-mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/constraint-mapping http://symfony.com/schema/dic/services/constraint-mapping-1.0.xsd">
-    <class name="Sylius\ShopApiPlugin\Request\PutOptionBasedConfigurableItemToCartRequest">
+    <class name="Sylius\SyliusShopApiPlugin\Request\PutOptionBasedConfigurableItemToCartRequest">
         <property name="token">
             <constraint name="NotNull">
                 <option name="message">sylius.shop_api.token.not_null</option>
             </constraint>
-            <constraint name="Sylius\ShopApiPlugin\Validator\Constraints\CartExists" />
+            <constraint name="Sylius\SyliusShopApiPlugin\Validator\Constraints\CartExists" />
         </property>
         <property name="quantity">
             <constraint name="Type">
@@ -38,8 +38,8 @@
             <constraint name="NotNull">
                 <option name="message">sylius.shop_api.product.not_null</option>
             </constraint>
-            <constraint name="Sylius\ShopApiPlugin\Validator\Constraints\ProductExists" />
-            <constraint name="Sylius\ShopApiPlugin\Validator\Constraints\ConfigurableProduct" />
+            <constraint name="Sylius\SyliusShopApiPlugin\Validator\Constraints\ProductExists" />
+            <constraint name="Sylius\SyliusShopApiPlugin\Validator\Constraints\ConfigurableProduct" />
         </property>
     </class>
 </constraint-mapping>

--- a/src/Resources/config/validation/PutSimpleItemToCartRequest.xml
+++ b/src/Resources/config/validation/PutSimpleItemToCartRequest.xml
@@ -12,12 +12,12 @@
 -->
 
 <constraint-mapping xmlns="http://symfony.com/schema/dic/constraint-mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/constraint-mapping http://symfony.com/schema/dic/services/constraint-mapping-1.0.xsd">
-    <class name="Sylius\ShopApiPlugin\Request\PutSimpleItemToCartRequest">
+    <class name="Sylius\SyliusShopApiPlugin\Request\PutSimpleItemToCartRequest">
         <property name="token">
             <constraint name="NotNull">
                 <option name="message">sylius.shop_api.token.not_null</option>
             </constraint>
-            <constraint name="Sylius\ShopApiPlugin\Validator\Constraints\CartExists" />
+            <constraint name="Sylius\SyliusShopApiPlugin\Validator\Constraints\CartExists" />
         </property>
         <property name="quantity">
             <constraint name="Type">
@@ -38,8 +38,8 @@
             <constraint name="NotNull">
                 <option name="message">sylius.shop_api.product.not_null</option>
             </constraint>
-            <constraint name="Sylius\ShopApiPlugin\Validator\Constraints\ProductExists" />
-            <constraint name="Sylius\ShopApiPlugin\Validator\Constraints\SimpleProduct" />
+            <constraint name="Sylius\SyliusShopApiPlugin\Validator\Constraints\ProductExists" />
+            <constraint name="Sylius\SyliusShopApiPlugin\Validator\Constraints\SimpleProduct" />
         </property>
     </class>
 </constraint-mapping>

--- a/src/Resources/config/validation/PutVariantBasedConfigutableItemToCartRequest.xml
+++ b/src/Resources/config/validation/PutVariantBasedConfigutableItemToCartRequest.xml
@@ -12,12 +12,12 @@
 -->
 
 <constraint-mapping xmlns="http://symfony.com/schema/dic/constraint-mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/constraint-mapping http://symfony.com/schema/dic/services/constraint-mapping-1.0.xsd">
-    <class name="Sylius\ShopApiPlugin\Request\PutVariantBasedConfigurableItemToCartRequest">
+    <class name="Sylius\SyliusShopApiPlugin\Request\PutVariantBasedConfigurableItemToCartRequest">
         <property name="token">
             <constraint name="NotNull">
                 <option name="message">sylius.shop_api.token.not_null</option>
             </constraint>
-            <constraint name="Sylius\ShopApiPlugin\Validator\Constraints\CartExists" />
+            <constraint name="Sylius\SyliusShopApiPlugin\Validator\Constraints\CartExists" />
         </property>
         <property name="quantity">
             <constraint name="Type">
@@ -38,14 +38,14 @@
             <constraint name="NotNull">
                 <option name="message">sylius.shop_api.product.not_null</option>
             </constraint>
-            <constraint name="Sylius\ShopApiPlugin\Validator\Constraints\ProductExists" />
-            <constraint name="Sylius\ShopApiPlugin\Validator\Constraints\ConfigurableProduct" />
+            <constraint name="Sylius\SyliusShopApiPlugin\Validator\Constraints\ProductExists" />
+            <constraint name="Sylius\SyliusShopApiPlugin\Validator\Constraints\ConfigurableProduct" />
         </property>
         <property name="variantCode">
             <constraint name="NotNull">
                 <option name="message">sylius.shop_api.product.not_null</option>
             </constraint>
-            <constraint name="Sylius\ShopApiPlugin\Validator\Constraints\ProductVariantExists" />
+            <constraint name="Sylius\SyliusShopApiPlugin\Validator\Constraints\ProductVariantExists" />
         </property>
     </class>
 </constraint-mapping>

--- a/src/Resources/config/validation/RegisterCustomerRequest.xml
+++ b/src/Resources/config/validation/RegisterCustomerRequest.xml
@@ -12,7 +12,7 @@
 -->
 
 <constraint-mapping xmlns="http://symfony.com/schema/dic/constraint-mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/constraint-mapping http://symfony.com/schema/dic/services/constraint-mapping-1.0.xsd">
-    <class name="Sylius\ShopApiPlugin\Request\RegisterCustomerRequest">
+    <class name="Sylius\SyliusShopApiPlugin\Request\RegisterCustomerRequest">
         <property name="email">
             <constraint name="NotBlank">
                 <option name="message">sylius.shop_api.email.not_blank</option>
@@ -20,7 +20,7 @@
             <constraint name="Email">
                 <option name="message">sylius.shop_api.email.invalid</option>
             </constraint>
-            <constraint name="Sylius\ShopApiPlugin\Validator\Constraints\ShopUserDoesNotExist" />
+            <constraint name="Sylius\SyliusShopApiPlugin\Validator\Constraints\ShopUserDoesNotExist" />
         </property>
         <property name="plainPassword">
             <constraint name="NotBlank">
@@ -41,7 +41,7 @@
             <constraint name="NotNull">
                 <option name="message">sylius.shop_api.channel.not_null</option>
             </constraint>
-            <constraint name="Sylius\ShopApiPlugin\Validator\Constraints\ChannelExists" />
+            <constraint name="Sylius\SyliusShopApiPlugin\Validator\Constraints\ChannelExists" />
         </property>
     </class>
 </constraint-mapping>

--- a/src/Resources/config/validation/RemoveCouponRequest.xml
+++ b/src/Resources/config/validation/RemoveCouponRequest.xml
@@ -12,12 +12,12 @@
 -->
 
 <constraint-mapping xmlns="http://symfony.com/schema/dic/constraint-mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/constraint-mapping http://symfony.com/schema/dic/services/constraint-mapping-1.0.xsd">
-    <class name="Sylius\ShopApiPlugin\Request\RemoveCouponRequest">
+    <class name="Sylius\SyliusShopApiPlugin\Request\RemoveCouponRequest">
         <property name="token">
             <constraint name="NotNull">
                 <option name="message">sylius.shop_api.token.not_null</option>
             </constraint>
-            <constraint name="Sylius\ShopApiPlugin\Validator\Constraints\CartExists" />
+            <constraint name="Sylius\SyliusShopApiPlugin\Validator\Constraints\CartExists" />
         </property>
     </class>
 </constraint-mapping>

--- a/src/Resources/config/validation/RemoveItemFromCartRequest.xml
+++ b/src/Resources/config/validation/RemoveItemFromCartRequest.xml
@@ -12,18 +12,18 @@
 -->
 
 <constraint-mapping xmlns="http://symfony.com/schema/dic/constraint-mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/constraint-mapping http://symfony.com/schema/dic/services/constraint-mapping-1.0.xsd">
-    <class name="Sylius\ShopApiPlugin\Request\RemoveItemFromCartRequest">
+    <class name="Sylius\SyliusShopApiPlugin\Request\RemoveItemFromCartRequest">
         <property name="token">
             <constraint name="NotNull">
                 <option name="message">sylius.shop_api.token.not_null</option>
             </constraint>
-            <constraint name="Sylius\ShopApiPlugin\Validator\Constraints\CartExists" />
+            <constraint name="Sylius\SyliusShopApiPlugin\Validator\Constraints\CartExists" />
         </property>
         <property name="id">
             <constraint name="NotNull">
                 <option name="message">sylius.shop_api.cart_item.not_null</option>
             </constraint>
-            <constraint name="Sylius\ShopApiPlugin\Validator\Constraints\CartItemExists" />
+            <constraint name="Sylius\SyliusShopApiPlugin\Validator\Constraints\CartItemExists" />
         </property>
     </class>
 </constraint-mapping>

--- a/src/Resources/config/validation/ResendVerificationTokenRequest.xml
+++ b/src/Resources/config/validation/ResendVerificationTokenRequest.xml
@@ -12,7 +12,7 @@
 -->
 
 <constraint-mapping xmlns="http://symfony.com/schema/dic/constraint-mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/constraint-mapping http://symfony.com/schema/dic/services/constraint-mapping-1.0.xsd">
-    <class name="Sylius\ShopApiPlugin\Request\ResendVerificationTokenRequest">
+    <class name="Sylius\SyliusShopApiPlugin\Request\ResendVerificationTokenRequest">
         <property name="email">
             <constraint name="NotNull">
                 <option name="message">sylius.shop_api.email.not_null</option>
@@ -20,7 +20,7 @@
             <constraint name="Email">
                 <option name="message">sylius.shop_api.email.not_valid</option>
             </constraint>
-            <constraint name="Sylius\ShopApiPlugin\Validator\Constraints\ShopUserExists" />
+            <constraint name="Sylius\SyliusShopApiPlugin\Validator\Constraints\ShopUserExists" />
         </property>
     </class>
 </constraint-mapping>

--- a/src/SyliusShopApiPlugin.php
+++ b/src/SyliusShopApiPlugin.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin;
+namespace Sylius\SyliusShopApiPlugin;
 
 use Sylius\Bundle\CoreBundle\Application\SyliusPluginTrait;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
-final class ShopApiPlugin extends Bundle
+final class SyliusShopApiPlugin extends Bundle
 {
     use SyliusPluginTrait;
 }

--- a/src/Validator/CartExistsValidator.php
+++ b/src/Validator/CartExistsValidator.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Validator;
+namespace Sylius\SyliusShopApiPlugin\Validator;
 
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Repository\OrderRepositoryInterface;

--- a/src/Validator/CartItemExistsValidator.php
+++ b/src/Validator/CartItemExistsValidator.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Validator;
+namespace Sylius\SyliusShopApiPlugin\Validator;
 
 use Sylius\Component\Order\Repository\OrderItemRepositoryInterface;
 use Symfony\Component\Validator\Constraint;

--- a/src/Validator/ChannelExistsValidator.php
+++ b/src/Validator/ChannelExistsValidator.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Validator;
+namespace Sylius\SyliusShopApiPlugin\Validator;
 
 use Sylius\Component\Channel\Repository\ChannelRepositoryInterface;
 use Symfony\Component\Validator\Constraint;

--- a/src/Validator/ConfigurableProductValidator.php
+++ b/src/Validator/ConfigurableProductValidator.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Validator;
+namespace Sylius\SyliusShopApiPlugin\Validator;
 
 use Sylius\Component\Core\Repository\ProductRepositoryInterface;
 use Symfony\Component\Validator\Constraint;

--- a/src/Validator/Constraints/CartExists.php
+++ b/src/Validator/Constraints/CartExists.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Validator\Constraints;
+namespace Sylius\SyliusShopApiPlugin\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 

--- a/src/Validator/Constraints/CartItemExists.php
+++ b/src/Validator/Constraints/CartItemExists.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Validator\Constraints;
+namespace Sylius\SyliusShopApiPlugin\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 

--- a/src/Validator/Constraints/ChannelExists.php
+++ b/src/Validator/Constraints/ChannelExists.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Validator\Constraints;
+namespace Sylius\SyliusShopApiPlugin\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 

--- a/src/Validator/Constraints/ConfigurableProduct.php
+++ b/src/Validator/Constraints/ConfigurableProduct.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Validator\Constraints;
+namespace Sylius\SyliusShopApiPlugin\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 

--- a/src/Validator/Constraints/ProductExists.php
+++ b/src/Validator/Constraints/ProductExists.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Validator\Constraints;
+namespace Sylius\SyliusShopApiPlugin\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 

--- a/src/Validator/Constraints/ProductVariantExists.php
+++ b/src/Validator/Constraints/ProductVariantExists.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Validator\Constraints;
+namespace Sylius\SyliusShopApiPlugin\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 

--- a/src/Validator/Constraints/ShopUserDoesNotExist.php
+++ b/src/Validator/Constraints/ShopUserDoesNotExist.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Validator\Constraints;
+namespace Sylius\SyliusShopApiPlugin\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 

--- a/src/Validator/Constraints/ShopUserExists.php
+++ b/src/Validator/Constraints/ShopUserExists.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Validator\Constraints;
+namespace Sylius\SyliusShopApiPlugin\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 

--- a/src/Validator/Constraints/SimpleProduct.php
+++ b/src/Validator/Constraints/SimpleProduct.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Validator\Constraints;
+namespace Sylius\SyliusShopApiPlugin\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 

--- a/src/Validator/Constraints/TokenIsNotUsed.php
+++ b/src/Validator/Constraints/TokenIsNotUsed.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Validator\Constraints;
+namespace Sylius\SyliusShopApiPlugin\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 

--- a/src/Validator/Constraints/ValidPromotionCouponCode.php
+++ b/src/Validator/Constraints/ValidPromotionCouponCode.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Validator\Constraints;
+namespace Sylius\SyliusShopApiPlugin\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 

--- a/src/Validator/ProductExistsValidator.php
+++ b/src/Validator/ProductExistsValidator.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Validator;
+namespace Sylius\SyliusShopApiPlugin\Validator;
 
 use Sylius\Component\Core\Repository\ProductRepositoryInterface;
 use Symfony\Component\Validator\Constraint;

--- a/src/Validator/ProductVariantExistsValidator.php
+++ b/src/Validator/ProductVariantExistsValidator.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Validator;
+namespace Sylius\SyliusShopApiPlugin\Validator;
 
 use Sylius\Component\Core\Repository\ProductVariantRepositoryInterface;
 use Symfony\Component\Validator\Constraint;

--- a/src/Validator/ShopUserDoesNotExistValidator.php
+++ b/src/Validator/ShopUserDoesNotExistValidator.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Validator;
+namespace Sylius\SyliusShopApiPlugin\Validator;
 
 use Sylius\Component\User\Repository\UserRepositoryInterface;
 use Symfony\Component\Validator\Constraint;

--- a/src/Validator/ShopUserExistsValidator.php
+++ b/src/Validator/ShopUserExistsValidator.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Validator;
+namespace Sylius\SyliusShopApiPlugin\Validator;
 
 use Sylius\Component\User\Repository\UserRepositoryInterface;
 use Symfony\Component\Validator\Constraint;

--- a/src/Validator/SimpleProductValidator.php
+++ b/src/Validator/SimpleProductValidator.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Validator;
+namespace Sylius\SyliusShopApiPlugin\Validator;
 
 use Sylius\Component\Core\Repository\ProductRepositoryInterface;
 use Symfony\Component\Validator\Constraint;

--- a/src/Validator/TokenIsNotUsedValidator.php
+++ b/src/Validator/TokenIsNotUsedValidator.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Validator;
+namespace Sylius\SyliusShopApiPlugin\Validator;
 
 use Sylius\Component\Core\Repository\OrderRepositoryInterface;
 use Symfony\Component\Validator\Constraint;

--- a/src/Validator/ValidPromotionCouponCodeValidator.php
+++ b/src/Validator/ValidPromotionCouponCodeValidator.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\Validator;
+namespace Sylius\SyliusShopApiPlugin\Validator;
 
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\PromotionCouponInterface;
 use Sylius\Component\Core\Repository\OrderRepositoryInterface;
 use Sylius\Component\Promotion\Checker\Eligibility\PromotionCouponEligibilityCheckerInterface;
 use Sylius\Component\Promotion\Repository\PromotionCouponRepositoryInterface;
-use Sylius\ShopApiPlugin\Request\AddCouponRequest;
+use Sylius\SyliusShopApiPlugin\Request\AddCouponRequest;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 use Webmozart\Assert\Assert;

--- a/src/View/AddressView.php
+++ b/src/View/AddressView.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\View;
+namespace Sylius\SyliusShopApiPlugin\View;
 
 class AddressView
 {

--- a/src/View/AdjustmentView.php
+++ b/src/View/AdjustmentView.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\View;
+namespace Sylius\SyliusShopApiPlugin\View;
 
 class AdjustmentView
 {

--- a/src/View/CartSummaryView.php
+++ b/src/View/CartSummaryView.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\View;
+namespace Sylius\SyliusShopApiPlugin\View;
 
 class CartSummaryView
 {

--- a/src/View/CustomerView.php
+++ b/src/View/CustomerView.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\View;
+namespace Sylius\SyliusShopApiPlugin\View;
 
 class CustomerView
 {

--- a/src/View/EstimatedShippingCostView.php
+++ b/src/View/EstimatedShippingCostView.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\View;
+namespace Sylius\SyliusShopApiPlugin\View;
 
 class EstimatedShippingCostView
 {

--- a/src/View/ImageView.php
+++ b/src/View/ImageView.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\View;
+namespace Sylius\SyliusShopApiPlugin\View;
 
 class ImageView
 {

--- a/src/View/ItemView.php
+++ b/src/View/ItemView.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\View;
+namespace Sylius\SyliusShopApiPlugin\View;
 
 class ItemView
 {

--- a/src/View/PageLinksView.php
+++ b/src/View/PageLinksView.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\View;
+namespace Sylius\SyliusShopApiPlugin\View;
 
 class PageLinksView
 {

--- a/src/View/PageView.php
+++ b/src/View/PageView.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\View;
+namespace Sylius\SyliusShopApiPlugin\View;
 
 class PageView
 {

--- a/src/View/PaymentMethodView.php
+++ b/src/View/PaymentMethodView.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\View;
+namespace Sylius\SyliusShopApiPlugin\View;
 
 class PaymentMethodView
 {

--- a/src/View/PaymentView.php
+++ b/src/View/PaymentView.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\View;
+namespace Sylius\SyliusShopApiPlugin\View;
 
 class PaymentView
 {

--- a/src/View/PriceView.php
+++ b/src/View/PriceView.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\View;
+namespace Sylius\SyliusShopApiPlugin\View;
 
 class PriceView
 {

--- a/src/View/ProductAttributeValueView.php
+++ b/src/View/ProductAttributeValueView.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\View;
+namespace Sylius\SyliusShopApiPlugin\View;
 
 class ProductAttributeValueView
 {

--- a/src/View/ProductListView.php
+++ b/src/View/ProductListView.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\View;
+namespace Sylius\SyliusShopApiPlugin\View;
 
 class ProductListView
 {

--- a/src/View/ProductReviewView.php
+++ b/src/View/ProductReviewView.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\View;
+namespace Sylius\SyliusShopApiPlugin\View;
 
 class ProductReviewView
 {

--- a/src/View/ProductTaxonView.php
+++ b/src/View/ProductTaxonView.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\View;
+namespace Sylius\SyliusShopApiPlugin\View;
 
 class ProductTaxonView
 {

--- a/src/View/ProductVariantView.php
+++ b/src/View/ProductVariantView.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\View;
+namespace Sylius\SyliusShopApiPlugin\View;
 
 class ProductVariantView
 {

--- a/src/View/ProductView.php
+++ b/src/View/ProductView.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\View;
+namespace Sylius\SyliusShopApiPlugin\View;
 
 class ProductView
 {

--- a/src/View/ShipmentView.php
+++ b/src/View/ShipmentView.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\View;
+namespace Sylius\SyliusShopApiPlugin\View;
 
 class ShipmentView
 {

--- a/src/View/ShippingMethodView.php
+++ b/src/View/ShippingMethodView.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\View;
+namespace Sylius\SyliusShopApiPlugin\View;
 
 class ShippingMethodView
 {

--- a/src/View/TaxonDetailsView.php
+++ b/src/View/TaxonDetailsView.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\View;
+namespace Sylius\SyliusShopApiPlugin\View;
 
 class TaxonDetailsView
 {

--- a/src/View/TaxonView.php
+++ b/src/View/TaxonView.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\View;
+namespace Sylius\SyliusShopApiPlugin\View;
 
 class TaxonView
 {

--- a/src/View/TotalsView.php
+++ b/src/View/TotalsView.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\View;
+namespace Sylius\SyliusShopApiPlugin\View;
 
 class TotalsView
 {

--- a/src/View/ValidationErrorView.php
+++ b/src/View/ValidationErrorView.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\View;
+namespace Sylius\SyliusShopApiPlugin\View;
 
 class ValidationErrorView
 {

--- a/src/View/VariantOptionValueView.php
+++ b/src/View/VariantOptionValueView.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\View;
+namespace Sylius\SyliusShopApiPlugin\View;
 
 class VariantOptionValueView
 {

--- a/src/View/VariantOptionView.php
+++ b/src/View/VariantOptionView.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\View;
+namespace Sylius\SyliusShopApiPlugin\View;
 
 class VariantOptionView
 {

--- a/src/ViewRepository/CartViewRepository.php
+++ b/src/ViewRepository/CartViewRepository.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\ViewRepository;
+namespace Sylius\SyliusShopApiPlugin\ViewRepository;
 
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Repository\OrderRepositoryInterface;
-use Sylius\ShopApiPlugin\Factory\CartViewFactoryInterface;
-use Sylius\ShopApiPlugin\View\CartSummaryView;
+use Sylius\SyliusShopApiPlugin\Factory\CartViewFactoryInterface;
+use Sylius\SyliusShopApiPlugin\View\CartSummaryView;
 use Webmozart\Assert\Assert;
 
 final class CartViewRepository implements CartViewRepositoryInterface

--- a/src/ViewRepository/CartViewRepositoryInterface.php
+++ b/src/ViewRepository/CartViewRepositoryInterface.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\ViewRepository;
+namespace Sylius\SyliusShopApiPlugin\ViewRepository;
 
-use Sylius\ShopApiPlugin\View\CartSummaryView;
+use Sylius\SyliusShopApiPlugin\View\CartSummaryView;
 
 interface CartViewRepositoryInterface
 {

--- a/src/ViewRepository/ProductCatalogViewRepository.php
+++ b/src/ViewRepository/ProductCatalogViewRepository.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\ViewRepository;
+namespace Sylius\SyliusShopApiPlugin\ViewRepository;
 
 use Pagerfanta\Adapter\DoctrineORMAdapter;
 use Pagerfanta\Pagerfanta;
@@ -12,10 +12,10 @@ use Sylius\Component\Core\Model\TaxonInterface;
 use Sylius\Component\Core\Repository\ProductRepositoryInterface;
 use Sylius\Component\Locale\Model\LocaleInterface;
 use Sylius\Component\Taxonomy\Repository\TaxonRepositoryInterface;
-use Sylius\ShopApiPlugin\Factory\PageViewFactoryInterface;
-use Sylius\ShopApiPlugin\Factory\ProductViewFactoryInterface;
-use Sylius\ShopApiPlugin\Model\PaginatorDetails;
-use Sylius\ShopApiPlugin\View\PageView;
+use Sylius\SyliusShopApiPlugin\Factory\PageViewFactoryInterface;
+use Sylius\SyliusShopApiPlugin\Factory\ProductViewFactoryInterface;
+use Sylius\SyliusShopApiPlugin\Model\PaginatorDetails;
+use Sylius\SyliusShopApiPlugin\View\PageView;
 use Webmozart\Assert\Assert;
 
 final class ProductCatalogViewRepository implements ProductCatalogViewRepositoryInterface

--- a/src/ViewRepository/ProductCatalogViewRepositoryInterface.php
+++ b/src/ViewRepository/ProductCatalogViewRepositoryInterface.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\ViewRepository;
+namespace Sylius\SyliusShopApiPlugin\ViewRepository;
 
-use Sylius\ShopApiPlugin\Model\PaginatorDetails;
-use Sylius\ShopApiPlugin\View\PageView;
+use Sylius\SyliusShopApiPlugin\Model\PaginatorDetails;
+use Sylius\SyliusShopApiPlugin\View\PageView;
 
 interface ProductCatalogViewRepositoryInterface
 {

--- a/src/ViewRepository/ProductDetailsViewRepository.php
+++ b/src/ViewRepository/ProductDetailsViewRepository.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\ViewRepository;
+namespace Sylius\SyliusShopApiPlugin\ViewRepository;
 
 use Sylius\Component\Channel\Repository\ChannelRepositoryInterface;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Repository\ProductRepositoryInterface;
 use Sylius\Component\Locale\Model\LocaleInterface;
-use Sylius\ShopApiPlugin\Factory\ProductViewFactoryInterface;
-use Sylius\ShopApiPlugin\View\ProductView;
+use Sylius\SyliusShopApiPlugin\Factory\ProductViewFactoryInterface;
+use Sylius\SyliusShopApiPlugin\View\ProductView;
 use Webmozart\Assert\Assert;
 
 final class ProductDetailsViewRepository implements ProductDetailsViewRepositoryInterface

--- a/src/ViewRepository/ProductDetailsViewRepositoryInterface.php
+++ b/src/ViewRepository/ProductDetailsViewRepositoryInterface.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\ViewRepository;
+namespace Sylius\SyliusShopApiPlugin\ViewRepository;
 
-use Sylius\ShopApiPlugin\View\ProductView;
+use Sylius\SyliusShopApiPlugin\View\ProductView;
 
 interface ProductDetailsViewRepositoryInterface
 {

--- a/src/ViewRepository/ProductLatestViewRepository.php
+++ b/src/ViewRepository/ProductLatestViewRepository.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\ViewRepository;
+namespace Sylius\SyliusShopApiPlugin\ViewRepository;
 
 use Sylius\Component\Channel\Repository\ChannelRepositoryInterface;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Repository\ProductRepositoryInterface;
 use Sylius\Component\Locale\Model\LocaleInterface;
-use Sylius\ShopApiPlugin\Factory\ProductViewFactoryInterface;
-use Sylius\ShopApiPlugin\View\ProductListView;
+use Sylius\SyliusShopApiPlugin\Factory\ProductViewFactoryInterface;
+use Sylius\SyliusShopApiPlugin\View\ProductListView;
 use Webmozart\Assert\Assert;
 
 final class ProductLatestViewRepository implements ProductLatestViewRepositoryInterface

--- a/src/ViewRepository/ProductLatestViewRepositoryInterface.php
+++ b/src/ViewRepository/ProductLatestViewRepositoryInterface.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\ViewRepository;
+namespace Sylius\SyliusShopApiPlugin\ViewRepository;
 
-use Sylius\ShopApiPlugin\View\ProductListView;
+use Sylius\SyliusShopApiPlugin\View\ProductListView;
 
 interface ProductLatestViewRepositoryInterface
 {

--- a/src/ViewRepository/ProductReviewsViewRepository.php
+++ b/src/ViewRepository/ProductReviewsViewRepository.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\ViewRepository;
+namespace Sylius\SyliusShopApiPlugin\ViewRepository;
 
 use Pagerfanta\Adapter\ArrayAdapter;
 use Pagerfanta\Pagerfanta;
@@ -12,10 +12,10 @@ use Sylius\Component\Core\Repository\ProductRepositoryInterface;
 use Sylius\Component\Core\Repository\ProductReviewRepositoryInterface;
 use Sylius\Component\Locale\Model\LocaleInterface;
 use Sylius\Component\Review\Model\ReviewInterface;
-use Sylius\ShopApiPlugin\Factory\PageViewFactoryInterface;
-use Sylius\ShopApiPlugin\Factory\ProductReviewViewFactoryInterface;
-use Sylius\ShopApiPlugin\Model\PaginatorDetails;
-use Sylius\ShopApiPlugin\View\PageView;
+use Sylius\SyliusShopApiPlugin\Factory\PageViewFactoryInterface;
+use Sylius\SyliusShopApiPlugin\Factory\ProductReviewViewFactoryInterface;
+use Sylius\SyliusShopApiPlugin\Model\PaginatorDetails;
+use Sylius\SyliusShopApiPlugin\View\PageView;
 use Webmozart\Assert\Assert;
 
 final class ProductReviewsViewRepository implements ProductReviewsViewRepositoryInterface

--- a/src/ViewRepository/ProductReviewsViewRepositoryInterface.php
+++ b/src/ViewRepository/ProductReviewsViewRepositoryInterface.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Sylius\ShopApiPlugin\ViewRepository;
+namespace Sylius\SyliusShopApiPlugin\ViewRepository;
 
-use Sylius\ShopApiPlugin\Model\PaginatorDetails;
-use Sylius\ShopApiPlugin\View\PageView;
+use Sylius\SyliusShopApiPlugin\Model\PaginatorDetails;
+use Sylius\SyliusShopApiPlugin\View\PageView;
 
 interface ProductReviewsViewRepositoryInterface
 {

--- a/tests/Application/app/AppKernel.php
+++ b/tests/Application/app/AppKernel.php
@@ -20,7 +20,7 @@ final class AppKernel extends Kernel
 
             new \League\Tactician\Bundle\TacticianBundle(),
 
-            new \Sylius\ShopApiPlugin\ShopApiPlugin(),
+            new \Sylius\SyliusShopApiPlugin\SyliusShopApiPlugin(),
             new \Lexik\Bundle\JWTAuthenticationBundle\LexikJWTAuthenticationBundle(),
         ]);
     }

--- a/tests/Controller/CartAddCouponShopApiTest.php
+++ b/tests/Controller/CartAddCouponShopApiTest.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace Tests\Sylius\ShopApiPlugin\Controller;
+namespace Tests\Sylius\SyliusShopApiPlugin\Controller;
 
 use Lakion\ApiTestCase\JsonApiTestCase;
 use League\Tactician\CommandBus;
-use Sylius\ShopApiPlugin\Command\PickupCart;
-use Sylius\ShopApiPlugin\Command\PutSimpleItemToCart;
+use Sylius\SyliusShopApiPlugin\Command\PickupCart;
+use Sylius\SyliusShopApiPlugin\Command\PutSimpleItemToCart;
 use Symfony\Component\HttpFoundation\Response;
 
 final class CartAddCouponShopApiTest extends JsonApiTestCase

--- a/tests/Controller/CartApiTest.php
+++ b/tests/Controller/CartApiTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\Sylius\ShopApiPlugin\Controller;
+namespace Tests\Sylius\SyliusShopApiPlugin\Controller;
 
 use Lakion\ApiTestCase\JsonApiTestCase;
 use Symfony\Component\HttpFoundation\Response;

--- a/tests/Controller/CartChangeItemQuantityApiTest.php
+++ b/tests/Controller/CartChangeItemQuantityApiTest.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace Tests\Sylius\ShopApiPlugin\Controller;
+namespace Tests\Sylius\SyliusShopApiPlugin\Controller;
 
 use Lakion\ApiTestCase\JsonApiTestCase;
 use League\Tactician\CommandBus;
-use Sylius\ShopApiPlugin\Command\PickupCart;
-use Sylius\ShopApiPlugin\Command\PutSimpleItemToCart;
+use Sylius\SyliusShopApiPlugin\Command\PickupCart;
+use Sylius\SyliusShopApiPlugin\Command\PutSimpleItemToCart;
 use Symfony\Component\HttpFoundation\Response;
 
 final class CartChangeItemQuantityApiTest extends JsonApiTestCase

--- a/tests/Controller/CartDropCartApiTest.php
+++ b/tests/Controller/CartDropCartApiTest.php
@@ -2,18 +2,18 @@
 
 declare(strict_types=1);
 
-namespace Tests\Sylius\ShopApiPlugin\Controller;
+namespace Tests\Sylius\SyliusShopApiPlugin\Controller;
 
 use Lakion\ApiTestCase\JsonApiTestCase;
 use League\Tactician\CommandBus;
 use Sylius\Component\Core\Model\OrderInterface;
-use Sylius\ShopApiPlugin\Command\AddressOrder;
-use Sylius\ShopApiPlugin\Command\ChoosePaymentMethod;
-use Sylius\ShopApiPlugin\Command\ChooseShippingMethod;
-use Sylius\ShopApiPlugin\Command\CompleteOrder;
-use Sylius\ShopApiPlugin\Command\PickupCart;
-use Sylius\ShopApiPlugin\Command\PutSimpleItemToCart;
-use Sylius\ShopApiPlugin\Model\Address;
+use Sylius\SyliusShopApiPlugin\Command\AddressOrder;
+use Sylius\SyliusShopApiPlugin\Command\ChoosePaymentMethod;
+use Sylius\SyliusShopApiPlugin\Command\ChooseShippingMethod;
+use Sylius\SyliusShopApiPlugin\Command\CompleteOrder;
+use Sylius\SyliusShopApiPlugin\Command\PickupCart;
+use Sylius\SyliusShopApiPlugin\Command\PutSimpleItemToCart;
+use Sylius\SyliusShopApiPlugin\Model\Address;
 use Symfony\Component\HttpFoundation\Response;
 
 final class CartDropCartApiTest extends JsonApiTestCase

--- a/tests/Controller/CartPickupApiTest.php
+++ b/tests/Controller/CartPickupApiTest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Tests\Sylius\ShopApiPlugin\Controller;
+namespace Tests\Sylius\SyliusShopApiPlugin\Controller;
 
 use Lakion\ApiTestCase\JsonApiTestCase;
 use League\Tactician\CommandBus;
-use Sylius\ShopApiPlugin\Command\PickupCart;
+use Sylius\SyliusShopApiPlugin\Command\PickupCart;
 use Symfony\Component\HttpFoundation\Response;
 
 final class CartPickupApiTest extends JsonApiTestCase

--- a/tests/Controller/CartPutItemToCartApiTest.php
+++ b/tests/Controller/CartPutItemToCartApiTest.php
@@ -2,18 +2,18 @@
 
 declare(strict_types=1);
 
-namespace Tests\Sylius\ShopApiPlugin\Controller;
+namespace Tests\Sylius\SyliusShopApiPlugin\Controller;
 
 use Lakion\ApiTestCase\JsonApiTestCase;
 use League\Tactician\CommandBus;
 use Sylius\Component\Core\Model\OrderInterface;
-use Sylius\ShopApiPlugin\Command\AddressOrder;
-use Sylius\ShopApiPlugin\Command\ChoosePaymentMethod;
-use Sylius\ShopApiPlugin\Command\ChooseShippingMethod;
-use Sylius\ShopApiPlugin\Command\CompleteOrder;
-use Sylius\ShopApiPlugin\Command\PickupCart;
-use Sylius\ShopApiPlugin\Command\PutSimpleItemToCart;
-use Sylius\ShopApiPlugin\Model\Address;
+use Sylius\SyliusShopApiPlugin\Command\AddressOrder;
+use Sylius\SyliusShopApiPlugin\Command\ChoosePaymentMethod;
+use Sylius\SyliusShopApiPlugin\Command\ChooseShippingMethod;
+use Sylius\SyliusShopApiPlugin\Command\CompleteOrder;
+use Sylius\SyliusShopApiPlugin\Command\PickupCart;
+use Sylius\SyliusShopApiPlugin\Command\PutSimpleItemToCart;
+use Sylius\SyliusShopApiPlugin\Model\Address;
 use Symfony\Component\HttpFoundation\Response;
 
 final class CartPutItemToCartApiTest extends JsonApiTestCase

--- a/tests/Controller/CartPutItemsToCartApiTest.php
+++ b/tests/Controller/CartPutItemsToCartApiTest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Tests\Sylius\ShopApiPlugin\Controller;
+namespace Tests\Sylius\SyliusShopApiPlugin\Controller;
 
 use Lakion\ApiTestCase\JsonApiTestCase;
 use League\Tactician\CommandBus;
-use Sylius\ShopApiPlugin\Command\PickupCart;
+use Sylius\SyliusShopApiPlugin\Command\PickupCart;
 use Symfony\Component\HttpFoundation\Response;
 
 final class CartPutItemsToCartApiTest extends JsonApiTestCase

--- a/tests/Controller/CartRemoveCouponShopApiTest.php
+++ b/tests/Controller/CartRemoveCouponShopApiTest.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace Tests\Sylius\ShopApiPlugin\Controller;
+namespace Tests\Sylius\SyliusShopApiPlugin\Controller;
 
 use Lakion\ApiTestCase\JsonApiTestCase;
 use League\Tactician\CommandBus;
-use Sylius\ShopApiPlugin\Command\AddCoupon;
-use Sylius\ShopApiPlugin\Command\PickupCart;
-use Sylius\ShopApiPlugin\Command\PutSimpleItemToCart;
+use Sylius\SyliusShopApiPlugin\Command\AddCoupon;
+use Sylius\SyliusShopApiPlugin\Command\PickupCart;
+use Sylius\SyliusShopApiPlugin\Command\PutSimpleItemToCart;
 use Symfony\Component\HttpFoundation\Response;
 
 final class CartRemoveCouponShopApiTest extends JsonApiTestCase

--- a/tests/Controller/CartRemoveItemFromCartApiTest.php
+++ b/tests/Controller/CartRemoveItemFromCartApiTest.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace Tests\Sylius\ShopApiPlugin\Controller;
+namespace Tests\Sylius\SyliusShopApiPlugin\Controller;
 
 use Lakion\ApiTestCase\JsonApiTestCase;
 use League\Tactician\CommandBus;
-use Sylius\ShopApiPlugin\Command\PickupCart;
-use Sylius\ShopApiPlugin\Command\PutSimpleItemToCart;
-use Sylius\ShopApiPlugin\Command\PutVariantBasedConfigurableItemToCart;
+use Sylius\SyliusShopApiPlugin\Command\PickupCart;
+use Sylius\SyliusShopApiPlugin\Command\PutSimpleItemToCart;
+use Sylius\SyliusShopApiPlugin\Command\PutVariantBasedConfigurableItemToCart;
 use Symfony\Component\HttpFoundation\Response;
 
 final class CartRemoveItemFromCartApiTest extends JsonApiTestCase

--- a/tests/Controller/CartSummarizeApiTest.php
+++ b/tests/Controller/CartSummarizeApiTest.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace Tests\Sylius\ShopApiPlugin\Controller;
+namespace Tests\Sylius\SyliusShopApiPlugin\Controller;
 
 use Lakion\ApiTestCase\JsonApiTestCase;
 use League\Tactician\CommandBus;
-use Sylius\ShopApiPlugin\Command\AddCoupon;
-use Sylius\ShopApiPlugin\Command\PickupCart;
-use Sylius\ShopApiPlugin\Command\PutSimpleItemToCart;
+use Sylius\SyliusShopApiPlugin\Command\AddCoupon;
+use Sylius\SyliusShopApiPlugin\Command\PickupCart;
+use Sylius\SyliusShopApiPlugin\Command\PutSimpleItemToCart;
 use Symfony\Component\HttpFoundation\Response;
 
 final class CartSummarizeApiTest extends JsonApiTestCase

--- a/tests/Controller/CheckoutAddressApiTest.php
+++ b/tests/Controller/CheckoutAddressApiTest.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace Tests\Sylius\ShopApiPlugin\Controller;
+namespace Tests\Sylius\SyliusShopApiPlugin\Controller;
 
 use Lakion\ApiTestCase\JsonApiTestCase;
 use League\Tactician\CommandBus;
-use Sylius\ShopApiPlugin\Command\PickupCart;
-use Sylius\ShopApiPlugin\Command\PutSimpleItemToCart;
+use Sylius\SyliusShopApiPlugin\Command\PickupCart;
+use Sylius\SyliusShopApiPlugin\Command\PutSimpleItemToCart;
 use Symfony\Component\HttpFoundation\Response;
 
 final class CheckoutAddressApiTest extends JsonApiTestCase

--- a/tests/Controller/CheckoutChoosePaymentMethodApiTest.php
+++ b/tests/Controller/CheckoutChoosePaymentMethodApiTest.php
@@ -2,15 +2,15 @@
 
 declare(strict_types=1);
 
-namespace Tests\Sylius\ShopApiPlugin\Controller;
+namespace Tests\Sylius\SyliusShopApiPlugin\Controller;
 
 use Lakion\ApiTestCase\JsonApiTestCase;
 use League\Tactician\CommandBus;
-use Sylius\ShopApiPlugin\Command\AddressOrder;
-use Sylius\ShopApiPlugin\Command\ChooseShippingMethod;
-use Sylius\ShopApiPlugin\Command\PickupCart;
-use Sylius\ShopApiPlugin\Command\PutSimpleItemToCart;
-use Sylius\ShopApiPlugin\Model\Address;
+use Sylius\SyliusShopApiPlugin\Command\AddressOrder;
+use Sylius\SyliusShopApiPlugin\Command\ChooseShippingMethod;
+use Sylius\SyliusShopApiPlugin\Command\PickupCart;
+use Sylius\SyliusShopApiPlugin\Command\PutSimpleItemToCart;
+use Sylius\SyliusShopApiPlugin\Model\Address;
 use Symfony\Component\HttpFoundation\Response;
 
 final class CheckoutChoosePaymentMethodApiTest extends JsonApiTestCase

--- a/tests/Controller/CheckoutChooseShippingMethodApiTest.php
+++ b/tests/Controller/CheckoutChooseShippingMethodApiTest.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace Tests\Sylius\ShopApiPlugin\Controller;
+namespace Tests\Sylius\SyliusShopApiPlugin\Controller;
 
 use Lakion\ApiTestCase\JsonApiTestCase;
 use League\Tactician\CommandBus;
-use Sylius\ShopApiPlugin\Command\AddressOrder;
-use Sylius\ShopApiPlugin\Command\PickupCart;
-use Sylius\ShopApiPlugin\Command\PutSimpleItemToCart;
-use Sylius\ShopApiPlugin\Model\Address;
+use Sylius\SyliusShopApiPlugin\Command\AddressOrder;
+use Sylius\SyliusShopApiPlugin\Command\PickupCart;
+use Sylius\SyliusShopApiPlugin\Command\PutSimpleItemToCart;
+use Sylius\SyliusShopApiPlugin\Model\Address;
 use Symfony\Component\HttpFoundation\Response;
 
 final class CheckoutChooseShippingMethodApiTest extends JsonApiTestCase

--- a/tests/Controller/CheckoutCompleteOrderApiTest.php
+++ b/tests/Controller/CheckoutCompleteOrderApiTest.php
@@ -2,16 +2,16 @@
 
 declare(strict_types=1);
 
-namespace Tests\Sylius\ShopApiPlugin\Controller;
+namespace Tests\Sylius\SyliusShopApiPlugin\Controller;
 
 use Lakion\ApiTestCase\JsonApiTestCase;
 use League\Tactician\CommandBus;
-use Sylius\ShopApiPlugin\Command\AddressOrder;
-use Sylius\ShopApiPlugin\Command\ChoosePaymentMethod;
-use Sylius\ShopApiPlugin\Command\ChooseShippingMethod;
-use Sylius\ShopApiPlugin\Command\PickupCart;
-use Sylius\ShopApiPlugin\Command\PutSimpleItemToCart;
-use Sylius\ShopApiPlugin\Model\Address;
+use Sylius\SyliusShopApiPlugin\Command\AddressOrder;
+use Sylius\SyliusShopApiPlugin\Command\ChoosePaymentMethod;
+use Sylius\SyliusShopApiPlugin\Command\ChooseShippingMethod;
+use Sylius\SyliusShopApiPlugin\Command\PickupCart;
+use Sylius\SyliusShopApiPlugin\Command\PutSimpleItemToCart;
+use Sylius\SyliusShopApiPlugin\Model\Address;
 use Symfony\Component\HttpFoundation\Response;
 
 final class CheckoutCompleteOrderApiTest extends JsonApiTestCase

--- a/tests/Controller/CheckoutShowAvailablePaymentMethodsShopApiTest.php
+++ b/tests/Controller/CheckoutShowAvailablePaymentMethodsShopApiTest.php
@@ -2,15 +2,15 @@
 
 declare(strict_types=1);
 
-namespace Tests\Sylius\ShopApiPlugin\Controller;
+namespace Tests\Sylius\SyliusShopApiPlugin\Controller;
 
 use Lakion\ApiTestCase\JsonApiTestCase;
 use League\Tactician\CommandBus;
-use Sylius\ShopApiPlugin\Command\AddressOrder;
-use Sylius\ShopApiPlugin\Command\ChooseShippingMethod;
-use Sylius\ShopApiPlugin\Command\PickupCart;
-use Sylius\ShopApiPlugin\Command\PutSimpleItemToCart;
-use Sylius\ShopApiPlugin\Model\Address;
+use Sylius\SyliusShopApiPlugin\Command\AddressOrder;
+use Sylius\SyliusShopApiPlugin\Command\ChooseShippingMethod;
+use Sylius\SyliusShopApiPlugin\Command\PickupCart;
+use Sylius\SyliusShopApiPlugin\Command\PutSimpleItemToCart;
+use Sylius\SyliusShopApiPlugin\Model\Address;
 use Symfony\Component\HttpFoundation\Response;
 
 final class CheckoutShowAvailablePaymentMethodsShopApiTest extends JsonApiTestCase

--- a/tests/Controller/CheckoutShowAvailableShippingMethodsShopApiTest.php
+++ b/tests/Controller/CheckoutShowAvailableShippingMethodsShopApiTest.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace Tests\Sylius\ShopApiPlugin\Controller;
+namespace Tests\Sylius\SyliusShopApiPlugin\Controller;
 
 use Lakion\ApiTestCase\JsonApiTestCase;
 use League\Tactician\CommandBus;
-use Sylius\ShopApiPlugin\Command\AddressOrder;
-use Sylius\ShopApiPlugin\Command\PickupCart;
-use Sylius\ShopApiPlugin\Command\PutSimpleItemToCart;
-use Sylius\ShopApiPlugin\Model\Address;
+use Sylius\SyliusShopApiPlugin\Command\AddressOrder;
+use Sylius\SyliusShopApiPlugin\Command\PickupCart;
+use Sylius\SyliusShopApiPlugin\Command\PutSimpleItemToCart;
+use Sylius\SyliusShopApiPlugin\Model\Address;
 use Symfony\Component\HttpFoundation\Response;
 
 final class CheckoutShowAvailableShippingMethodsShopApiTest extends JsonApiTestCase

--- a/tests/Controller/CheckoutSummarizeApiTest.php
+++ b/tests/Controller/CheckoutSummarizeApiTest.php
@@ -2,15 +2,15 @@
 
 declare(strict_types=1);
 
-namespace Tests\Sylius\ShopApiPlugin\Controller;
+namespace Tests\Sylius\SyliusShopApiPlugin\Controller;
 
 use Lakion\ApiTestCase\JsonApiTestCase;
 use League\Tactician\CommandBus;
-use Sylius\ShopApiPlugin\Command\AddressOrder;
-use Sylius\ShopApiPlugin\Command\ChooseShippingMethod;
-use Sylius\ShopApiPlugin\Command\PickupCart;
-use Sylius\ShopApiPlugin\Command\PutSimpleItemToCart;
-use Sylius\ShopApiPlugin\Model\Address;
+use Sylius\SyliusShopApiPlugin\Command\AddressOrder;
+use Sylius\SyliusShopApiPlugin\Command\ChooseShippingMethod;
+use Sylius\SyliusShopApiPlugin\Command\PickupCart;
+use Sylius\SyliusShopApiPlugin\Command\PutSimpleItemToCart;
+use Sylius\SyliusShopApiPlugin\Model\Address;
 use Symfony\Component\HttpFoundation\Response;
 
 final class CheckoutSummarizeApiTest extends JsonApiTestCase

--- a/tests/Controller/CustomerLoginApiTest.php
+++ b/tests/Controller/CustomerLoginApiTest.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace Tests\Sylius\ShopApiPlugin\Controller;
+namespace Tests\Sylius\SyliusShopApiPlugin\Controller;
 
 use Lakion\ApiTestCase\JsonApiTestCase;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Response;
-use Tests\Sylius\ShopApiPlugin\Controller\Utils\PurgeSpooledMessagesTrait;
+use Tests\Sylius\SyliusShopApiPlugin\Controller\Utils\PurgeSpooledMessagesTrait;
 
 /**
  * @author Łukasz Chruściel <lukasz.chrusciel@lakion.com>

--- a/tests/Controller/CustomerRegisterApiTest.php
+++ b/tests/Controller/CustomerRegisterApiTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\Sylius\ShopApiPlugin\Controller;
+namespace Tests\Sylius\SyliusShopApiPlugin\Controller;
 
 use Lakion\ApiTestCase\JsonApiTestCase;
 use PHPUnit\Framework\Assert;
@@ -10,7 +10,7 @@ use Sylius\Component\Core\Test\Services\EmailCheckerInterface;
 use Sylius\Component\User\Repository\UserRepositoryInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Response;
-use Tests\Sylius\ShopApiPlugin\Controller\Utils\PurgeSpooledMessagesTrait;
+use Tests\Sylius\SyliusShopApiPlugin\Controller\Utils\PurgeSpooledMessagesTrait;
 
 final class CustomerRegisterApiTest extends JsonApiTestCase
 {

--- a/tests/Controller/CustomerRequestPasswordResettingApiTest.php
+++ b/tests/Controller/CustomerRequestPasswordResettingApiTest.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace Tests\Sylius\ShopApiPlugin\Controller;
+namespace Tests\Sylius\SyliusShopApiPlugin\Controller;
 
 use Lakion\ApiTestCase\JsonApiTestCase;
 use Sylius\Component\Core\Test\Services\EmailCheckerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Response;
-use Tests\Sylius\ShopApiPlugin\Controller\Utils\PurgeSpooledMessagesTrait;
+use Tests\Sylius\SyliusShopApiPlugin\Controller\Utils\PurgeSpooledMessagesTrait;
 
 final class CustomerRequestPasswordResettingApiTest extends JsonApiTestCase
 {

--- a/tests/Controller/CustomerResendVerificationTokenApiTest.php
+++ b/tests/Controller/CustomerResendVerificationTokenApiTest.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace Tests\Sylius\ShopApiPlugin\Controller;
+namespace Tests\Sylius\SyliusShopApiPlugin\Controller;
 
 use Lakion\ApiTestCase\JsonApiTestCase;
 use Sylius\Component\Core\Test\Services\EmailCheckerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Response;
-use Tests\Sylius\ShopApiPlugin\Controller\Utils\PurgeSpooledMessagesTrait;
+use Tests\Sylius\SyliusShopApiPlugin\Controller\Utils\PurgeSpooledMessagesTrait;
 
 final class CustomerResendVerificationTokenApiTest extends JsonApiTestCase
 {

--- a/tests/Controller/CustomerResetPasswordApiTest.php
+++ b/tests/Controller/CustomerResetPasswordApiTest.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace Tests\Sylius\ShopApiPlugin\Controller;
+namespace Tests\Sylius\SyliusShopApiPlugin\Controller;
 
 use Lakion\ApiTestCase\JsonApiTestCase;
 use Sylius\Component\Core\Model\ShopUserInterface;
 use Sylius\Component\User\Repository\UserRepositoryInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Response;
-use Tests\Sylius\ShopApiPlugin\Controller\Utils\PurgeSpooledMessagesTrait;
+use Tests\Sylius\SyliusShopApiPlugin\Controller\Utils\PurgeSpooledMessagesTrait;
 
 final class CustomerResetPasswordApiTest extends JsonApiTestCase
 {

--- a/tests/Controller/CustomerUpdateCustomerApiTest.php
+++ b/tests/Controller/CustomerUpdateCustomerApiTest.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace Tests\Sylius\ShopApiPlugin\Controller;
+namespace Tests\Sylius\SyliusShopApiPlugin\Controller;
 
 use Lakion\ApiTestCase\JsonApiTestCase;
 use PHPUnit\Framework\Assert;
 use Sylius\Component\Core\Model\CustomerInterface;
 use Sylius\Component\Core\Repository\CustomerRepositoryInterface;
 use Symfony\Component\HttpFoundation\Response;
-use Tests\Sylius\ShopApiPlugin\Controller\Utils\ShopUserLoginTrait;
+use Tests\Sylius\SyliusShopApiPlugin\Controller\Utils\ShopUserLoginTrait;
 
 final class CustomerUpdateCustomerApiTest extends JsonApiTestCase
 {

--- a/tests/Controller/CustomerVerifyApiTest.php
+++ b/tests/Controller/CustomerVerifyApiTest.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace Tests\Sylius\ShopApiPlugin\Controller;
+namespace Tests\Sylius\SyliusShopApiPlugin\Controller;
 
 use Lakion\ApiTestCase\JsonApiTestCase;
 use Sylius\Component\User\Repository\UserRepositoryInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Response;
-use Tests\Sylius\ShopApiPlugin\Controller\Utils\PurgeSpooledMessagesTrait;
+use Tests\Sylius\SyliusShopApiPlugin\Controller\Utils\PurgeSpooledMessagesTrait;
 
 final class CustomerVerifyApiTest extends JsonApiTestCase
 {

--- a/tests/Controller/LoggedInCustomerDetailsActionTest.php
+++ b/tests/Controller/LoggedInCustomerDetailsActionTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\Sylius\ShopApiPlugin\Controller\Customer;
+namespace Tests\Sylius\SyliusShopApiPlugin\Controller\Customer;
 
 use Lakion\ApiTestCase\JsonApiTestCase;
 use Symfony\Component\HttpFoundation\Response;

--- a/tests/Controller/ProductAddReviewByCodeApiTest.php
+++ b/tests/Controller/ProductAddReviewByCodeApiTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\Sylius\ShopApiPlugin\Controller;
+namespace Tests\Sylius\SyliusShopApiPlugin\Controller;
 
 use Lakion\ApiTestCase\JsonApiTestCase;
 use Symfony\Component\HttpFoundation\Response;

--- a/tests/Controller/ProductAddReviewBySlugApiTest.php
+++ b/tests/Controller/ProductAddReviewBySlugApiTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\Sylius\ShopApiPlugin\Controller;
+namespace Tests\Sylius\SyliusShopApiPlugin\Controller;
 
 use Lakion\ApiTestCase\JsonApiTestCase;
 use Symfony\Component\HttpFoundation\Response;

--- a/tests/Controller/ProductShowCatalogByCodeApiTest.php
+++ b/tests/Controller/ProductShowCatalogByCodeApiTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\Sylius\ShopApiPlugin\Controller;
+namespace Tests\Sylius\SyliusShopApiPlugin\Controller;
 
 use Lakion\ApiTestCase\JsonApiTestCase;
 use Symfony\Component\HttpFoundation\Response;

--- a/tests/Controller/ProductShowCatalogBySlugApiTest.php
+++ b/tests/Controller/ProductShowCatalogBySlugApiTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\Sylius\ShopApiPlugin\Controller;
+namespace Tests\Sylius\SyliusShopApiPlugin\Controller;
 
 use Lakion\ApiTestCase\JsonApiTestCase;
 use Symfony\Component\HttpFoundation\Response;

--- a/tests/Controller/ProductShowDetailsByCodeApiTest.php
+++ b/tests/Controller/ProductShowDetailsByCodeApiTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\Sylius\ShopApiPlugin\Controller;
+namespace Tests\Sylius\SyliusShopApiPlugin\Controller;
 
 use Lakion\ApiTestCase\JsonApiTestCase;
 use Symfony\Component\HttpFoundation\Response;

--- a/tests/Controller/ProductShowDetailsBySlugApiTest.php
+++ b/tests/Controller/ProductShowDetailsBySlugApiTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\Sylius\ShopApiPlugin\Controller;
+namespace Tests\Sylius\SyliusShopApiPlugin\Controller;
 
 use Lakion\ApiTestCase\JsonApiTestCase;
 use Symfony\Component\HttpFoundation\Response;

--- a/tests/Controller/ProductShowLatestApiTest.php
+++ b/tests/Controller/ProductShowLatestApiTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\Sylius\ShopApiPlugin\Controller;
+namespace Tests\Sylius\SyliusShopApiPlugin\Controller;
 
 use Lakion\ApiTestCase\JsonApiTestCase;
 use Symfony\Component\HttpFoundation\Response;

--- a/tests/Controller/ProductShowReviewsByCodeApiTest.php
+++ b/tests/Controller/ProductShowReviewsByCodeApiTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\Sylius\ShopApiPlugin\Controller;
+namespace Tests\Sylius\SyliusShopApiPlugin\Controller;
 
 use Lakion\ApiTestCase\JsonApiTestCase;
 use Symfony\Component\HttpFoundation\Response;

--- a/tests/Controller/ProductShowReviewsBySlugApiTest.php
+++ b/tests/Controller/ProductShowReviewsBySlugApiTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\Sylius\ShopApiPlugin\Controller;
+namespace Tests\Sylius\SyliusShopApiPlugin\Controller;
 
 use Lakion\ApiTestCase\JsonApiTestCase;
 use Symfony\Component\HttpFoundation\Response;

--- a/tests/Controller/TaxonShowDetailsApiTest.php
+++ b/tests/Controller/TaxonShowDetailsApiTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\Sylius\ShopApiPlugin\Controller;
+namespace Tests\Sylius\SyliusShopApiPlugin\Controller;
 
 use Lakion\ApiTestCase\JsonApiTestCase;
 use Symfony\Component\HttpFoundation\Response;

--- a/tests/Controller/TaxonShowTreeApiTest.php
+++ b/tests/Controller/TaxonShowTreeApiTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\Sylius\ShopApiPlugin\Controller;
+namespace Tests\Sylius\SyliusShopApiPlugin\Controller;
 
 use Lakion\ApiTestCase\JsonApiTestCase;
 use Symfony\Component\HttpFoundation\Response;

--- a/tests/Controller/Utils/PurgeSpooledMessagesTrait.php
+++ b/tests/Controller/Utils/PurgeSpooledMessagesTrait.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\Sylius\ShopApiPlugin\Controller\Utils;
+namespace Tests\Sylius\SyliusShopApiPlugin\Controller\Utils;
 
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Filesystem\Filesystem;

--- a/tests/Controller/Utils/ShopUserLoginTrait.php
+++ b/tests/Controller/Utils/ShopUserLoginTrait.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\Sylius\ShopApiPlugin\Controller\Utils;
+namespace Tests\Sylius\SyliusShopApiPlugin\Controller\Utils;
 
 use PHPUnit\Framework\Assert;
 use Symfony\Bundle\FrameworkBundle\Client;

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace Tests\Sylius\ShopApiPlugin\DependencyInjection;
+namespace Tests\Sylius\SyliusShopApiPlugin\DependencyInjection;
 
 use Matthias\SymfonyConfigTest\PhpUnit\ConfigurationTestCaseTrait;
 use PHPUnit\Framework\TestCase;
-use Sylius\ShopApiPlugin\DependencyInjection\Configuration;
-use Sylius\ShopApiPlugin\View;
+use Sylius\SyliusShopApiPlugin\DependencyInjection\Configuration;
+use Sylius\SyliusShopApiPlugin\View;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 final class ConfigurationTest extends TestCase

--- a/tests/DependencyInjection/ShopApiExtensionTest.php
+++ b/tests/DependencyInjection/ShopApiExtensionTest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Tests\Sylius\ShopApiPlugin\DependencyInjection;
+namespace Tests\Sylius\SyliusShopApiPlugin\DependencyInjection;
 
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
-use Sylius\ShopApiPlugin\DependencyInjection\ShopApiExtension;
-use Sylius\ShopApiPlugin\View;
+use Sylius\SyliusShopApiPlugin\DependencyInjection\ShopApiExtension;
+use Sylius\SyliusShopApiPlugin\View;
 
 final class ShopApiExtensionTest extends AbstractExtensionTestCase
 {

--- a/tests/Request/AddCouponRequestTest.php
+++ b/tests/Request/AddCouponRequestTest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Tests\Sylius\ShopApiPlugin\Request;
+namespace Tests\Sylius\SyliusShopApiPlugin\Request;
 
 use PHPUnit\Framework\TestCase;
-use Sylius\ShopApiPlugin\Command\AddCoupon;
-use Sylius\ShopApiPlugin\Request\AddCouponRequest;
+use Sylius\SyliusShopApiPlugin\Command\AddCoupon;
+use Sylius\SyliusShopApiPlugin\Request\AddCouponRequest;
 use Symfony\Component\HttpFoundation\Request;
 
 final class AddCouponRequestTest extends TestCase

--- a/tests/Request/AddProductReviewByCodeRequestTest.php
+++ b/tests/Request/AddProductReviewByCodeRequestTest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Tests\Sylius\ShopApiPlugin\Request;
+namespace Tests\Sylius\SyliusShopApiPlugin\Request;
 
 use PHPUnit\Framework\TestCase;
-use Sylius\ShopApiPlugin\Command\AddProductReviewByCode;
-use Sylius\ShopApiPlugin\Request\AddProductReviewByCodeRequest;
+use Sylius\SyliusShopApiPlugin\Command\AddProductReviewByCode;
+use Sylius\SyliusShopApiPlugin\Request\AddProductReviewByCodeRequest;
 use Symfony\Component\HttpFoundation\Request;
 
 final class AddProductReviewByCodeRequestTest extends TestCase

--- a/tests/Request/AddProductReviewBySlugRequestTest.php
+++ b/tests/Request/AddProductReviewBySlugRequestTest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Tests\Sylius\ShopApiPlugin\Request;
+namespace Tests\Sylius\SyliusShopApiPlugin\Request;
 
 use PHPUnit\Framework\TestCase;
-use Sylius\ShopApiPlugin\Command\AddProductReviewBySlug;
-use Sylius\ShopApiPlugin\Request\AddProductReviewBySlugRequest;
+use Sylius\SyliusShopApiPlugin\Command\AddProductReviewBySlug;
+use Sylius\SyliusShopApiPlugin\Request\AddProductReviewBySlugRequest;
 use Symfony\Component\HttpFoundation\Request;
 
 final class AddProductReviewBySlugRequestTest extends TestCase

--- a/tests/Request/ChangeItemQuantityRequestTest.php
+++ b/tests/Request/ChangeItemQuantityRequestTest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Tests\Sylius\ShopApiPlugin\Request;
+namespace Tests\Sylius\SyliusShopApiPlugin\Request;
 
 use PHPUnit\Framework\TestCase;
-use Sylius\ShopApiPlugin\Command\ChangeItemQuantity;
-use Sylius\ShopApiPlugin\Request\ChangeItemQuantityRequest;
+use Sylius\SyliusShopApiPlugin\Command\ChangeItemQuantity;
+use Sylius\SyliusShopApiPlugin\Request\ChangeItemQuantityRequest;
 use Symfony\Component\HttpFoundation\Request;
 
 final class ChangeItemQuantityRequestTest extends TestCase

--- a/tests/Request/DropCartRequestTest.php
+++ b/tests/Request/DropCartRequestTest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Tests\Sylius\ShopApiPlugin\Request;
+namespace Tests\Sylius\SyliusShopApiPlugin\Request;
 
 use PHPUnit\Framework\TestCase;
-use Sylius\ShopApiPlugin\Command\DropCart;
-use Sylius\ShopApiPlugin\Request\DropCartRequest;
+use Sylius\SyliusShopApiPlugin\Command\DropCart;
+use Sylius\SyliusShopApiPlugin\Request\DropCartRequest;
 use Symfony\Component\HttpFoundation\Request;
 
 final class DropCartRequestTest extends TestCase

--- a/tests/Request/PickupCartRequestTest.php
+++ b/tests/Request/PickupCartRequestTest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Tests\Sylius\ShopApiPlugin\Request;
+namespace Tests\Sylius\SyliusShopApiPlugin\Request;
 
 use PHPUnit\Framework\TestCase;
-use Sylius\ShopApiPlugin\Command\PickupCart;
-use Sylius\ShopApiPlugin\Request\PickupCartRequest;
+use Sylius\SyliusShopApiPlugin\Command\PickupCart;
+use Sylius\SyliusShopApiPlugin\Request\PickupCartRequest;
 use Symfony\Component\HttpFoundation\Request;
 
 final class PickupCartRequestTest extends TestCase

--- a/tests/Request/PutOptionBasedConfigurableItemToCartRequestTest.php
+++ b/tests/Request/PutOptionBasedConfigurableItemToCartRequestTest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Tests\Sylius\ShopApiPlugin\Request;
+namespace Tests\Sylius\SyliusShopApiPlugin\Request;
 
 use PHPUnit\Framework\TestCase;
-use Sylius\ShopApiPlugin\Command\PutOptionBasedConfigurableItemToCart;
-use Sylius\ShopApiPlugin\Request\PutOptionBasedConfigurableItemToCartRequest;
+use Sylius\SyliusShopApiPlugin\Command\PutOptionBasedConfigurableItemToCart;
+use Sylius\SyliusShopApiPlugin\Request\PutOptionBasedConfigurableItemToCartRequest;
 use Symfony\Component\HttpFoundation\Request;
 
 final class PutOptionBasedConfigurableItemToCartRequestTest extends TestCase

--- a/tests/Request/PutSimpleItemToCartRequestTest.php
+++ b/tests/Request/PutSimpleItemToCartRequestTest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Tests\Sylius\ShopApiPlugin\Request;
+namespace Tests\Sylius\SyliusShopApiPlugin\Request;
 
 use PHPUnit\Framework\TestCase;
-use Sylius\ShopApiPlugin\Command\PutSimpleItemToCart;
-use Sylius\ShopApiPlugin\Request\PutSimpleItemToCartRequest;
+use Sylius\SyliusShopApiPlugin\Command\PutSimpleItemToCart;
+use Sylius\SyliusShopApiPlugin\Request\PutSimpleItemToCartRequest;
 use Symfony\Component\HttpFoundation\Request;
 
 final class PutSimpleItemToCartRequestTest extends TestCase

--- a/tests/Request/PutVariantBasedConfigurableItemToCartRequestTest.php
+++ b/tests/Request/PutVariantBasedConfigurableItemToCartRequestTest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Tests\Sylius\ShopApiPlugin\Request;
+namespace Tests\Sylius\SyliusShopApiPlugin\Request;
 
 use PHPUnit\Framework\TestCase;
-use Sylius\ShopApiPlugin\Command\PutVariantBasedConfigurableItemToCart;
-use Sylius\ShopApiPlugin\Request\PutVariantBasedConfigurableItemToCartRequest;
+use Sylius\SyliusShopApiPlugin\Command\PutVariantBasedConfigurableItemToCart;
+use Sylius\SyliusShopApiPlugin\Request\PutVariantBasedConfigurableItemToCartRequest;
 use Symfony\Component\HttpFoundation\Request;
 
 final class PutVariantBasedConfigurableItemToCartRequestTest extends TestCase

--- a/tests/Request/ResendVerificationTokenRequestTest.php
+++ b/tests/Request/ResendVerificationTokenRequestTest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Tests\Sylius\ShopApiPlugin\Request;
+namespace Tests\Sylius\SyliusShopApiPlugin\Request;
 
 use PHPUnit\Framework\TestCase;
-use Sylius\ShopApiPlugin\Command\SendVerificationToken;
-use Sylius\ShopApiPlugin\Request\ResendVerificationTokenRequest;
+use Sylius\SyliusShopApiPlugin\Command\SendVerificationToken;
+use Sylius\SyliusShopApiPlugin\Request\ResendVerificationTokenRequest;
 use Symfony\Component\HttpFoundation\Request;
 
 final class ResendVerificationTokenRequestTest extends TestCase

--- a/tests/Request/UpdateCustomerRequestTest.php
+++ b/tests/Request/UpdateCustomerRequestTest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Tests\Sylius\ShopApiPlugin\Request;
+namespace Tests\Sylius\SyliusShopApiPlugin\Request;
 
 use PHPUnit\Framework\TestCase;
-use Sylius\ShopApiPlugin\Command\UpdateCustomer;
-use Sylius\ShopApiPlugin\Request\UpdateCustomerRequest;
+use Sylius\SyliusShopApiPlugin\Command\UpdateCustomer;
+use Sylius\SyliusShopApiPlugin\Request\UpdateCustomerRequest;
 use Symfony\Component\HttpFoundation\Request;
 
 final class UpdateCustomerRequestTest extends TestCase

--- a/tests/Request/VerifyAccountRequestTest.php
+++ b/tests/Request/VerifyAccountRequestTest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Tests\Sylius\ShopApiPlugin\Request;
+namespace Tests\Sylius\SyliusShopApiPlugin\Request;
 
 use PHPUnit\Framework\TestCase;
-use Sylius\ShopApiPlugin\Command\VerifyAccount;
-use Sylius\ShopApiPlugin\Request\VerifyAccountRequest;
+use Sylius\SyliusShopApiPlugin\Command\VerifyAccount;
+use Sylius\SyliusShopApiPlugin\Request\VerifyAccountRequest;
 use Symfony\Component\HttpFoundation\Request;
 
 final class VerifyAccountRequestTest extends TestCase


### PR DESCRIPTION
Making the plugin compatible with the correct naming convention. This requires the plugin to be renamed so you might also need to update the packagist information.