### PR TITLE
Require channel code in all endpoints

### DIFF
--- a/doc/swagger.yml
+++ b/doc/swagger.yml
@@ -9,7 +9,7 @@ info:
         name: "MIT"
         url: "https://opensource.org/licenses/MIT"
 host: "demo.sylius.org"
-basePath: "/shop-api"
+basePath: "/shop-api/{channelCode}"
 tags:
 - name: "cart"
   description: "All actions related to cart management."

--- a/spec/Checker/ChannelExistenceCheckerSpec.php
+++ b/spec/Checker/ChannelExistenceCheckerSpec.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\Sylius\ShopApiPlugin\Checker;
+
+use PhpSpec\ObjectBehavior;
+use Sylius\Component\Channel\Repository\ChannelRepositoryInterface;
+use Sylius\Component\Core\Model\ChannelInterface;
+use Sylius\ShopApiPlugin\Checker\ChannelExistenceCheckerInterface;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+final class ChannelExistenceCheckerSpec extends ObjectBehavior
+{
+    function let(ChannelRepositoryInterface $channelRepository): void
+    {
+        $this->beConstructedWith($channelRepository);
+    }
+
+    function it_implements_channel_existence_checker_interface(): void
+    {
+        $this->shouldImplement(ChannelExistenceCheckerInterface::class);
+    }
+
+    function it_does_nothing_if_channel_with_given_code_exists(
+        ChannelRepositoryInterface $channelRepository,
+        ChannelInterface $channel
+    ): void {
+        $channelRepository->findOneByCode('WEB_US')->willReturn($channel);
+
+        $this->withCode('WEB_US');
+    }
+
+    function it_throws_exception_if_channel_with_given_code_does_not_exist(
+        ChannelRepositoryInterface $channelRepository
+    ): void {
+        $channelRepository->findOneByCode('WEB_US')->willReturn(null);
+
+        $this
+            ->shouldThrow(NotFoundHttpException::class)
+            ->during('withCode', ['WEB_US'])
+        ;
+    }
+}

--- a/spec/Command/SendResetPasswordTokenSpec.php
+++ b/spec/Command/SendResetPasswordTokenSpec.php
@@ -11,7 +11,7 @@ final class SendResetPasswordTokenSpec extends ObjectBehavior
 {
     function let(): void
     {
-        $this->beConstructedWith('example@customer.com');
+        $this->beConstructedWith('example@customer.com', 'WEB_GB');
     }
 
     function it_is_initializable(): void
@@ -22,5 +22,10 @@ final class SendResetPasswordTokenSpec extends ObjectBehavior
     function it_has_email(): void
     {
         $this->email()->shouldReturn('example@customer.com');
+    }
+
+    function it_has_channel_code(): void
+    {
+        $this->channelCode()->shouldReturn('WEB_GB');
     }
 }

--- a/spec/Command/SendVerificationTokenSpec.php
+++ b/spec/Command/SendVerificationTokenSpec.php
@@ -11,7 +11,7 @@ final class SendVerificationTokenSpec extends ObjectBehavior
 {
     function let(): void
     {
-        $this->beConstructedWith('example@customer.com');
+        $this->beConstructedWith('example@customer.com', 'WEB_GB');
     }
 
     function it_is_initializable(): void
@@ -22,5 +22,10 @@ final class SendVerificationTokenSpec extends ObjectBehavior
     function it_has_email(): void
     {
         $this->email()->shouldReturn('example@customer.com');
+    }
+
+    function it_has_channel_code(): void
+    {
+        $this->channelCode()->shouldReturn('WEB_GB');
     }
 }

--- a/spec/EventListener/UserRegistrationListenerSpec.php
+++ b/spec/EventListener/UserRegistrationListenerSpec.php
@@ -36,7 +36,7 @@ final class UserRegistrationListenerSpec extends ObjectBehavior
         $channel->isAccountVerificationRequired()->willReturn(true);
 
         $bus->handle(new GenerateVerificationToken('shop@example.com'))->shouldBeCalled();
-        $bus->handle(new SendVerificationToken('shop@example.com'))->shouldBeCalled();
+        $bus->handle(new SendVerificationToken('shop@example.com', 'FOOBAR'))->shouldBeCalled();
 
         $this->handleUserVerification(new CustomerRegistered(
             'shop@example.com',

--- a/spec/EventSubscriber/RequestChannelSubscriberSpec.php
+++ b/spec/EventSubscriber/RequestChannelSubscriberSpec.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\Sylius\ShopApiPlugin\EventSubscriber;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Sylius\ShopApiPlugin\Checker\ChannelExistenceCheckerInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\ParameterBag;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+final class RequestChannelSubscriberSpec extends ObjectBehavior
+{
+    function let(ChannelExistenceCheckerInterface $channelExistenceChecker): void
+    {
+        $this->beConstructedWith($channelExistenceChecker);
+    }
+
+    function it_implements_event_subscriber_interface(): void
+    {
+        $this->shouldImplement(EventSubscriberInterface::class);
+    }
+
+    function it_validates_channel_code_put_in_request_attributes(
+        ChannelExistenceCheckerInterface $channelExistenceChecker,
+        FilterControllerEvent $event,
+        Request $request
+    ): void {
+        $event->getRequest()->willReturn($request);
+        $request->attributes = new ParameterBag(['channelCode' => 'WEB_US']);
+
+        $channelExistenceChecker->withCode('WEB_US')->willThrow(NotFoundHttpException::class);
+
+        $this
+            ->shouldThrow(NotFoundHttpException::class)
+            ->during('checkChannelCode', [$event])
+        ;
+    }
+
+    function it_does_nothing_if_there_is_no_channel_code_in_request_attributes(
+        ChannelExistenceCheckerInterface $channelExistenceChecker,
+        FilterControllerEvent $event,
+        Request $request
+    ): void {
+        $event->getRequest()->willReturn($request);
+        $request->attributes = new ParameterBag([]);
+
+        $channelExistenceChecker->withCode(Argument::any())->shouldNotBeCalled();
+
+        $this->checkChannelCode($event);
+    }
+}

--- a/spec/Factory/ProductViewFactorySpec.php
+++ b/spec/Factory/ProductViewFactorySpec.php
@@ -66,6 +66,8 @@ final class ProductViewFactorySpec extends ObjectBehavior
         $taxon->getCode()->willReturn('TAXON');
         $mainTaxon->getCode()->willReturn('MAIN');
 
+        $channel->getCode()->willReturn('WEB_GB');
+
         $firstProductImage->getProductVariants()->willReturn(new ArrayCollection([]));
         $secondProductImage->getProductVariants()->willReturn(new ArrayCollection([]));
 
@@ -97,6 +99,7 @@ final class ProductViewFactorySpec extends ObjectBehavior
         $productView->taxons = $taxonView;
         $productView->images = [new ImageView(), new ImageView()];
         $productView->attributes = [];
+        $productView->channelCode = 'WEB_GB';
 
         $this->create($product, $channel, 'en_GB')->shouldBeLike($productView);
     }

--- a/spec/Handler/SendResetPasswordTokenHandlerSpec.php
+++ b/spec/Handler/SendResetPasswordTokenHandlerSpec.php
@@ -32,9 +32,9 @@ final class SendResetPasswordTokenHandlerSpec extends ObjectBehavior
         $userRepository->findOneByEmail('example@customer.com')->willReturn($user);
         $user->getPasswordResetToken()->willReturn('SOMERANDOMSTRINGASDAFSASFAFAFAACEAFCCEFACVAFVSF');
 
-        $sender->send(Emails::EMAIL_RESET_PASSWORD_TOKEN, ['example@customer.com'], ['user' => $user])->shouldBeCalled();
+        $sender->send(Emails::EMAIL_RESET_PASSWORD_TOKEN, ['example@customer.com'], ['user' => $user, 'channelCode' => 'WEB_GB'])->shouldBeCalled();
 
-        $this->handle(new SendResetPasswordToken('example@customer.com'));
+        $this->handle(new SendResetPasswordToken('example@customer.com', 'WEB_GB'));
     }
 
     function it_throws_an_exception_if_user_has_not_been_found(
@@ -42,7 +42,7 @@ final class SendResetPasswordTokenHandlerSpec extends ObjectBehavior
     ): void {
         $userRepository->findOneByEmail('example@customer.com')->willReturn(null);
 
-        $this->shouldThrow(\InvalidArgumentException::class)->during('handle', [new SendResetPasswordToken('example@customer.com')]);
+        $this->shouldThrow(\InvalidArgumentException::class)->during('handle', [new SendResetPasswordToken('example@customer.com', 'WEB_GB')]);
     }
 
     function it_throws_an_exception_if_user_has_not_verification_token(
@@ -52,6 +52,6 @@ final class SendResetPasswordTokenHandlerSpec extends ObjectBehavior
         $userRepository->findOneByEmail('example@customer.com')->willReturn($user);
         $user->getPasswordResetToken()->willReturn(null);
 
-        $this->shouldThrow(\InvalidArgumentException::class)->during('handle', [new SendResetPasswordToken('example@customer.com')]);
+        $this->shouldThrow(\InvalidArgumentException::class)->during('handle', [new SendResetPasswordToken('example@customer.com', 'WEB_GB')]);
     }
 }

--- a/spec/Handler/SendVerificationTokenHandlerSpec.php
+++ b/spec/Handler/SendVerificationTokenHandlerSpec.php
@@ -32,9 +32,9 @@ final class SendVerificationTokenHandlerSpec extends ObjectBehavior
         $userRepository->findOneByEmail('example@customer.com')->willReturn($user);
         $user->getEmailVerificationToken()->willReturn('SOMERANDOMSTRINGASDAFSASFAFAFAACEAFCCEFACVAFVSF');
 
-        $sender->send(Emails::EMAIL_VERIFICATION_TOKEN, ['example@customer.com'], ['user' => $user])->shouldBeCalled();
+        $sender->send(Emails::EMAIL_VERIFICATION_TOKEN, ['example@customer.com'], ['user' => $user, 'channelCode' => 'WEB_GB'])->shouldBeCalled();
 
-        $this->handle(new SendVerificationToken('example@customer.com'));
+        $this->handle(new SendVerificationToken('example@customer.com', 'WEB_GB'));
     }
 
     function it_throws_an_exception_if_user_has_not_been_found(
@@ -42,7 +42,10 @@ final class SendVerificationTokenHandlerSpec extends ObjectBehavior
     ): void {
         $userRepository->findOneByEmail('example@customer.com')->willReturn(null);
 
-        $this->shouldThrow(\InvalidArgumentException::class)->during('handle', [new SendVerificationToken('example@customer.com')]);
+        $this
+            ->shouldThrow(\InvalidArgumentException::class)
+            ->during('handle', [new SendVerificationToken('example@customer.com', 'WEB_GB')])
+        ;
     }
 
     function it_throws_an_exception_if_user_has_not_verification_token(
@@ -52,6 +55,9 @@ final class SendVerificationTokenHandlerSpec extends ObjectBehavior
         $userRepository->findOneByEmail('example@customer.com')->willReturn($user);
         $user->getEmailVerificationToken()->willReturn(null);
 
-        $this->shouldThrow(\InvalidArgumentException::class)->during('handle', [new SendVerificationToken('example@customer.com')]);
+        $this
+            ->shouldThrow(\InvalidArgumentException::class)
+            ->during('handle', [new SendVerificationToken('example@customer.com', 'WEB_GB')])
+        ;
     }
 }

--- a/src/Checker/ChannelExistenceChecker.php
+++ b/src/Checker/ChannelExistenceChecker.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\ShopApiPlugin\Checker;
+
+use Sylius\Component\Channel\Repository\ChannelRepositoryInterface;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+final class ChannelExistenceChecker implements ChannelExistenceCheckerInterface
+{
+    /** @var ChannelRepositoryInterface */
+    private $channelRepository;
+
+    public function __construct(ChannelRepositoryInterface $channelRepository)
+    {
+        $this->channelRepository = $channelRepository;
+    }
+
+    public function withCode(string $channelCode): void
+    {
+        $channel = $this->channelRepository->findOneByCode($channelCode);
+
+        if (null === $channel) {
+            throw new NotFoundHttpException(sprintf('Channel with code %s has not been found.', $channelCode));
+        }
+    }
+}

--- a/src/Checker/ChannelExistenceCheckerInterface.php
+++ b/src/Checker/ChannelExistenceCheckerInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\ShopApiPlugin\Checker;
+
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+interface ChannelExistenceCheckerInterface
+{
+    /** @throws NotFoundHttpException if channel with passed code does not exits */
+    public function withCode(string $channelCode): void;
+}

--- a/src/Command/SendResetPasswordToken.php
+++ b/src/Command/SendResetPasswordToken.php
@@ -9,13 +9,22 @@ final class SendResetPasswordToken
     /** @var string */
     private $email;
 
-    public function __construct(string $email)
+    /** @var string */
+    private $channelCode;
+
+    public function __construct(string $email, string $channelCode)
     {
         $this->email = $email;
+        $this->channelCode = $channelCode;
     }
 
     public function email(): string
     {
         return $this->email;
+    }
+
+    public function channelCode(): string
+    {
+        return $this->channelCode;
     }
 }

--- a/src/Command/SendVerificationToken.php
+++ b/src/Command/SendVerificationToken.php
@@ -9,13 +9,22 @@ final class SendVerificationToken
     /** @var string */
     private $email;
 
-    public function __construct(string $email)
+    /** @var string */
+    private $channelCode;
+
+    public function __construct(string $email, string $channelCode)
     {
         $this->email = $email;
+        $this->channelCode = $channelCode;
     }
 
     public function email(): string
     {
         return $this->email;
+    }
+
+    public function channelCode(): string
+    {
+        return $this->channelCode;
     }
 }

--- a/src/Controller/Customer/RequestPasswordResettingAction.php
+++ b/src/Controller/Customer/RequestPasswordResettingAction.php
@@ -31,7 +31,7 @@ final class RequestPasswordResettingAction
     public function __invoke(Request $request): Response
     {
         $this->bus->handle(new GenerateResetPasswordToken($request->request->get('email')));
-        $this->bus->handle(new SendResetPasswordToken($request->request->get('email')));
+        $this->bus->handle(new SendResetPasswordToken($request->request->get('email'), $request->attributes->get('channelCode')));
 
         return $this->viewHandler->handle(View::create(null, Response::HTTP_NO_CONTENT));
     }

--- a/src/Controller/Product/ShowLatestProductAction.php
+++ b/src/Controller/Product/ShowLatestProductAction.php
@@ -29,13 +29,9 @@ final class ShowLatestProductAction
 
     public function __invoke(Request $request): Response
     {
-        if (!$request->query->has('channel')) {
-            throw new NotFoundHttpException('Cannot find product without channel provided');
-        }
-
         try {
             return $this->viewHandler->handle(View::create($this->productLatestQuery->getLatestProducts(
-                $request->query->get('channel'),
+                $request->attributes->get('channelCode'),
                 $request->query->get('locale'),
                 $request->query->getInt('limit', 4)
             ), Response::HTTP_OK));

--- a/src/Controller/Product/ShowProductCatalogByTaxonCodeAction.php
+++ b/src/Controller/Product/ShowProductCatalogByTaxonCodeAction.php
@@ -30,14 +30,10 @@ final class ShowProductCatalogByTaxonCodeAction
 
     public function __invoke(Request $request): Response
     {
-        if (!$request->query->has('channel')) {
-            throw new NotFoundHttpException('Cannot find product without channel provided');
-        }
-
         try {
             return $this->viewHandler->handle(View::create($this->productCatalogQuery->findByTaxonCode(
                 $request->attributes->get('code'),
-                $request->query->get('channel'),
+                $request->attributes->get('channelCode'),
                 new PaginatorDetails($request->attributes->get('_route'), $request->query->all()),
                 $request->query->get('locale')
             ), Response::HTTP_OK));

--- a/src/Controller/Product/ShowProductCatalogByTaxonSlugAction.php
+++ b/src/Controller/Product/ShowProductCatalogByTaxonSlugAction.php
@@ -30,14 +30,10 @@ final class ShowProductCatalogByTaxonSlugAction
 
     public function __invoke(Request $request): Response
     {
-        if (!$request->query->has('channel')) {
-            throw new NotFoundHttpException('Cannot find product without channel provided');
-        }
-
         try {
             return $this->viewHandler->handle(View::create($this->productCatalogQuery->findByTaxonSlug(
                 $request->attributes->get('taxonSlug'),
-                $request->query->get('channel'),
+                $request->attributes->get('channelCode'),
                 new PaginatorDetails($request->attributes->get('_route'), $request->query->all()),
                 $request->query->get('locale')
             ), Response::HTTP_OK));

--- a/src/Controller/Product/ShowProductDetailsByCodeAction.php
+++ b/src/Controller/Product/ShowProductDetailsByCodeAction.php
@@ -29,14 +29,10 @@ final class ShowProductDetailsByCodeAction
 
     public function __invoke(Request $request): Response
     {
-        if (!$request->query->has('channel')) {
-            throw new NotFoundHttpException('Cannot find product without channel provided');
-        }
-
         try {
             return $this->viewHandler->handle(View::create($this->productCatalog->findOneByCode(
                 $request->attributes->get('code'),
-                $request->query->get('channel'),
+                $request->attributes->get('channelCode'),
                 $request->query->get('locale')
             ), Response::HTTP_OK));
         } catch (\InvalidArgumentException $exception) {

--- a/src/Controller/Product/ShowProductDetailsBySlugAction.php
+++ b/src/Controller/Product/ShowProductDetailsBySlugAction.php
@@ -29,14 +29,10 @@ final class ShowProductDetailsBySlugAction
 
     public function __invoke(Request $request): Response
     {
-        if (!$request->query->has('channel')) {
-            throw new NotFoundHttpException('Cannot find product without channel provided');
-        }
-
         try {
             return $this->viewHandler->handle(View::create($this->productCatalog->findOneBySlug(
                 $request->attributes->get('slug'),
-                $request->query->get('channel'),
+                $request->attributes->get('channelCode'),
                 $request->query->get('locale')
             ), Response::HTTP_OK));
         } catch (\InvalidArgumentException $exception) {

--- a/src/Controller/Product/ShowProductReviewsByCodeAction.php
+++ b/src/Controller/Product/ShowProductReviewsByCodeAction.php
@@ -30,13 +30,9 @@ final class ShowProductReviewsByCodeAction
 
     public function __invoke(Request $request): Response
     {
-        if (!$request->query->has('channel')) {
-            throw new NotFoundHttpException('Cannot find product without channel provided');
-        }
-
         $page = $this->productReviewsViewRepository->getByProductCode(
             $request->attributes->get('code'),
-            $request->query->get('channel'),
+            $request->attributes->get('channelCode'),
             new PaginatorDetails($request->attributes->get('_route'), $request->query->all())
         );
 

--- a/src/Controller/Product/ShowProductReviewsByCodeAction.php
+++ b/src/Controller/Product/ShowProductReviewsByCodeAction.php
@@ -10,7 +10,6 @@ use Sylius\ShopApiPlugin\Model\PaginatorDetails;
 use Sylius\ShopApiPlugin\ViewRepository\ProductReviewsViewRepositoryInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 final class ShowProductReviewsByCodeAction
 {

--- a/src/Controller/Product/ShowProductReviewsBySlugAction.php
+++ b/src/Controller/Product/ShowProductReviewsBySlugAction.php
@@ -10,7 +10,6 @@ use Sylius\ShopApiPlugin\Model\PaginatorDetails;
 use Sylius\ShopApiPlugin\ViewRepository\ProductReviewsViewRepositoryInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 final class ShowProductReviewsBySlugAction
 {

--- a/src/Controller/Product/ShowProductReviewsBySlugAction.php
+++ b/src/Controller/Product/ShowProductReviewsBySlugAction.php
@@ -30,13 +30,9 @@ final class ShowProductReviewsBySlugAction
 
     public function __invoke(Request $request): Response
     {
-        if (!$request->query->has('channel')) {
-            throw new NotFoundHttpException('Cannot find product without channel provided');
-        }
-
         $page = $this->productReviewsViewRepository->getByProductSlug(
             $request->attributes->get('slug'),
-            $request->query->get('channel'),
+            $request->attributes->get('channelCode'),
             new PaginatorDetails($request->attributes->get('_route'), $request->query->all()),
             $request->query->get('locale')
         );

--- a/src/EventListener/UserRegistrationListener.php
+++ b/src/EventListener/UserRegistrationListener.php
@@ -59,6 +59,6 @@ final class UserRegistrationListener
         }
 
         $this->bus->handle(new GenerateVerificationToken($event->email()));
-        $this->bus->handle(new SendVerificationToken($event->email()));
+        $this->bus->handle(new SendVerificationToken($event->email(), $event->channelCode()));
     }
 }

--- a/src/EventSubscriber/RequestChannelSubscriber.php
+++ b/src/EventSubscriber/RequestChannelSubscriber.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\ShopApiPlugin\EventSubscriber;
+
+use Sylius\ShopApiPlugin\Checker\ChannelExistenceCheckerInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+final class RequestChannelSubscriber implements EventSubscriberInterface
+{
+    /** @var ChannelExistenceCheckerInterface */
+    private $channelExistenceChecker;
+
+    public function __construct(ChannelExistenceCheckerInterface $channelExistenceChecker)
+    {
+        $this->channelExistenceChecker = $channelExistenceChecker;
+    }
+
+    public function checkChannelCode(FilterControllerEvent $event): void
+    {
+        $requestAttributes = $event->getRequest()->attributes;
+
+        if (!$requestAttributes->has('channelCode')) {
+            return;
+        }
+
+        $this->channelExistenceChecker->withCode($requestAttributes->get('channelCode'));
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::CONTROLLER => 'checkChannelCode',
+        ];
+    }
+}

--- a/src/Factory/ProductViewFactory.php
+++ b/src/Factory/ProductViewFactory.php
@@ -59,6 +59,7 @@ final class ProductViewFactory implements ProductViewFactoryInterface
         $productView->shortDescription = $translation->getShortDescription();
         $productView->metaKeywords = $translation->getMetaKeywords();
         $productView->metaDescription = $translation->getMetaDescription();
+        $productView->channelCode = $channel->getCode();
 
         /** @var ProductImageInterface $image */
         foreach ($product->getImages() as $image) {

--- a/src/Handler/SendResetPasswordTokenHandler.php
+++ b/src/Handler/SendResetPasswordTokenHandler.php
@@ -35,6 +35,10 @@ final class SendResetPasswordTokenHandler
         Assert::notNull($user, sprintf('User with %s email has not been found.', $email));
         Assert::notNull($user->getPasswordResetToken(), sprintf('User with %s email has not verification token defined.', $email));
 
-        $this->sender->send(Emails::EMAIL_RESET_PASSWORD_TOKEN, [$email], ['user' => $user]);
+        $this->sender->send(
+            Emails::EMAIL_RESET_PASSWORD_TOKEN,
+            [$email],
+            ['user' => $user, 'channelCode' => $resendResetPasswordToken->channelCode()]
+        );
     }
 }

--- a/src/Handler/SendVerificationTokenHandler.php
+++ b/src/Handler/SendVerificationTokenHandler.php
@@ -35,6 +35,10 @@ final class SendVerificationTokenHandler
         Assert::notNull($user, sprintf('User with %s email has not been found.', $email));
         Assert::notNull($user->getEmailVerificationToken(), sprintf('User with %s email has not verification token defined.', $email));
 
-        $this->sender->send(Emails::EMAIL_VERIFICATION_TOKEN, [$email], ['user' => $user]);
+        $this->sender->send(
+            Emails::EMAIL_VERIFICATION_TOKEN,
+            [$email],
+            ['user' => $user, 'channelCode' => $resendVerificationToken->channelCode()]
+        );
     }
 }

--- a/src/Request/ResendVerificationTokenRequest.php
+++ b/src/Request/ResendVerificationTokenRequest.php
@@ -12,13 +12,17 @@ final class ResendVerificationTokenRequest
     /** @var string */
     private $email;
 
+    /** @var string */
+    private $channelCode;
+
     public function __construct(Request $request)
     {
         $this->email = $request->request->get('email');
+        $this->channelCode = $request->attributes->get('channelCode');
     }
 
     public function getCommand(): SendVerificationToken
     {
-        return new SendVerificationToken($this->email);
+        return new SendVerificationToken($this->email, $this->channelCode);
     }
 }

--- a/src/Resources/config/routing.yml
+++ b/src/Resources/config/routing.yml
@@ -1,39 +1,39 @@
 sylius_shop_api_cart:
     resource: "@ShopApiPlugin/Resources/config/routing/cart.yml"
-    prefix: /shop-api
+    prefix: /shop-api/{channelCode}
 
 sylius_shop_api_product_by_slug:
     resource: "@ShopApiPlugin/Resources/config/routing/productBySlug.yml"
-    prefix: /shop-api
+    prefix: /shop-api/{channelCode}
 
 sylius_shop_api_product_by_code:
     resource: "@ShopApiPlugin/Resources/config/routing/productByCode.yml"
-    prefix: /shop-api
+    prefix: /shop-api/{channelCode}
 
 sylius_shop_api_taxon:
     resource: "@ShopApiPlugin/Resources/config/routing/taxon.yml"
-    prefix: /shop-api
+    prefix: /shop-api/{channelCode}
 
 sylius_shop_api_register:
     resource: "@ShopApiPlugin/Resources/config/routing/register.yml"
-    prefix: /shop-api
+    prefix: /shop-api/{channelCode}
 
 sylius_shop_api_checkout:
     resource: "@ShopApiPlugin/Resources/config/routing/checkout.yml"
-    prefix: /shop-api/checkout
+    prefix: /shop-api/{channelCode}/checkout
 
 sylius_shop_api_customer:
     resource: "@ShopApiPlugin/Resources/config/routing/customer.yml"
-    prefix: /shop-api
+    prefix: /shop-api/{channelCode}
 
 sylius_shop_api_product_list:
     resource: "@ShopApiPlugin/Resources/config/routing/productList.yml"
-    prefix: /shop-api
+    prefix: /shop-api/{channelCode}
 
 sylius_shop_api_address_book:
     resource: "@ShopApiPlugin/Resources/config/routing/address_book.yml"
-    prefix: /shop-api
+    prefix: /shop-api/{channelCode}
 
 sylius_shop_api_order:
     resource: "@ShopApiPlugin/Resources/config/routing/order.yml"
-    prefix: /shop-api
+    prefix: /shop-api/{channelCode}

--- a/src/Resources/config/serializer/ProductView.yml
+++ b/src/Resources/config/serializer/ProductView.yml
@@ -48,4 +48,5 @@ Sylius\ShopApiPlugin\View\ProductView:
             href:
                 route: sylius_shop_api_product_show_details_by_slug
                 parameters:
+                    channelCode: "WEB_GB"
                     slug: expr(object.slug)

--- a/src/Resources/config/serializer/ProductView.yml
+++ b/src/Resources/config/serializer/ProductView.yml
@@ -11,6 +11,9 @@ Sylius\ShopApiPlugin\View\ProductView:
         slug:
             expose: true
             type: string
+        channelCode:
+            expose: true
+            type: string
         breadcrumb:
             expose: true
             type: string
@@ -48,5 +51,5 @@ Sylius\ShopApiPlugin\View\ProductView:
             href:
                 route: sylius_shop_api_product_show_details_by_slug
                 parameters:
-                    channelCode: "WEB_GB"
+                    channelCode: expr(object.channelCode)
                     slug: expr(object.slug)

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -29,6 +29,10 @@
             <argument type="service" id="sylius.promotion_coupon_eligibility_checker"/>
         </service>
 
+        <service id="sylius.shop_api_plugin.checker.channel_existence" class="Sylius\ShopApiPlugin\Checker\ChannelExistenceChecker">
+            <argument type="service" id="sylius.repository.channel"/>
+        </service>
+
         <service id="sylius.shop_api_plugin.event_listener.user_registration_listener" class="Sylius\ShopApiPlugin\EventListener\UserRegistrationListener">
             <argument type="service" id="tactician.commandbus" />
             <argument type="service" id="sylius.repository.channel"/>

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -41,6 +41,11 @@
             <tag name="kernel.event_listener" event="sylius.customer.post_api_registered" method="handleUserVerification" />
         </service>
 
+        <service id="sylius.shop_api_plugin.event_subscriber.request_channel" class="Sylius\ShopApiPlugin\EventSubscriber\RequestChannelSubscriber">
+            <argument type="service" id="sylius.shop_api_plugin.checker.channel_existence" />
+            <tag name="kernel.event_subscriber"/>
+        </service>
+
         <service id="sylius.shop_api_plugin.generator.product_breadcrumb_generator" class="Sylius\ShopApiPlugin\Generator\ProductBreadcrumbGenerator" />
 
         <service id="sylius.shop_api_plugin.event_listener.request_locale_setter" class="Sylius\ShopApiPlugin\EventListener\RequestLocaleSetter" >

--- a/src/Resources/views/Email/passwordReset.html.twig
+++ b/src/Resources/views/Email/passwordReset.html.twig
@@ -3,7 +3,7 @@
 {% endblock %}
 
 {% block body %}
-    {% set url = url('sylius_shop_api_password_reset', {'channelCode': 'WEB_GB', 'token': user.passwordResetToken}) %}
+    {% set url = url('sylius_shop_api_password_reset', {'channelCode': channelCode, 'token': user.passwordResetToken}) %}
     {% autoescape %}
         <h3>Hello {{ user.username }}</h3>
 

--- a/src/Resources/views/Email/passwordReset.html.twig
+++ b/src/Resources/views/Email/passwordReset.html.twig
@@ -3,7 +3,7 @@
 {% endblock %}
 
 {% block body %}
-    {% set url = url('sylius_shop_api_password_reset', { 'token': user.passwordResetToken}) %}
+    {% set url = url('sylius_shop_api_password_reset', {'channelCode': 'WEB_GB', 'token': user.passwordResetToken}) %}
     {% autoescape %}
         <h3>Hello {{ user.username }}</h3>
 

--- a/src/Resources/views/Email/verification.html.twig
+++ b/src/Resources/views/Email/verification.html.twig
@@ -3,7 +3,7 @@
 {% endblock %}
 
 {% block body %}
-    {% set url = url('sylius_shop_api_user_verification', {'channelCode': 'WEB_GB', 'token': user.emailVerificationToken}) %}
+    {% set url = url('sylius_shop_api_user_verification', {'channelCode': channelCode, 'token': user.emailVerificationToken}) %}
     {% autoescape %}
         To verify your email address - please visit {{ url|raw }}
     {% endautoescape %}

--- a/src/Resources/views/Email/verification.html.twig
+++ b/src/Resources/views/Email/verification.html.twig
@@ -3,7 +3,7 @@
 {% endblock %}
 
 {% block body %}
-    {% set url = url('sylius_shop_api_user_verification', { 'token': user.emailVerificationToken}) %}
+    {% set url = url('sylius_shop_api_user_verification', {'channelCode': 'WEB_GB', 'token': user.emailVerificationToken}) %}
     {% autoescape %}
         To verify your email address - please visit {{ url|raw }}
     {% endautoescape %}

--- a/src/View/ProductView.php
+++ b/src/View/ProductView.php
@@ -16,6 +16,9 @@ class ProductView
     public $slug;
 
     /** @var string */
+    public $channelCode;
+
+    /** @var string */
     public $breadcrumb;
 
     /** @var string */

--- a/src/ViewRepository/ProductCatalogViewRepository.php
+++ b/src/ViewRepository/ProductCatalogViewRepository.php
@@ -64,6 +64,7 @@ final class ProductCatalogViewRepository implements ProductCatalogViewRepository
 
         Assert::notNull($taxon, sprintf('Taxon with slug %s in locale %s has not been found', $taxonSlug, $localeCode));
         $paginatorDetails->addToParameters('taxonSlug', $taxonSlug);
+        $paginatorDetails->addToParameters('channelCode', $channelCode);
 
         return $this->findByTaxon($taxon, $channel, $paginatorDetails, $localeCode);
     }
@@ -78,6 +79,7 @@ final class ProductCatalogViewRepository implements ProductCatalogViewRepository
 
         Assert::notNull($taxon, sprintf('Taxon with code %s has not been found', $taxonCode));
         $paginatorDetails->addToParameters('code', $taxonCode);
+        $paginatorDetails->addToParameters('channelCode', $channelCode);
 
         return $this->findByTaxon($taxon, $channel, $paginatorDetails, $localeCode);
     }

--- a/src/ViewRepository/ProductReviewsViewRepository.php
+++ b/src/ViewRepository/ProductReviewsViewRepository.php
@@ -62,6 +62,7 @@ final class ProductReviewsViewRepository implements ProductReviewsViewRepository
         $reviews = $this->productReviewRepository->findAcceptedByProductSlugAndChannel($productSlug, $localeCode, $channel);
 
         $paginatorDetails->addToParameters('slug', $productSlug);
+        $paginatorDetails->addToParameters('channelCode', $channelCode);
 
         return $this->createProductReviewPage($reviews, $paginatorDetails);
     }
@@ -76,6 +77,7 @@ final class ProductReviewsViewRepository implements ProductReviewsViewRepository
         $reviews = $this->productReviewRepository->findBy(['reviewSubject' => $product->getId(), 'status' => ReviewInterface::STATUS_ACCEPTED]);
 
         $paginatorDetails->addToParameters('code', $productCode);
+        $paginatorDetails->addToParameters('channelCode', $channelCode);
 
         return $this->createProductReviewPage($reviews, $paginatorDetails);
     }

--- a/tests/Controller/AddressBookCreateAddressApiTest.php
+++ b/tests/Controller/AddressBookCreateAddressApiTest.php
@@ -162,7 +162,7 @@ EOT;
         $this->client->request('POST', '/shop-api/SPACE_KLINGON/address-book', [], [], self::$acceptAndContentTypeHeader, $data);
 
         $response = $this->client->getResponse();
-        $this->assertResponse($response, 'address_book/channel_has_not_been_found_response', Response::HTTP_NOT_FOUND);
+        $this->assertResponse($response, 'channel_has_not_been_found_response', Response::HTTP_NOT_FOUND);
     }
 
 }

--- a/tests/Controller/AddressBookCreateAddressApiTest.php
+++ b/tests/Controller/AddressBookCreateAddressApiTest.php
@@ -23,7 +23,7 @@ final class AddressBookCreateAddressApiTest extends JsonApiTestCase
      */
     public function it_allows_user_to_add_new_address_to_address_book()
     {
-        $this->loadFixturesFromFiles(['customer.yml', 'country.yml']);
+        $this->loadFixturesFromFiles(['channel.yml', 'customer.yml', 'country.yml']);
         $this->logInUser('oliver@queen.com', '123password');
 
         $data =
@@ -64,7 +64,7 @@ EOT;
      */
     public function it_does_not_allow_user_to_add_new_address_to_address_book_without_passing_required_data()
     {
-        $this->loadFixturesFromFiles(['customer.yml', 'country.yml']);
+        $this->loadFixturesFromFiles(['channel.yml', 'customer.yml', 'country.yml']);
         $this->logInUser('oliver@queen.com', '123password');
 
         $data =
@@ -91,7 +91,7 @@ EOT;
      */
     public function it_does_not_allow_user_to_add_new_address_to_address_book_without_passing_correct_country_code()
     {
-        $this->loadFixturesFromFiles(['customer.yml', 'country.yml']);
+        $this->loadFixturesFromFiles(['channel.yml', 'customer.yml', 'country.yml']);
         $this->logInUser('oliver@queen.com', '123password');
 
         $data =
@@ -117,7 +117,7 @@ EOT;
      */
     public function it_does_not_allow_user_to_add_new_address_to_address_book_without_passing_correct_province_code()
     {
-        $this->loadFixturesFromFiles(['customer.yml', 'country.yml']);
+        $this->loadFixturesFromFiles(['channel.yml', 'customer.yml', 'country.yml']);
         $this->logInUser('oliver@queen.com', '123password');
 
         $data =
@@ -138,4 +138,31 @@ EOT;
         $response = $this->client->getResponse();
         $this->assertResponse($response, 'address_book/validation_create_address_book_with_wrong_province_response', Response::HTTP_INTERNAL_SERVER_ERROR);
     }
+
+    /**
+     * @test
+     */
+    public function it_does_not_allow_user_to_add_new_address_to_address_book_in_non_existent_channel()
+    {
+        $this->loadFixturesFromFiles(['channel.yml', 'customer.yml', 'country.yml']);
+        $this->logInUser('oliver@queen.com', '123password');
+
+        $data =
+            <<<EOT
+        {
+            "firstName": "Davor",
+            "lastName": "Duhovic",
+            "countryCode": "WRONG_COUNTRY_NAME",
+            "street": "Marmontova 21",
+            "city": "Split",
+            "postcode": "2100"
+        }
+EOT;
+
+        $this->client->request('POST', '/shop-api/SPACE_KLINGON/address-book', [], [], self::$acceptAndContentTypeHeader, $data);
+
+        $response = $this->client->getResponse();
+        $this->assertResponse($response, 'address_book/channel_has_not_been_found_response', Response::HTTP_NOT_FOUND);
+    }
+
 }

--- a/tests/Controller/AddressBookCreateAddressApiTest.php
+++ b/tests/Controller/AddressBookCreateAddressApiTest.php
@@ -164,5 +164,4 @@ EOT;
         $response = $this->client->getResponse();
         $this->assertResponse($response, 'channel_has_not_been_found_response', Response::HTTP_NOT_FOUND);
     }
-
 }

--- a/tests/Controller/AddressBookCreateAddressApiTest.php
+++ b/tests/Controller/AddressBookCreateAddressApiTest.php
@@ -39,7 +39,7 @@ final class AddressBookCreateAddressApiTest extends JsonApiTestCase
         }
 EOT;
 
-        $this->client->request('POST', '/shop-api/address-book', [], [], self::$acceptAndContentTypeHeader, $data);
+        $this->client->request('POST', '/shop-api/WEB_GB/address-book', [], [], self::$acceptAndContentTypeHeader, $data);
 
         $response = $this->client->getResponse();
         $this->assertResponse($response, 'address_book/add_address_response', Response::HTTP_CREATED);
@@ -80,7 +80,7 @@ EOT;
         }
 EOT;
 
-        $this->client->request('POST', '/shop-api/address-book', [], [], self::$acceptAndContentTypeHeader, $data);
+        $this->client->request('POST', '/shop-api/WEB_GB/address-book', [], [], self::$acceptAndContentTypeHeader, $data);
 
         $response = $this->client->getResponse();
         $this->assertResponse($response, 'address_book/validation_create_address_book_response', Response::HTTP_BAD_REQUEST);
@@ -106,7 +106,7 @@ EOT;
         }
 EOT;
 
-        $this->client->request('POST', '/shop-api/address-book', [], [], self::$acceptAndContentTypeHeader, $data);
+        $this->client->request('POST', '/shop-api/WEB_GB/address-book', [], [], self::$acceptAndContentTypeHeader, $data);
 
         $response = $this->client->getResponse();
         $this->assertResponse($response, 'address_book/validation_create_address_book_with_wrong_country_response', Response::HTTP_INTERNAL_SERVER_ERROR);
@@ -133,7 +133,7 @@ EOT;
         }
 EOT;
 
-        $this->client->request('POST', '/shop-api/address-book', [], [], self::$acceptAndContentTypeHeader, $data);
+        $this->client->request('POST', '/shop-api/WEB_GB/address-book', [], [], self::$acceptAndContentTypeHeader, $data);
 
         $response = $this->client->getResponse();
         $this->assertResponse($response, 'address_book/validation_create_address_book_with_wrong_province_response', Response::HTTP_INTERNAL_SERVER_ERROR);

--- a/tests/Controller/AddressBookRemoveAddressApiTest.php
+++ b/tests/Controller/AddressBookRemoveAddressApiTest.php
@@ -29,7 +29,7 @@ final class AddressBookRemoveAddressApiTest extends JsonApiTestCase
         /** @var AddressInterface $address */
         $address = $addressRepository->findOneBy(['street' => 'Kupreska']);
 
-        $this->client->request('DELETE', sprintf('/shop-api/address-book/%s', $address->getId()), [], [], self::$acceptAndContentTypeHeader);
+        $this->client->request('DELETE', sprintf('/shop-api/WEB_GB/address-book/%s', $address->getId()), [], [], self::$acceptAndContentTypeHeader);
         $response = $this->client->getResponse();
 
         $address = $addressRepository->findOneBy(['street' => 'Kupreska']);
@@ -46,7 +46,7 @@ final class AddressBookRemoveAddressApiTest extends JsonApiTestCase
         $this->loadFixturesFromFiles(['customer.yml', 'country.yml', 'address.yml']);
         $this->logInUser('oliver@queen.com', '123password');
 
-        $this->client->request('DELETE', sprintf('/shop-api/address-book/-1'), [], [], self::$acceptAndContentTypeHeader);
+        $this->client->request('DELETE', sprintf('/shop-api/WEB_GB/address-book/-1'), [], [], self::$acceptAndContentTypeHeader);
         $response = $this->client->getResponse();
 
         $this->assertResponseCode($response, Response::HTTP_BAD_REQUEST);
@@ -65,7 +65,7 @@ final class AddressBookRemoveAddressApiTest extends JsonApiTestCase
         /** @var AddressInterface $address */
         $address = $addressRepository->findOneBy(['street' => 'Vukovarska']);
 
-        $this->client->request('DELETE', sprintf('/shop-api/address-book/%s', $address->getId()), [], [], self::$acceptAndContentTypeHeader);
+        $this->client->request('DELETE', sprintf('/shop-api/WEB_GB/address-book/%s', $address->getId()), [], [], self::$acceptAndContentTypeHeader);
         $response = $this->client->getResponse();
 
         $this->assertResponseCode($response, Response::HTTP_BAD_REQUEST);

--- a/tests/Controller/AddressBookRemoveAddressApiTest.php
+++ b/tests/Controller/AddressBookRemoveAddressApiTest.php
@@ -21,7 +21,7 @@ final class AddressBookRemoveAddressApiTest extends JsonApiTestCase
      */
     public function it_deletes_address_from_address_book()
     {
-        $this->loadFixturesFromFiles(['customer.yml', 'country.yml', 'address.yml']);
+        $this->loadFixturesFromFiles(['channel.yml', 'customer.yml', 'country.yml', 'address.yml']);
         $this->logInUser('oliver@queen.com', '123password');
 
         /** @var AddressRepositoryInterface $addressRepository */
@@ -43,7 +43,7 @@ final class AddressBookRemoveAddressApiTest extends JsonApiTestCase
      */
     public function it_returns_bad_request_exception_if_address_has_not_been_found()
     {
-        $this->loadFixturesFromFiles(['customer.yml', 'country.yml', 'address.yml']);
+        $this->loadFixturesFromFiles(['channel.yml', 'customer.yml', 'country.yml', 'address.yml']);
         $this->logInUser('oliver@queen.com', '123password');
 
         $this->client->request('DELETE', sprintf('/shop-api/WEB_GB/address-book/-1'), [], [], self::$acceptAndContentTypeHeader);
@@ -57,7 +57,7 @@ final class AddressBookRemoveAddressApiTest extends JsonApiTestCase
      */
     public function it_validates_if_current_user_is_owner_of_address()
     {
-        $this->loadFixturesFromFiles(['customer.yml', 'country.yml', 'address.yml']);
+        $this->loadFixturesFromFiles(['channel.yml', 'customer.yml', 'country.yml', 'address.yml']);
         $this->logInUser('oliver@queen.com', '123password');
 
         /** @var AddressRepositoryInterface $addressRepository */
@@ -69,5 +69,19 @@ final class AddressBookRemoveAddressApiTest extends JsonApiTestCase
         $response = $this->client->getResponse();
 
         $this->assertResponseCode($response, Response::HTTP_BAD_REQUEST);
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_allow_user_to_delete_address_in_non_existent_channel()
+    {
+        $this->loadFixturesFromFiles(['channel.yml', 'customer.yml', 'country.yml', 'address.yml']);
+        $this->logInUser('oliver@queen.com', '123password');
+
+        $this->client->request('DELETE', sprintf('/shop-api/SPACE_KLINGON/address-book/1'), [], [], self::$acceptAndContentTypeHeader);
+        $response = $this->client->getResponse();
+
+        $this->assertResponse($response, 'channel_has_not_been_found_response', Response::HTTP_NOT_FOUND);
     }
 }

--- a/tests/Controller/AddressBookSetDefaultAddressApiTest.php
+++ b/tests/Controller/AddressBookSetDefaultAddressApiTest.php
@@ -31,7 +31,7 @@ final class AddressBookSetDefaultAddressApiTest extends JsonApiTestCase
         /** @var ResourceInterface $address */
         $address = $addressRepository->findOneBy(['street' => 'Kupreska']);
 
-        $this->client->request('PATCH', sprintf('/shop-api/address-book/%s/default', $address->getId()), [], [], self::$acceptAndContentTypeHeader);
+        $this->client->request('PATCH', sprintf('/shop-api/WEB_GB/address-book/%s/default', $address->getId()), [], [], self::$acceptAndContentTypeHeader);
         $response = $this->client->getResponse();
         $this->assertResponseCode($response, Response::HTTP_NO_CONTENT);
 

--- a/tests/Controller/AddressBookSetDefaultAddressApiTest.php
+++ b/tests/Controller/AddressBookSetDefaultAddressApiTest.php
@@ -23,7 +23,7 @@ final class AddressBookSetDefaultAddressApiTest extends JsonApiTestCase
      */
     public function it_sets_given_address_as_default()
     {
-        $this->loadFixturesFromFiles(['customer.yml', 'country.yml', 'address.yml']);
+        $this->loadFixturesFromFiles(['channel.yml', 'customer.yml', 'country.yml', 'address.yml']);
         $this->logInUser('oliver@queen.com', '123password');
 
         /** @var AddressRepositoryInterface $addressRepository */
@@ -44,5 +44,19 @@ final class AddressBookSetDefaultAddressApiTest extends JsonApiTestCase
             $shopUser->getCustomer()->getDefaultAddress()->getId(),
             $address->getId()
         );
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_allow_to_set_address_as_default_in_non_existent_channel()
+    {
+        $this->loadFixturesFromFiles(['channel.yml', 'customer.yml', 'country.yml', 'address.yml']);
+        $this->logInUser('oliver@queen.com', '123password');
+
+        $this->client->request('PATCH', sprintf('/shop-api/SPACE_KLINGON/address-book/1/default'), [], [], self::$acceptAndContentTypeHeader);
+        $response = $this->client->getResponse();
+
+        $this->assertResponse($response, 'channel_has_not_been_found_response', Response::HTTP_NOT_FOUND);
     }
 }

--- a/tests/Controller/AddressBookShowApiTest.php
+++ b/tests/Controller/AddressBookShowApiTest.php
@@ -19,7 +19,7 @@ final class AddressBookShowApiTest extends JsonApiTestCase
         $this->loadFixturesFromFiles(['customer.yml', 'country.yml', 'address.yml']);
         $this->logInUser('oliver@queen.com', '123password');
 
-        $this->client->request('GET', '/shop-api/address-book', [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('GET', '/shop-api/WEB_GB/address-book', [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'address_book/show_address_book_response', Response::HTTP_OK);
@@ -30,7 +30,7 @@ final class AddressBookShowApiTest extends JsonApiTestCase
      */
     public function it_returns_an_unauthorized_exception_if_there_is_no_logged_in_user()
     {
-        $this->client->request('GET', '/shop-api/address-book', [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('GET', '/shop-api/WEB_GB/address-book', [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponseCode($response, Response::HTTP_UNAUTHORIZED);

--- a/tests/Controller/AddressBookShowApiTest.php
+++ b/tests/Controller/AddressBookShowApiTest.php
@@ -16,7 +16,7 @@ final class AddressBookShowApiTest extends JsonApiTestCase
      */
     public function it_shows_address_book()
     {
-        $this->loadFixturesFromFiles(['customer.yml', 'country.yml', 'address.yml']);
+        $this->loadFixturesFromFiles(['channel.yml', 'customer.yml', 'country.yml', 'address.yml']);
         $this->logInUser('oliver@queen.com', '123password');
 
         $this->client->request('GET', '/shop-api/WEB_GB/address-book', [], [], ['ACCEPT' => 'application/json']);
@@ -30,9 +30,24 @@ final class AddressBookShowApiTest extends JsonApiTestCase
      */
     public function it_returns_an_unauthorized_exception_if_there_is_no_logged_in_user()
     {
+        $this->loadFixturesFromFile('channel.yml');
+
         $this->client->request('GET', '/shop-api/WEB_GB/address-book', [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponseCode($response, Response::HTTP_UNAUTHORIZED);
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_show_address_book_in_non_existent_channel()
+    {
+        $this->loadFixturesFromFile('channel.yml');
+
+        $this->client->request('GET', '/shop-api/SPACE_KLINGON/address-book', [], [], ['ACCEPT' => 'application/json']);
+        $response = $this->client->getResponse();
+
+        $this->assertResponse($response, 'channel_has_not_been_found_response', Response::HTTP_NOT_FOUND);
     }
 }

--- a/tests/Controller/AddressBookUpdateAddressApiTest.php
+++ b/tests/Controller/AddressBookUpdateAddressApiTest.php
@@ -21,7 +21,7 @@ final class AddressBookUpdateAddressApiTest extends JsonApiTestCase
      */
     public function it_updates_address_in_address_book()
     {
-        $this->loadFixturesFromFiles(['customer.yml', 'country.yml', 'address.yml']);
+        $this->loadFixturesFromFiles(['channel.yml', 'customer.yml', 'country.yml', 'address.yml']);
         $this->logInUser('oliver@queen.com', '123password');
 
         /** @var AddressRepositoryInterface $addressRepository */
@@ -64,7 +64,7 @@ EOT;
      */
     public function it_does_not_allow_to_update_address_if_country_or_province_code_are_not_valid()
     {
-        $this->loadFixturesFromFiles(['customer.yml', 'country.yml', 'address.yml']);
+        $this->loadFixturesFromFiles(['channel.yml', 'customer.yml', 'country.yml', 'address.yml']);
         $this->logInUser('oliver@queen.com', '123password');
 
         /** @var AddressRepositoryInterface $addressRepository */
@@ -97,7 +97,7 @@ EOT;
      */
     public function it_does_not_allow_to_update_address_without_passing_required_data()
     {
-        $this->loadFixturesFromFiles(['customer.yml', 'country.yml', 'address.yml']);
+        $this->loadFixturesFromFiles(['channel.yml', 'customer.yml', 'country.yml', 'address.yml']);
         $this->logInUser('oliver@queen.com', '123password');
 
         /** @var AddressRepositoryInterface $addressRepository */
@@ -120,5 +120,33 @@ EOT;
         $response = $this->client->getResponse();
 
         $this->assertResponseCode($response, Response::HTTP_BAD_REQUEST);
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_allow_to_update_address_in_non_existent_channel()
+    {
+        $this->loadFixturesFromFile('channel.yml');
+
+        $data =
+<<<EOT
+        {
+            "firstName": "New name",
+            "lastName": "New lastName",
+            "company": "Locastic",
+            "street": "New street",
+            "countryCode": "WRONG_CODE",
+            "provinceCode": "WRONG_CODE",
+            "city": "New city",
+            "postcode": "2000",
+            "phoneNumber": "0918972132"
+        }
+EOT;
+
+        $this->client->request('PUT', '/shop-api/SPACE_KLINGON/address-book/1', [], [], self::$contentTypeHeader, $data);
+        $response = $this->client->getResponse();
+
+        $this->assertResponse($response, 'channel_has_not_been_found_response', Response::HTTP_NOT_FOUND);
     }
 }

--- a/tests/Controller/AddressBookUpdateAddressApiTest.php
+++ b/tests/Controller/AddressBookUpdateAddressApiTest.php
@@ -43,7 +43,7 @@ final class AddressBookUpdateAddressApiTest extends JsonApiTestCase
             "phoneNumber": "0918972132"
         }
 EOT;
-        $this->client->request('PUT', sprintf('/shop-api/address-book/%s', $address->getId()), [], [], self::$contentTypeHeader, $data);
+        $this->client->request('PUT', sprintf('/shop-api/WEB_GB/address-book/%s', $address->getId()), [], [], self::$contentTypeHeader, $data);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'address_book/update_address', Response::HTTP_OK);
@@ -86,7 +86,7 @@ EOT;
             "phoneNumber": "0918972132"
         }
 EOT;
-        $this->client->request('PUT', sprintf('/shop-api/address-book/%s', $address->getId()), [], [], self::$contentTypeHeader, $data);
+        $this->client->request('PUT', sprintf('/shop-api/WEB_GB/address-book/%s', $address->getId()), [], [], self::$contentTypeHeader, $data);
         $response = $this->client->getResponse();
 
         $this->assertResponseCode($response, Response::HTTP_INTERNAL_SERVER_ERROR);
@@ -116,7 +116,7 @@ EOT;
             "postcode": "",
         }
 EOT;
-        $this->client->request('PUT', sprintf('/shop-api/address-book/%s', $address->getId()), [], [], self::$contentTypeHeader, $data);
+        $this->client->request('PUT', sprintf('/shop-api/WEB_GB/address-book/%s', $address->getId()), [], [], self::$contentTypeHeader, $data);
         $response = $this->client->getResponse();
 
         $this->assertResponseCode($response, Response::HTTP_BAD_REQUEST);

--- a/tests/Controller/CartAddCouponShopApiTest.php
+++ b/tests/Controller/CartAddCouponShopApiTest.php
@@ -172,7 +172,7 @@ EOT;
      */
     public function it_does_not_allow_to_add_promotion_code_in_non_existent_channel()
     {
-        $this->loadFixturesFromFiles(['channel.yml' ,'shop.yml', 'coupon_based_promotion.yml']);
+        $this->loadFixturesFromFiles(['channel.yml', 'shop.yml', 'coupon_based_promotion.yml']);
 
         $token = 'SDAOSLEFNWU35H3QLI5325';
 

--- a/tests/Controller/CartAddCouponShopApiTest.php
+++ b/tests/Controller/CartAddCouponShopApiTest.php
@@ -34,7 +34,7 @@ final class CartAddCouponShopApiTest extends JsonApiTestCase
         }
 EOT;
 
-        $this->client->request('PUT', sprintf('/shop-api/carts/%s/coupon', $token), [], [], static::$acceptAndContentTypeHeader, $data);
+        $this->client->request('PUT', sprintf('/shop-api/WEB_GB/carts/%s/coupon', $token), [], [], static::$acceptAndContentTypeHeader, $data);
 
         $response = $this->client->getResponse();
 
@@ -55,7 +55,7 @@ EOT;
         $bus->handle(new PickupCart($token, 'WEB_GB'));
         $bus->handle(new PutSimpleItemToCart($token, 'LOGAN_MUG_CODE', 5));
 
-        $this->client->request('PUT', sprintf('/shop-api/carts/%s/coupon', $token), [], [], static::$acceptAndContentTypeHeader);
+        $this->client->request('PUT', sprintf('/shop-api/WEB_GB/carts/%s/coupon', $token), [], [], static::$acceptAndContentTypeHeader);
 
         $response = $this->client->getResponse();
 
@@ -76,7 +76,7 @@ EOT;
         }
 EOT;
 
-        $this->client->request('PUT', '/shop-api/carts/WRONGTOKEN/coupon', [], [], static::$acceptAndContentTypeHeader, $data);
+        $this->client->request('PUT', '/shop-api/WEB_GB/carts/WRONGTOKEN/coupon', [], [], static::$acceptAndContentTypeHeader, $data);
 
         $response = $this->client->getResponse();
 
@@ -104,7 +104,7 @@ EOT;
         }
 EOT;
 
-        $this->client->request('PUT', sprintf('/shop-api/carts/%s/coupon', $token), [], [], static::$acceptAndContentTypeHeader, $data);
+        $this->client->request('PUT', sprintf('/shop-api/WEB_GB/carts/%s/coupon', $token), [], [], static::$acceptAndContentTypeHeader, $data);
 
         $response = $this->client->getResponse();
 
@@ -132,7 +132,7 @@ EOT;
         }
 EOT;
 
-        $this->client->request('PUT', sprintf('/shop-api/carts/%s/coupon', $token), [], [], static::$acceptAndContentTypeHeader, $data);
+        $this->client->request('PUT', sprintf('/shop-api/WEB_GB/carts/%s/coupon', $token), [], [], static::$acceptAndContentTypeHeader, $data);
 
         $response = $this->client->getResponse();
 
@@ -160,7 +160,7 @@ EOT;
         }
 EOT;
 
-        $this->client->request('PUT', sprintf('/shop-api/carts/%s/coupon', $token), [], [], static::$acceptAndContentTypeHeader, $data);
+        $this->client->request('PUT', sprintf('/shop-api/WEB_GB/carts/%s/coupon', $token), [], [], static::$acceptAndContentTypeHeader, $data);
 
         $response = $this->client->getResponse();
 

--- a/tests/Controller/CartAddCouponShopApiTest.php
+++ b/tests/Controller/CartAddCouponShopApiTest.php
@@ -18,7 +18,7 @@ final class CartAddCouponShopApiTest extends JsonApiTestCase
      */
     public function it_allows_to_add_promotion_coupon_to_the_cart()
     {
-        $this->loadFixturesFromFiles(['shop.yml', 'coupon_based_promotion.yml']);
+        $this->loadFixturesFromFiles(['channel.yml', 'shop.yml', 'coupon_based_promotion.yml']);
 
         $token = 'SDAOSLEFNWU35H3QLI5325';
 
@@ -46,7 +46,7 @@ EOT;
      */
     public function it_does_not_allow_to_add_promotion_if_coupon_is_not_specified()
     {
-        $this->loadFixturesFromFiles(['shop.yml']);
+        $this->loadFixturesFromFiles(['channel.yml', 'shop.yml']);
 
         $token = 'SDAOSLEFNWU35H3QLI5325';
 
@@ -67,7 +67,7 @@ EOT;
      */
     public function it_does_not_allow_to_add_promotion_code_if_cart_does_not_exists()
     {
-        $this->loadFixturesFromFiles(['shop.yml']);
+        $this->loadFixturesFromFiles(['channel.yml', 'shop.yml']);
 
         $data =
 <<<EOT
@@ -88,7 +88,7 @@ EOT;
      */
     public function it_does_not_allow_to_add_promotion_code_if_promotion_code_does_not_exist()
     {
-        $this->loadFixturesFromFiles(['shop.yml']);
+        $this->loadFixturesFromFiles(['channel.yml', 'shop.yml']);
 
         $token = 'SDAOSLEFNWU35H3QLI5325';
 
@@ -116,7 +116,7 @@ EOT;
      */
     public function it_does_not_allow_to_add_promotion_code_if_code_is_invalid()
     {
-        $this->loadFixturesFromFiles(['shop.yml', 'coupon_based_promotion.yml']);
+        $this->loadFixturesFromFiles(['channel.yml', 'shop.yml', 'coupon_based_promotion.yml']);
 
         $token = 'SDAOSLEFNWU35H3QLI5325';
 
@@ -144,7 +144,7 @@ EOT;
      */
     public function it_does_not_allow_to_add_promotion_code_if_related_promotion_is_not_valid()
     {
-        $this->loadFixturesFromFiles(['shop.yml', 'coupon_based_promotion.yml']);
+        $this->loadFixturesFromFiles(['channel.yml', 'shop.yml', 'coupon_based_promotion.yml']);
 
         $token = 'SDAOSLEFNWU35H3QLI5325';
 
@@ -165,5 +165,32 @@ EOT;
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'cart/validation_coupon_not_valid_response', Response::HTTP_BAD_REQUEST);
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_allow_to_add_promotion_code_in_non_existent_channel()
+    {
+        $this->loadFixturesFromFiles(['channel.yml' ,'shop.yml', 'coupon_based_promotion.yml']);
+
+        $token = 'SDAOSLEFNWU35H3QLI5325';
+
+        /** @var CommandBus $bus */
+        $bus = $this->get('tactician.commandbus');
+        $bus->handle(new PickupCart($token, 'WEB_GB'));
+        $bus->handle(new PutSimpleItemToCart($token, 'LOGAN_MUG_CODE', 5));
+
+        $data =
+<<<EOT
+        {
+            "coupon": "PINEAPPLE"
+        }
+EOT;
+
+        $this->client->request('PUT', sprintf('/shop-api/SPACE_KLINGON/carts/%s/coupon', $token), [], [], static::$acceptAndContentTypeHeader, $data);
+        $response = $this->client->getResponse();
+
+        $this->assertResponse($response, 'channel_has_not_been_found_response', Response::HTTP_NOT_FOUND);
     }
 }

--- a/tests/Controller/CartChangeItemQuantityApiTest.php
+++ b/tests/Controller/CartChangeItemQuantityApiTest.php
@@ -20,7 +20,7 @@ final class CartChangeItemQuantityApiTest extends JsonApiTestCase
      */
     public function it_does_not_allow_to_change_quantity_if_cart_does_not_exists()
     {
-        $this->loadFixturesFromFiles(['shop.yml']);
+        $this->loadFixturesFromFiles(['channel.yml', 'shop.yml']);
 
         $data =
 <<<EOT
@@ -39,7 +39,7 @@ EOT;
      */
     public function it_changes_item_quantity()
     {
-        $this->loadFixturesFromFiles(['shop.yml']);
+        $this->loadFixturesFromFiles(['channel.yml', 'shop.yml']);
 
         $token = 'SDAOSLEFNWU35H3QLI5325';
 
@@ -65,7 +65,7 @@ EOT;
      */
     public function it_does_not_allow_to_set_quantity_lower_than_one()
     {
-        $this->loadFixturesFromFiles(['shop.yml']);
+        $this->loadFixturesFromFiles(['channel.yml', 'shop.yml']);
 
         $token = 'SDAOSLEFNWU35H3QLI5325';
 
@@ -91,7 +91,7 @@ EOT;
      */
     public function it_does_not_allow_to_change_quantity_without_quantity_defined()
     {
-        $this->loadFixturesFromFiles(['shop.yml']);
+        $this->loadFixturesFromFiles(['channel.yml', 'shop.yml']);
 
         $token = 'SDAOSLEFNWU35H3QLI5325';
 
@@ -111,7 +111,7 @@ EOT;
      */
     public function it_does_not_allow_to_change_quantity_if_cart_item_does_not_exists()
     {
-        $this->loadFixturesFromFiles(['shop.yml']);
+        $this->loadFixturesFromFiles(['channel.yml', 'shop.yml']);
 
         $token = 'SDAOSLEFNWU35H3QLI5325';
 
@@ -129,6 +129,31 @@ EOT;
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'cart/validation_cart_item_not_exists_response', Response::HTTP_BAD_REQUEST);
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_allow_to_change_item_quantity_in_non_existent_channel()
+    {
+        $this->loadFixturesFromFiles(['channel.yml', 'shop.yml']);
+
+        $token = 'SDAOSLEFNWU35H3QLI5325';
+
+        /** @var CommandBus $bus */
+        $bus = $this->get('tactician.commandbus');
+        $bus->handle(new PickupCart($token, 'WEB_GB'));
+
+        $data =
+<<<EOT
+        {
+            "quantity": 5
+        }
+EOT;
+        $this->client->request('PUT', '/shop-api/SPACE_KLINGON/carts/SDAOSLEFNWU35H3QLI5325/items/420', [], [], static::$acceptAndContentTypeHeader, $data);
+        $response = $this->client->getResponse();
+
+        $this->assertResponse($response, 'channel_has_not_been_found_response', Response::HTTP_NOT_FOUND);
     }
 
     private function getFirstOrderItemId(string $orderToken): string

--- a/tests/Controller/CartChangeItemQuantityApiTest.php
+++ b/tests/Controller/CartChangeItemQuantityApiTest.php
@@ -28,7 +28,7 @@ final class CartChangeItemQuantityApiTest extends JsonApiTestCase
             "quantity": 5
         }
 EOT;
-        $this->client->request('PUT', '/shop-api/carts/SDAOSLEFNWU35H3QLI5325/items/1', [], [], static::$acceptAndContentTypeHeader, $data);
+        $this->client->request('PUT', '/shop-api/WEB_GB/carts/SDAOSLEFNWU35H3QLI5325/items/1', [], [], static::$acceptAndContentTypeHeader, $data);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'cart/validation_cart_and_cart_item_not_exist_response', Response::HTTP_BAD_REQUEST);
@@ -54,7 +54,7 @@ EOT;
             "quantity": 5
         }
 EOT;
-        $this->client->request('PUT', '/shop-api/carts/SDAOSLEFNWU35H3QLI5325/items/' . $this->getFirstOrderItemId($token), [], [], static::$acceptAndContentTypeHeader, $data);
+        $this->client->request('PUT', '/shop-api/WEB_GB/carts/SDAOSLEFNWU35H3QLI5325/items/' . $this->getFirstOrderItemId($token), [], [], static::$acceptAndContentTypeHeader, $data);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'cart/filled_cart_with_simple_product_summary_response', Response::HTTP_OK);
@@ -80,7 +80,7 @@ EOT;
             "quantity": 0
         }
 EOT;
-        $this->client->request('PUT', '/shop-api/carts/SDAOSLEFNWU35H3QLI5325/items/' . $this->getFirstOrderItemId($token), [], [], static::$acceptAndContentTypeHeader, $data);
+        $this->client->request('PUT', '/shop-api/WEB_GB/carts/SDAOSLEFNWU35H3QLI5325/items/' . $this->getFirstOrderItemId($token), [], [], static::$acceptAndContentTypeHeader, $data);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'cart/validation_quantity_lower_than_one_response', Response::HTTP_BAD_REQUEST);
@@ -100,7 +100,7 @@ EOT;
         $bus->handle(new PickupCart($token, 'WEB_GB'));
         $bus->handle(new PutSimpleItemToCart($token, 'LOGAN_MUG_CODE', 3));
 
-        $this->client->request('PUT', '/shop-api/carts/SDAOSLEFNWU35H3QLI5325/items/' . $this->getFirstOrderItemId($token), [], [], static::$acceptAndContentTypeHeader);
+        $this->client->request('PUT', '/shop-api/WEB_GB/carts/SDAOSLEFNWU35H3QLI5325/items/' . $this->getFirstOrderItemId($token), [], [], static::$acceptAndContentTypeHeader);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'cart/validation_quantity_lower_than_one_response', Response::HTTP_BAD_REQUEST);
@@ -125,7 +125,7 @@ EOT;
             "quantity": 5
         }
 EOT;
-        $this->client->request('PUT', '/shop-api/carts/SDAOSLEFNWU35H3QLI5325/items/420', [], [], static::$acceptAndContentTypeHeader, $data);
+        $this->client->request('PUT', '/shop-api/WEB_GB/carts/SDAOSLEFNWU35H3QLI5325/items/420', [], [], static::$acceptAndContentTypeHeader, $data);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'cart/validation_cart_item_not_exists_response', Response::HTTP_BAD_REQUEST);

--- a/tests/Controller/CartDropCartApiTest.php
+++ b/tests/Controller/CartDropCartApiTest.php
@@ -24,12 +24,12 @@ final class CartDropCartApiTest extends JsonApiTestCase
     {
         $this->loadFixturesFromFiles(['shop.yml']);
 
-        $this->client->request('DELETE', '/shop-api/carts/SDAOSLEFNWU35H3QLI5325', [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('DELETE', '/shop-api/WEB_GB/carts/SDAOSLEFNWU35H3QLI5325', [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'cart/validation_cart_not_exists_response', Response::HTTP_BAD_REQUEST);
 
-        $this->client->request('DELETE', '/shop-api/carts/SDAOSLEFNWU35H3QLI5325?locale=de_DE', [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('DELETE', '/shop-api/WEB_GB/carts/SDAOSLEFNWU35H3QLI5325?locale=de_DE', [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'cart/validation_cart_not_exists_in_german_response', Response::HTTP_BAD_REQUEST);
@@ -49,7 +49,7 @@ final class CartDropCartApiTest extends JsonApiTestCase
         $bus->handle(new PickupCart($token, 'WEB_GB'));
         $bus->handle(new PutSimpleItemToCart($token, 'LOGAN_MUG_CODE', 5));
 
-        $this->client->request('DELETE', '/shop-api/carts/' . $token, [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('DELETE', '/shop-api/WEB_GB/carts/' . $token, [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponseCode($response, Response::HTTP_NO_CONTENT);
@@ -96,7 +96,7 @@ final class CartDropCartApiTest extends JsonApiTestCase
 
         $bus->handle(new CompleteOrder($token, 'sylius@example.com'));
 
-        $this->client->request('DELETE', '/shop-api/carts/' . $order->getTokenValue(), [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('DELETE', '/shop-api/WEB_GB/carts/' . $order->getTokenValue(), [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'cart/validation_cart_not_exists_response', Response::HTTP_BAD_REQUEST);

--- a/tests/Controller/CartDropCartApiTest.php
+++ b/tests/Controller/CartDropCartApiTest.php
@@ -22,7 +22,7 @@ final class CartDropCartApiTest extends JsonApiTestCase
      */
     public function it_returns_not_found_exception_if_cart_has_not_been_found()
     {
-        $this->loadFixturesFromFiles(['shop.yml']);
+        $this->loadFixturesFromFiles(['channel.yml', 'shop.yml']);
 
         $this->client->request('DELETE', '/shop-api/WEB_GB/carts/SDAOSLEFNWU35H3QLI5325', [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
@@ -40,7 +40,7 @@ final class CartDropCartApiTest extends JsonApiTestCase
      */
     public function it_deletes_a_cart()
     {
-        $this->loadFixturesFromFiles(['shop.yml']);
+        $this->loadFixturesFromFiles(['channel.yml', 'shop.yml']);
 
         $token = 'SDAOSLEFNWU35H3QLI5325';
 
@@ -60,7 +60,7 @@ final class CartDropCartApiTest extends JsonApiTestCase
      */
     public function it_returns_not_found_exception_if_order_is_in_different_state_then_cart()
     {
-        $this->loadFixturesFromFiles(['shop.yml', 'country.yml', 'shipping.yml', 'payment.yml']);
+        $this->loadFixturesFromFiles(['channel.yml', 'shop.yml', 'country.yml', 'shipping.yml', 'payment.yml']);
 
         $token = 'SDAOSLEFNWU35H3QLI5325';
 
@@ -100,5 +100,25 @@ final class CartDropCartApiTest extends JsonApiTestCase
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'cart/validation_cart_not_exists_response', Response::HTTP_BAD_REQUEST);
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_allow_to_delete_cart_in_non_existent_channel()
+    {
+        $this->loadFixturesFromFiles(['channel.yml', 'shop.yml']);
+
+        $token = 'SDAOSLEFNWU35H3QLI5325';
+
+        /** @var CommandBus $bus */
+        $bus = $this->get('tactician.commandbus');
+        $bus->handle(new PickupCart($token, 'WEB_GB'));
+        $bus->handle(new PutSimpleItemToCart($token, 'LOGAN_MUG_CODE', 5));
+
+        $this->client->request('DELETE', '/shop-api/SPACE_KLINGON/carts/' . $token, [], [], ['ACCEPT' => 'application/json']);
+        $response = $this->client->getResponse();
+
+        $this->assertResponse($response, 'channel_has_not_been_found_response', Response::HTTP_NOT_FOUND);
     }
 }

--- a/tests/Controller/CartEstimateShippingTest.php
+++ b/tests/Controller/CartEstimateShippingTest.php
@@ -17,7 +17,7 @@ final class CartEstimateShippingTest extends JsonApiTestCase
     {
         $this->loadFixturesFromFiles(['shop.yml', 'country.yml']);
 
-        $this->client->request('GET', '/shop-api/carts/SDAOSLEFNWU35H3QLI5325/estimated-shipping-cost', [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('GET', '/shop-api/WEB_GB/carts/SDAOSLEFNWU35H3QLI5325/estimated-shipping-cost', [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'cart/cart_and_country_does_not_exist_response', Response::HTTP_BAD_REQUEST);
@@ -35,7 +35,7 @@ final class CartEstimateShippingTest extends JsonApiTestCase
         $this->pickupCart($token, 'WEB_GB');
         $this->putItemToCart($token);
 
-        $this->client->request('GET', sprintf('/shop-api/carts/%s/estimated-shipping-cost?countryCode=GB', $token), [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('GET', sprintf('/shop-api/WEB_GB/carts/%s/estimated-shipping-cost?countryCode=GB', $token), [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'cart/estimated_shipping_cost_bases_on_country_response', Response::HTTP_OK);
@@ -53,7 +53,7 @@ final class CartEstimateShippingTest extends JsonApiTestCase
         $this->pickupCart($token, 'WEB_GB');
         $this->putItemToCart($token);
 
-        $this->client->request('GET', sprintf('/shop-api/carts/%s/estimated-shipping-cost?countryCode=GB&provinceCode=GB-SCT', $token), [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('GET', sprintf('/shop-api/WEB_GB/carts/%s/estimated-shipping-cost?countryCode=GB&provinceCode=GB-SCT', $token), [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'cart/estimated_shipping_cost_bases_on_country_and_province_response', Response::HTTP_OK);
@@ -72,7 +72,7 @@ final class CartEstimateShippingTest extends JsonApiTestCase
         }
 EOT;
 
-        $this->client->request('POST', '/shop-api/carts/' . $token, [], [], static::$acceptAndContentTypeHeader, $data);
+        $this->client->request('POST', '/shop-api/WEB_GB/carts/' . $token, [], [], static::$acceptAndContentTypeHeader, $data);
     }
 
     /**
@@ -87,6 +87,6 @@ EOT;
             "quantity": 5
         }
 EOT;
-        $this->client->request('POST', sprintf('/shop-api/carts/%s/items', $token), [], [], static::$acceptAndContentTypeHeader, $data);
+        $this->client->request('POST', sprintf('/shop-api/WEB_GB/carts/%s/items', $token), [], [], static::$acceptAndContentTypeHeader, $data);
     }
 }

--- a/tests/Controller/CartEstimateShippingTest.php
+++ b/tests/Controller/CartEstimateShippingTest.php
@@ -60,6 +60,19 @@ final class CartEstimateShippingTest extends JsonApiTestCase
     }
 
     /**
+     * @test
+     */
+    public function it_does_not_allow_to_estimate_shipping_in_non_existent_channel()
+    {
+        $this->loadFixturesFromFiles(['shop.yml', 'country.yml']);
+
+        $this->client->request('GET', '/shop-api/SPACE_KLINGON/carts/SDAOSLEFNWU35H3QLI5325/estimated-shipping-cost', [], [], ['ACCEPT' => 'application/json']);
+        $response = $this->client->getResponse();
+
+        $this->assertResponse($response, 'channel_has_not_been_found_response', Response::HTTP_NOT_FOUND);
+    }
+
+    /**
      * @param string $token
      * @param string $channelCode
      */

--- a/tests/Controller/CartPickupApiTest.php
+++ b/tests/Controller/CartPickupApiTest.php
@@ -115,4 +115,18 @@ EOT;
 
         $this->assertResponse($response, 'cart/validation_channel_not_found_response', Response::HTTP_BAD_REQUEST);
     }
+
+    /**
+     * @test
+     */
+    public function it_does_not_allow_to_create_a_new_cart_in_non_existent_channel()
+    {
+        $this->loadFixturesFromFiles(['shop.yml']);
+
+        $this->client->request('POST', '/shop-api/SPACE_KLINGON/carts/SDAOSLEFNWU35H3QLI5325', [], [], static::$acceptAndContentTypeHeader);
+
+        $response = $this->client->getResponse();
+
+        $this->assertResponse($response, 'channel_has_not_been_found_response', Response::HTTP_NOT_FOUND);
+    }
 }

--- a/tests/Controller/CartPickupApiTest.php
+++ b/tests/Controller/CartPickupApiTest.php
@@ -26,7 +26,7 @@ final class CartPickupApiTest extends JsonApiTestCase
         }
 EOT;
 
-        $this->client->request('POST', '/shop-api/carts', [], [], static::$acceptAndContentTypeHeader, $data);
+        $this->client->request('POST', '/shop-api/WEB_GB/carts', [], [], static::$acceptAndContentTypeHeader, $data);
 
         $response = $this->client->getResponse();
 
@@ -47,7 +47,7 @@ EOT;
         }
 EOT;
 
-        $this->client->request('POST', '/shop-api/carts/SDAOSLEFNWU35H3QLI5325', [], [], static::$acceptAndContentTypeHeader, $data);
+        $this->client->request('POST', '/shop-api/WEB_GB/carts/SDAOSLEFNWU35H3QLI5325', [], [], static::$acceptAndContentTypeHeader, $data);
 
         $response = $this->client->getResponse();
 
@@ -74,7 +74,7 @@ EOT;
         }
 EOT;
 
-        $this->client->request('POST', '/shop-api/carts/' . $token, [], [], static::$acceptAndContentTypeHeader, $data);
+        $this->client->request('POST', '/shop-api/WEB_GB/carts/' . $token, [], [], static::$acceptAndContentTypeHeader, $data);
 
         $response = $this->client->getResponse();
 
@@ -95,7 +95,7 @@ EOT;
         }
 EOT;
 
-        $this->client->request('POST', '/shop-api/carts/SDAOSLEFNWU35H3QLI5325', [], [], static::$acceptAndContentTypeHeader, $data);
+        $this->client->request('POST', '/shop-api/WEB_GB/carts/SDAOSLEFNWU35H3QLI5325', [], [], static::$acceptAndContentTypeHeader, $data);
 
         $response = $this->client->getResponse();
 
@@ -109,7 +109,7 @@ EOT;
     {
         $this->loadFixturesFromFiles(['shop.yml']);
 
-        $this->client->request('POST', '/shop-api/carts/SDAOSLEFNWU35H3QLI5325', [], [], static::$acceptAndContentTypeHeader);
+        $this->client->request('POST', '/shop-api/WEB_GB/carts/SDAOSLEFNWU35H3QLI5325', [], [], static::$acceptAndContentTypeHeader);
 
         $response = $this->client->getResponse();
 

--- a/tests/Controller/CartPutItemToCartApiTest.php
+++ b/tests/Controller/CartPutItemToCartApiTest.php
@@ -579,4 +579,30 @@ EOT;
 
         $this->assertResponse($response, 'cart/add_product_variant_based_on_options_multiple_times_to_cart_response', Response::HTTP_CREATED);
     }
+
+    /**
+     * @test
+     */
+    public function it_does_not_allow_to_put_item_to_cart_in_non_existent_channel()
+    {
+        $this->loadFixturesFromFiles(['shop.yml']);
+
+        $token = 'SDAOSLEFNWU35H3QLI5325';
+
+        /** @var CommandBus $bus */
+        $bus = $this->get('tactician.commandbus');
+        $bus->handle(new PickupCart($token, 'WEB_GB'));
+
+        $data =
+<<<EOT
+        {
+            "productCode": "LOGAN_MUG_CODE",
+            "quantity": 3
+        }
+EOT;
+        $this->client->request('POST', sprintf('/shop-api/SPACE_KLINGON/carts/%s/items', $token), [], [], static::$acceptAndContentTypeHeader, $data);
+        $response = $this->client->getResponse();
+
+        $this->assertResponse($response, 'channel_has_not_been_found_response', Response::HTTP_NOT_FOUND);
+    }
 }

--- a/tests/Controller/CartPutItemToCartApiTest.php
+++ b/tests/Controller/CartPutItemToCartApiTest.php
@@ -39,7 +39,7 @@ final class CartPutItemToCartApiTest extends JsonApiTestCase
             "quantity": 3
         }
 EOT;
-        $this->client->request('POST', sprintf('/shop-api/carts/%s/items', $token), [], [], static::$acceptAndContentTypeHeader, $data);
+        $this->client->request('POST', sprintf('/shop-api/WEB_GB/carts/%s/items', $token), [], [], static::$acceptAndContentTypeHeader, $data);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'cart/add_simple_product_to_cart_response', Response::HTTP_CREATED);
@@ -65,8 +65,8 @@ EOT;
             "quantity": 1
         }
 EOT;
-        $this->client->request('POST', sprintf('/shop-api/carts/%s/items', $token), [], [], static::$acceptAndContentTypeHeader, $data);
-        $this->client->request('POST', sprintf('/shop-api/carts/%s/items', $token), [], [], static::$acceptAndContentTypeHeader, $data);
+        $this->client->request('POST', sprintf('/shop-api/WEB_GB/carts/%s/items', $token), [], [], static::$acceptAndContentTypeHeader, $data);
+        $this->client->request('POST', sprintf('/shop-api/WEB_GB/carts/%s/items', $token), [], [], static::$acceptAndContentTypeHeader, $data);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'cart/add_simple_product_multiple_times_to_cart_response', Response::HTTP_CREATED);
@@ -92,7 +92,7 @@ EOT;
             "quantity": 3
         }
 EOT;
-        $this->client->request('POST', sprintf('/shop-api/carts/%s/items', $token), [], [], static::$acceptAndContentTypeHeader, $data);
+        $this->client->request('POST', sprintf('/shop-api/WEB_GB/carts/%s/items', $token), [], [], static::$acceptAndContentTypeHeader, $data);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'cart/validation_product_not_simple_response', Response::HTTP_BAD_REQUEST);
@@ -118,7 +118,7 @@ EOT;
             "quantity": 0
         }
 EOT;
-        $this->client->request('POST', sprintf('/shop-api/carts/%s/items', $token), [], [], static::$acceptAndContentTypeHeader, $data);
+        $this->client->request('POST', sprintf('/shop-api/WEB_GB/carts/%s/items', $token), [], [], static::$acceptAndContentTypeHeader, $data);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'cart/validation_quantity_lower_than_one_response', Response::HTTP_BAD_REQUEST);
@@ -144,7 +144,7 @@ EOT;
             "quantity": "3"
         }
 EOT;
-        $this->client->request('POST', sprintf('/shop-api/carts/%s/items', $token), [], [], static::$acceptAndContentTypeHeader, $data);
+        $this->client->request('POST', sprintf('/shop-api/WEB_GB/carts/%s/items', $token), [], [], static::$acceptAndContentTypeHeader, $data);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'cart/add_simple_product_to_cart_response', Response::HTTP_CREATED);
@@ -169,7 +169,7 @@ EOT;
             "quantity": 3
         }
 EOT;
-        $this->client->request('POST', sprintf('/shop-api/carts/%s/items', $token), [], [], static::$acceptAndContentTypeHeader, $data);
+        $this->client->request('POST', sprintf('/shop-api/WEB_GB/carts/%s/items', $token), [], [], static::$acceptAndContentTypeHeader, $data);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'cart/validation_product_not_defined_response', Response::HTTP_BAD_REQUEST);
@@ -195,7 +195,7 @@ EOT;
             "quantity": 3
         }
 EOT;
-        $this->client->request('POST', sprintf('/shop-api/carts/%s/items', $token), [], [], static::$acceptAndContentTypeHeader, $data);
+        $this->client->request('POST', sprintf('/shop-api/WEB_GB/carts/%s/items', $token), [], [], static::$acceptAndContentTypeHeader, $data);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'cart/validation_product_not_exists_response', Response::HTTP_BAD_REQUEST);
@@ -217,7 +217,7 @@ EOT;
             "quantity": 3
         }
 EOT;
-        $this->client->request('POST', sprintf('/shop-api/carts/%s/items', $token), [], [], static::$acceptAndContentTypeHeader, $data);
+        $this->client->request('POST', sprintf('/shop-api/WEB_GB/carts/%s/items', $token), [], [], static::$acceptAndContentTypeHeader, $data);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'cart/validation_cart_not_exists_response', Response::HTTP_BAD_REQUEST);
@@ -271,7 +271,7 @@ EOT;
             "quantity": 3
         }
 EOT;
-        $this->client->request('POST', sprintf('/shop-api/carts/%s/items', $order->getTokenValue()), [], [], static::$acceptAndContentTypeHeader, $data);
+        $this->client->request('POST', sprintf('/shop-api/WEB_GB/carts/%s/items', $order->getTokenValue()), [], [], static::$acceptAndContentTypeHeader, $data);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'cart/validation_cart_not_exists_response', Response::HTTP_BAD_REQUEST);
@@ -298,7 +298,7 @@ EOT;
             "quantity": 3
         }
 EOT;
-        $this->client->request('POST', sprintf('/shop-api/carts/%s/items', $token), [], [], static::$acceptAndContentTypeHeader, $data);
+        $this->client->request('POST', sprintf('/shop-api/WEB_GB/carts/%s/items', $token), [], [], static::$acceptAndContentTypeHeader, $data);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'cart/add_product_variant_to_cart_response', Response::HTTP_CREATED);
@@ -325,8 +325,8 @@ EOT;
             "quantity": 3
         }
 EOT;
-        $this->client->request('POST', sprintf('/shop-api/carts/%s/items', $token), [], [], static::$acceptAndContentTypeHeader, $data);
-        $this->client->request('POST', sprintf('/shop-api/carts/%s/items', $token), [], [], static::$acceptAndContentTypeHeader, $data);
+        $this->client->request('POST', sprintf('/shop-api/WEB_GB/carts/%s/items', $token), [], [], static::$acceptAndContentTypeHeader, $data);
+        $this->client->request('POST', sprintf('/shop-api/WEB_GB/carts/%s/items', $token), [], [], static::$acceptAndContentTypeHeader, $data);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'cart/add_product_variant_multiple_times_to_cart_response', Response::HTTP_CREATED);
@@ -353,7 +353,7 @@ EOT;
             "quantity": 0
         }
 EOT;
-        $this->client->request('POST', sprintf('/shop-api/carts/%s/items', $token), [], [], static::$acceptAndContentTypeHeader, $data);
+        $this->client->request('POST', sprintf('/shop-api/WEB_GB/carts/%s/items', $token), [], [], static::$acceptAndContentTypeHeader, $data);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'cart/validation_quantity_lower_than_one_response', Response::HTTP_BAD_REQUEST);
@@ -380,7 +380,7 @@ EOT;
             "quantity": "3"
         }
 EOT;
-        $this->client->request('POST', sprintf('/shop-api/carts/%s/items', $token), [], [], static::$acceptAndContentTypeHeader, $data);
+        $this->client->request('POST', sprintf('/shop-api/WEB_GB/carts/%s/items', $token), [], [], static::$acceptAndContentTypeHeader, $data);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'cart/add_product_variant_to_cart_response', Response::HTTP_CREATED);
@@ -406,7 +406,7 @@ EOT;
             "quantity": 3
         }
 EOT;
-        $this->client->request('POST', sprintf('/shop-api/carts/%s/items', $token), [], [], static::$acceptAndContentTypeHeader, $data);
+        $this->client->request('POST', sprintf('/shop-api/WEB_GB/carts/%s/items', $token), [], [], static::$acceptAndContentTypeHeader, $data);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'cart/validation_product_not_defined_response', Response::HTTP_BAD_REQUEST);
@@ -433,7 +433,7 @@ EOT;
             "quantity": 3
         }
 EOT;
-        $this->client->request('POST', sprintf('/shop-api/carts/%s/items', $token), [], [], static::$acceptAndContentTypeHeader, $data);
+        $this->client->request('POST', sprintf('/shop-api/WEB_GB/carts/%s/items', $token), [], [], static::$acceptAndContentTypeHeader, $data);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'cart/validation_product_not_exists_response', Response::HTTP_BAD_REQUEST);
@@ -460,7 +460,7 @@ EOT;
             "quantity": 3
         }
 EOT;
-        $this->client->request('POST', sprintf('/shop-api/carts/%s/items', $token), [], [], static::$acceptAndContentTypeHeader, $data);
+        $this->client->request('POST', sprintf('/shop-api/WEB_GB/carts/%s/items', $token), [], [], static::$acceptAndContentTypeHeader, $data);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'cart/validation_product_not_configurable_response', Response::HTTP_BAD_REQUEST);
@@ -487,7 +487,7 @@ EOT;
             "quantity": 3
         }
 EOT;
-        $this->client->request('POST', sprintf('/shop-api/carts/%s/items', $token), [], [], static::$acceptAndContentTypeHeader, $data);
+        $this->client->request('POST', sprintf('/shop-api/WEB_GB/carts/%s/items', $token), [], [], static::$acceptAndContentTypeHeader, $data);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'cart/validation_product_variant_not_exists_response', Response::HTTP_BAD_REQUEST);
@@ -513,7 +513,7 @@ EOT;
             "quantity": 3
         }
 EOT;
-        $this->client->request('POST', '/shop-api/carts/SDAOSLEFNWU35H3QLI5325/items', [], [], static::$acceptAndContentTypeHeader, $data);
+        $this->client->request('POST', '/shop-api/WEB_GB/carts/SDAOSLEFNWU35H3QLI5325/items', [], [], static::$acceptAndContentTypeHeader, $data);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'cart/product_variant_has_not_been_found_response', Response::HTTP_NOT_FOUND);
@@ -543,7 +543,7 @@ EOT;
             "quantity": 3
         }
 EOT;
-        $this->client->request('POST', '/shop-api/carts/SDAOSLEFNWU35H3QLI5325/items', [], [], static::$acceptAndContentTypeHeader, $data);
+        $this->client->request('POST', '/shop-api/WEB_GB/carts/SDAOSLEFNWU35H3QLI5325/items', [], [], static::$acceptAndContentTypeHeader, $data);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'cart/add_product_variant_based_on_options_to_cart_response', Response::HTTP_CREATED);
@@ -573,8 +573,8 @@ EOT;
             "quantity": 3
         }
 EOT;
-        $this->client->request('POST', sprintf('/shop-api/carts/%s/items', $token), [], [], static::$acceptAndContentTypeHeader, $data);
-        $this->client->request('POST', sprintf('/shop-api/carts/%s/items', $token), [], [], static::$acceptAndContentTypeHeader, $data);
+        $this->client->request('POST', sprintf('/shop-api/WEB_GB/carts/%s/items', $token), [], [], static::$acceptAndContentTypeHeader, $data);
+        $this->client->request('POST', sprintf('/shop-api/WEB_GB/carts/%s/items', $token), [], [], static::$acceptAndContentTypeHeader, $data);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'cart/add_product_variant_based_on_options_multiple_times_to_cart_response', Response::HTTP_CREATED);

--- a/tests/Controller/CartPutItemsToCartApiTest.php
+++ b/tests/Controller/CartPutItemsToCartApiTest.php
@@ -132,4 +132,43 @@ EOT;
 
         $this->assertResponse($response, 'cart/add_multiple_products_to_cart_validation_error_response', Response::HTTP_BAD_REQUEST);
     }
+
+    /**
+     * @test
+     */
+    public function it_does_not_allow_to_put_items_to_cart_in_non_existent_channel()
+    {
+        $this->loadFixturesFromFiles(['shop.yml']);
+
+        $token = 'SDAOSLEFNWU35H3QLI5325';
+
+        /** @var CommandBus $bus */
+        $bus = $this->get('tactician.commandbus');
+        $bus->handle(new PickupCart($token, 'WEB_GB'));
+
+        $data =
+<<<EOT
+        [
+            {
+                "productCode": "LOGAN_MUG_CODE",
+                "quantity": 3
+            },
+            {
+                "productCode": "LOGAN_T_SHIRT_CODE",
+                "variantCode": "SMALL_LOGAN_T_SHIRT_CODE"
+            },
+            {
+                "productCode": "LOGAN_HAT_CODE",
+                "options": {
+                    "HAT_SIZE": "HAT_SIZE_S",
+                    "HAT_COLOR": "HAT_COLOR_RED"
+                }
+            }
+        ]
+EOT;
+        $this->client->request('POST', sprintf('/shop-api/SPACE_KLINGON/carts/%s/multiple-items', $token), [], [], static::$acceptAndContentTypeHeader, $data);
+        $response = $this->client->getResponse();
+
+        $this->assertResponse($response, 'channel_has_not_been_found_response', Response::HTTP_NOT_FOUND);
+    }
 }

--- a/tests/Controller/CartPutItemsToCartApiTest.php
+++ b/tests/Controller/CartPutItemsToCartApiTest.php
@@ -47,7 +47,7 @@ final class CartPutItemsToCartApiTest extends JsonApiTestCase
             }
         ]
 EOT;
-        $this->client->request('POST', sprintf('/shop-api/carts/%s/multiple-items', $token), [], [], static::$acceptAndContentTypeHeader, $data);
+        $this->client->request('POST', sprintf('/shop-api/WEB_GB/carts/%s/multiple-items', $token), [], [], static::$acceptAndContentTypeHeader, $data);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'cart/add_multiple_products_to_cart_response', Response::HTTP_CREATED);
@@ -87,8 +87,8 @@ EOT;
             }
         ]
 EOT;
-        $this->client->request('POST', sprintf('/shop-api/carts/%s/multiple-items', $token), [], [], static::$acceptAndContentTypeHeader, $data);
-        $this->client->request('GET', sprintf('/shop-api/carts/%s', $token), [], [], static::$acceptAndContentTypeHeader, $data);
+        $this->client->request('POST', sprintf('/shop-api/WEB_GB/carts/%s/multiple-items', $token), [], [], static::$acceptAndContentTypeHeader, $data);
+        $this->client->request('GET', sprintf('/shop-api/WEB_GB/carts/%s', $token), [], [], static::$acceptAndContentTypeHeader, $data);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'cart/empty_response', Response::HTTP_OK);
@@ -127,7 +127,7 @@ EOT;
             }
         ]
 EOT;
-        $this->client->request('POST', sprintf('/shop-api/carts/%s/multiple-items', $token), [], [], static::$acceptAndContentTypeHeader, $data);
+        $this->client->request('POST', sprintf('/shop-api/WEB_GB/carts/%s/multiple-items', $token), [], [], static::$acceptAndContentTypeHeader, $data);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'cart/add_multiple_products_to_cart_validation_error_response', Response::HTTP_BAD_REQUEST);

--- a/tests/Controller/CartRemoveCouponShopApiTest.php
+++ b/tests/Controller/CartRemoveCouponShopApiTest.php
@@ -70,4 +70,18 @@ final class CartRemoveCouponShopApiTest extends JsonApiTestCase
 
         $this->assertResponse($response, 'cart/validation_cart_not_exists_response', Response::HTTP_BAD_REQUEST);
     }
+
+    /**
+     * @test
+     */
+    public function it_does_not_allow_to_add_promotion_code_in_non_existent_channel()
+    {
+        $this->loadFixturesFromFiles(['shop.yml']);
+
+        $this->client->request('DELETE', '/shop-api/SPACE_KLINGON/carts/WRONGTOKEN/coupon', [], [], static::$acceptAndContentTypeHeader, null);
+
+        $response = $this->client->getResponse();
+
+        $this->assertResponse($response, 'channel_has_not_been_found_response', Response::HTTP_NOT_FOUND);
+    }
 }

--- a/tests/Controller/CartRemoveCouponShopApiTest.php
+++ b/tests/Controller/CartRemoveCouponShopApiTest.php
@@ -29,7 +29,7 @@ final class CartRemoveCouponShopApiTest extends JsonApiTestCase
         $bus->handle(new PutSimpleItemToCart($token, 'LOGAN_MUG_CODE', 5));
         $bus->handle(new AddCoupon($token, 'BANANAS'));
 
-        $this->client->request('DELETE', sprintf('/shop-api/carts/%s/coupon', $token), [], [], static::$acceptAndContentTypeHeader, null);
+        $this->client->request('DELETE', sprintf('/shop-api/WEB_GB/carts/%s/coupon', $token), [], [], static::$acceptAndContentTypeHeader, null);
 
         $response = $this->client->getResponse();
 
@@ -50,7 +50,7 @@ final class CartRemoveCouponShopApiTest extends JsonApiTestCase
         $bus->handle(new PickupCart($token, 'WEB_GB'));
         $bus->handle(new PutSimpleItemToCart($token, 'LOGAN_MUG_CODE', 5));
 
-        $this->client->request('DELETE', sprintf('/shop-api/carts/%s/coupon', $token), [], [], static::$acceptAndContentTypeHeader, null);
+        $this->client->request('DELETE', sprintf('/shop-api/WEB_GB/carts/%s/coupon', $token), [], [], static::$acceptAndContentTypeHeader, null);
 
         $response = $this->client->getResponse();
 
@@ -64,7 +64,7 @@ final class CartRemoveCouponShopApiTest extends JsonApiTestCase
     {
         $this->loadFixturesFromFiles(['shop.yml']);
 
-        $this->client->request('DELETE', '/shop-api/carts/WRONGTOKEN/coupon', [], [], static::$acceptAndContentTypeHeader, null);
+        $this->client->request('DELETE', '/shop-api/WEB_GB/carts/WRONGTOKEN/coupon', [], [], static::$acceptAndContentTypeHeader, null);
 
         $response = $this->client->getResponse();
 

--- a/tests/Controller/CartRemoveItemFromCartApiTest.php
+++ b/tests/Controller/CartRemoveItemFromCartApiTest.php
@@ -64,6 +64,25 @@ final class CartRemoveItemFromCartApiTest extends JsonApiTestCase
     /**
      * @test
      */
+    public function it_does_not_allow_to_remove_item_from_cart_in_non_existent_channel()
+    {
+        $this->loadFixturesFromFiles(['shop.yml']);
+
+        $token = 'SDAOSLEFNWU35H3QLI5325';
+
+        /** @var CommandBus $bus */
+        $bus = $this->get('tactician.commandbus');
+        $bus->handle(new PickupCart($token, 'WEB_GB'));
+
+        $this->client->request('DELETE', '/shop-api/SPACE_KLINGON/carts/SDAOSLEFNWU35H3QLI5325/items/420', [], [], ['ACCEPT' => 'application/json']);
+        $response = $this->client->getResponse();
+
+        $this->assertResponse($response, 'channel_has_not_been_found_response', Response::HTTP_NOT_FOUND);
+    }
+
+    /**
+     * @test
+     */
     public function it_reprocesses_the_order_after_deleting_an_item()
     {
         $this->loadFixturesFromFiles(['shop.yml', 'promotion.yml']);

--- a/tests/Controller/CartRemoveItemFromCartApiTest.php
+++ b/tests/Controller/CartRemoveItemFromCartApiTest.php
@@ -36,7 +36,7 @@ final class CartRemoveItemFromCartApiTest extends JsonApiTestCase
         /** @var OrderItemInterface $orderItem */
         $orderItem = $order->getItems()->first();
 
-        $this->client->request('DELETE', '/shop-api/carts/SDAOSLEFNWU35H3QLI5325/items/' . $orderItem->getId(), [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('DELETE', '/shop-api/WEB_GB/carts/SDAOSLEFNWU35H3QLI5325/items/' . $orderItem->getId(), [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'cart/cart_after_deleting_an_item', Response::HTTP_OK);
@@ -55,7 +55,7 @@ final class CartRemoveItemFromCartApiTest extends JsonApiTestCase
         $bus = $this->get('tactician.commandbus');
         $bus->handle(new PickupCart($token, 'WEB_GB'));
 
-        $this->client->request('DELETE', '/shop-api/carts/SDAOSLEFNWU35H3QLI5325/items/420', [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('DELETE', '/shop-api/WEB_GB/carts/SDAOSLEFNWU35H3QLI5325/items/420', [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'cart/cart_item_has_not_been_found_response', Response::HTTP_BAD_REQUEST);
@@ -84,7 +84,7 @@ final class CartRemoveItemFromCartApiTest extends JsonApiTestCase
         /** @var OrderItemInterface $orderItem */
         $orderItem = $order->getItems()->last();
 
-        $this->client->request('DELETE', '/shop-api/carts/SDAOSLEFNWU35H3QLI5325/items/' . $orderItem->getId(), [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('DELETE', '/shop-api/WEB_GB/carts/SDAOSLEFNWU35H3QLI5325/items/' . $orderItem->getId(), [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'cart/reprocessed_cart_after_deleting_an_item', Response::HTTP_OK);

--- a/tests/Controller/CartSummarizeApiTest.php
+++ b/tests/Controller/CartSummarizeApiTest.php
@@ -27,7 +27,7 @@ final class CartSummarizeApiTest extends JsonApiTestCase
         $bus = $this->get('tactician.commandbus');
         $bus->handle(new PickupCart($token, 'WEB_GB'));
 
-        $this->client->request('GET', '/shop-api/carts/' . $token, [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('GET', '/shop-api/WEB_GB/carts/' . $token, [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'cart/empty_response', Response::HTTP_OK);
@@ -40,7 +40,7 @@ final class CartSummarizeApiTest extends JsonApiTestCase
     {
         $this->loadFixturesFromFiles(['shop.yml']);
 
-        $this->client->request('GET', '/shop-api/carts/SDAOSLEFNWU35H3QLI5325', [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('GET', '/shop-api/WEB_GB/carts/SDAOSLEFNWU35H3QLI5325', [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'cart/cart_has_not_been_found_response', Response::HTTP_NOT_FOUND);
@@ -60,7 +60,7 @@ final class CartSummarizeApiTest extends JsonApiTestCase
         $bus->handle(new PickupCart($token, 'WEB_GB'));
         $bus->handle(new PutSimpleItemToCart($token, 'LOGAN_MUG_CODE', 5));
 
-        $this->client->request('GET', '/shop-api/carts/' . $token, [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('GET', '/shop-api/WEB_GB/carts/' . $token, [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'cart/filled_cart_with_simple_product_summary_response', Response::HTTP_OK);
@@ -80,7 +80,7 @@ final class CartSummarizeApiTest extends JsonApiTestCase
         $bus->handle(new PickupCart($token, 'WEB_DE'));
         $bus->handle(new PutSimpleItemToCart($token, 'LOGAN_MUG_CODE', 5));
 
-        $this->client->request('GET', sprintf('/shop-api/carts/%s', $token), [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('GET', sprintf('/shop-api/WEB_GB/carts/%s', $token), [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'cart/german_filled_cart_with_simple_product_summary_response', Response::HTTP_OK);
@@ -119,10 +119,10 @@ EOT;
             "quantity": 3
         }
 EOT;
-        $this->client->request('POST', sprintf('/shop-api/carts/%s/items', $token), [], [], static::$acceptAndContentTypeHeader, $regularVariant);
-        $this->client->request('POST', sprintf('/shop-api/carts/%s/items', $token), [], [], static::$acceptAndContentTypeHeader, $variantWithOptions);
+        $this->client->request('POST', sprintf('/shop-api/WEB_GB/carts/%s/items', $token), [], [], static::$acceptAndContentTypeHeader, $regularVariant);
+        $this->client->request('POST', sprintf('/shop-api/WEB_GB/carts/%s/items', $token), [], [], static::$acceptAndContentTypeHeader, $variantWithOptions);
 
-        $this->client->request('GET', sprintf('/shop-api/carts/%s', $token), [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('GET', sprintf('/shop-api/WEB_GB/carts/%s', $token), [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'cart/filled_cart_with_product_variant_summary_response', Response::HTTP_OK);
@@ -153,9 +153,9 @@ EOT;
         }
 EOT;
 
-        $this->client->request('POST', sprintf('/shop-api/carts/%s/items', $token), [], [], static::$acceptAndContentTypeHeader, $variantWithOptions);
+        $this->client->request('POST', sprintf('/shop-api/WEB_GB/carts/%s/items', $token), [], [], static::$acceptAndContentTypeHeader, $variantWithOptions);
 
-        $this->client->request('GET', sprintf('/shop-api/carts/%s', $token), [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('GET', sprintf('/shop-api/WEB_GB/carts/%s', $token), [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'cart/german_filled_cart_with_product_variant_summary_response', Response::HTTP_OK);
@@ -176,7 +176,7 @@ EOT;
         $bus->handle(new PutSimpleItemToCart($token, 'LOGAN_MUG_CODE', 5));
         $bus->handle(new AddCoupon($token, 'BANANAS'));
 
-        $this->client->request('GET', '/shop-api/checkout/' . $token, [], [], static::$acceptAndContentTypeHeader);
+        $this->client->request('GET', '/shop-api/WEB_GB/checkout/' . $token, [], [], static::$acceptAndContentTypeHeader);
 
         $response = $this->client->getResponse();
         $this->assertResponse($response, 'cart/cart_with_coupon_based_promotion_applied_response', Response::HTTP_OK);

--- a/tests/Controller/CartSummarizeApiTest.php
+++ b/tests/Controller/CartSummarizeApiTest.php
@@ -49,6 +49,19 @@ final class CartSummarizeApiTest extends JsonApiTestCase
     /**
      * @test
      */
+    public function it_does_not_allow_to_summarize_cart_in_non_existent_channel()
+    {
+        $this->loadFixturesFromFiles(['shop.yml']);
+
+        $this->client->request('GET', '/shop-api/SPACE_KLINGON/carts/SDAOSLEFNWU35H3QLI5325', [], [], ['ACCEPT' => 'application/json']);
+        $response = $this->client->getResponse();
+
+        $this->assertResponse($response, 'channel_has_not_been_found_response', Response::HTTP_NOT_FOUND);
+    }
+
+    /**
+     * @test
+     */
     public function it_shows_summary_of_a_cart_filled_with_a_simple_product()
     {
         $this->loadFixturesFromFiles(['shop.yml']);

--- a/tests/Controller/CheckoutAddressApiTest.php
+++ b/tests/Controller/CheckoutAddressApiTest.php
@@ -15,7 +15,7 @@ final class CheckoutAddressApiTest extends JsonApiTestCase
 
     public function it_does_not_allow_to_address_unexisting_order()
     {
-        $this->client->request('PUT', '/shop-api/checkout/SDAOSLEFNWU35H3QLI5325/address', [], [], static::$acceptAndContentTypeHeader);
+        $this->client->request('PUT', '/shop-api/WEB_GB/checkout/SDAOSLEFNWU35H3QLI5325/address', [], [], static::$acceptAndContentTypeHeader);
 
         $response = $this->client->getResponse();
         $this->assertResponse($response, 'cart/cart_has_not_been_found_response', Response::HTTP_NOT_FOUND);
@@ -50,7 +50,7 @@ final class CheckoutAddressApiTest extends JsonApiTestCase
         }
 EOT;
 
-        $this->client->request('PUT', sprintf('/shop-api/checkout/%s/address', $token), [], [], static::$acceptAndContentTypeHeader, $data);
+        $this->client->request('PUT', sprintf('/shop-api/WEB_GB/checkout/%s/address', $token), [], [], static::$acceptAndContentTypeHeader, $data);
 
         $response = $this->client->getResponse();
         $this->assertResponseCode($response, Response::HTTP_NO_CONTENT);
@@ -84,7 +84,7 @@ EOT;
         }
 EOT;
 
-        $this->client->request('PUT', '/shop-api/checkout/SDAOSLEFNWU35H3QLI5325/address', [], [], static::$acceptAndContentTypeHeader, $data);
+        $this->client->request('PUT', '/shop-api/WEB_GB/checkout/SDAOSLEFNWU35H3QLI5325/address', [], [], static::$acceptAndContentTypeHeader, $data);
 
         $response = $this->client->getResponse();
         $this->assertResponseCode($response, Response::HTTP_NO_CONTENT);
@@ -128,7 +128,7 @@ EOT;
         }
 EOT;
 
-        $this->client->request('PUT', sprintf('/shop-api/checkout/%s/address', $token), [], [], static::$acceptAndContentTypeHeader, $data);
+        $this->client->request('PUT', sprintf('/shop-api/WEB_GB/checkout/%s/address', $token), [], [], static::$acceptAndContentTypeHeader, $data);
 
         $response = $this->client->getResponse();
         $this->assertResponseCode($response, Response::HTTP_NO_CONTENT);

--- a/tests/Controller/CheckoutAddressApiTest.php
+++ b/tests/Controller/CheckoutAddressApiTest.php
@@ -13,12 +13,50 @@ final class CheckoutAddressApiTest extends JsonApiTestCase
 {
     private static $acceptAndContentTypeHeader = ['CONTENT_TYPE' => 'application/json', 'ACCEPT' => 'application/json'];
 
+    /**
+     * TODO check is it possible (test annotation make it fail)
+     */
     public function it_does_not_allow_to_address_unexisting_order()
     {
         $this->client->request('PUT', '/shop-api/WEB_GB/checkout/SDAOSLEFNWU35H3QLI5325/address', [], [], static::$acceptAndContentTypeHeader);
 
         $response = $this->client->getResponse();
         $this->assertResponse($response, 'cart/cart_has_not_been_found_response', Response::HTTP_NOT_FOUND);
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_allow_to_address_cart_in_non_existent_channel()
+    {
+        $this->loadFixturesFromFiles(['shop.yml']);
+
+        $token = 'SDAOSLEFNWU35H3QLI5325';
+
+        /** @var CommandBus $bus */
+        $bus = $this->get('tactician.commandbus');
+        $bus->handle(new PickupCart($token, 'WEB_GB'));
+        $bus->handle(new PutSimpleItemToCart($token, 'LOGAN_MUG_CODE', 5));
+
+        $data =
+<<<EOT
+        {
+            "shippingAddress": {
+                "firstName": "Sherlock",
+                "lastName": "Holmes",
+                "countryCode": "GB",
+                "street": "Baker Street 221b",
+                "city": "London",
+                "postcode": "NW1",
+                "provinceName": "Greater London"
+            }
+        }
+EOT;
+
+        $this->client->request('PUT', sprintf('/shop-api/SPACE_KLINGON/checkout/%s/address', $token), [], [], static::$acceptAndContentTypeHeader, $data);
+
+        $response = $this->client->getResponse();
+        $this->assertResponse($response, 'channel_has_not_been_found_response', Response::HTTP_NOT_FOUND);
     }
 
     /**

--- a/tests/Controller/CheckoutChoosePaymentMethodApiTest.php
+++ b/tests/Controller/CheckoutChoosePaymentMethodApiTest.php
@@ -69,6 +69,6 @@ EOT;
      */
     private function getPaymentUrl($token)
     {
-        return sprintf('/shop-api/checkout/%s/payment', $token);
+        return sprintf('/shop-api/WEB_GB/checkout/%s/payment', $token);
     }
 }

--- a/tests/Controller/CheckoutChooseShippingMethodApiTest.php
+++ b/tests/Controller/CheckoutChooseShippingMethodApiTest.php
@@ -67,6 +67,6 @@ EOT;
      */
     private function getShippingUrl($token)
     {
-        return sprintf('/shop-api/checkout/%s/shipping', $token);
+        return sprintf('/shop-api/WEB_GB/checkout/%s/shipping', $token);
     }
 }

--- a/tests/Controller/CheckoutChooseShippingMethodApiTest.php
+++ b/tests/Controller/CheckoutChooseShippingMethodApiTest.php
@@ -61,6 +61,53 @@ EOT;
     }
 
     /**
+     * @test
+     */
+    public function it_does_not_allow_to_choose_shipping_method_in_non_existent_channel()
+    {
+        $this->loadFixturesFromFiles(['shop.yml', 'country.yml', 'shipping.yml']);
+
+        $token = 'SDAOSLEFNWU35H3QLI5325';
+
+        /** @var CommandBus $bus */
+        $bus = $this->get('tactician.commandbus');
+        $bus->handle(new PickupCart($token, 'WEB_GB'));
+        $bus->handle(new PutSimpleItemToCart($token, 'LOGAN_MUG_CODE', 5));
+        $bus->handle(new AddressOrder(
+            $token,
+            Address::createFromArray([
+                'firstName' => 'Sherlock',
+                'lastName' => 'Holmes',
+                'city' => 'London',
+                'street' => 'Baker Street 221b',
+                'countryCode' => 'GB',
+                'postcode' => 'NWB',
+                'provinceName' => 'Greater London',
+            ]), Address::createFromArray([
+                'firstName' => 'Sherlock',
+                'lastName' => 'Holmes',
+                'city' => 'London',
+                'street' => 'Baker Street 221b',
+                'countryCode' => 'GB',
+                'postcode' => 'NWB',
+                'provinceName' => 'Greater London',
+            ])
+        ));
+
+        $data =
+<<<EOT
+        {
+            "method": "DHL"
+        }
+EOT;
+
+        $this->client->request('PUT', sprintf('/shop-api/SPACE_KLINGON/checkout/%s/shipping/0', $token), [], [], ['CONTENT_TYPE' => 'application/json', 'ACCEPT' => 'application/json'], $data);
+
+        $response = $this->client->getResponse();
+        $this->assertResponse($response, 'channel_has_not_been_found_response', Response::HTTP_NOT_FOUND);
+    }
+
+    /**
      * @param string $token
      *
      * @return string

--- a/tests/Controller/CheckoutCompleteOrderApiTest.php
+++ b/tests/Controller/CheckoutCompleteOrderApiTest.php
@@ -57,7 +57,7 @@ final class CheckoutCompleteOrderApiTest extends JsonApiTestCase
             "email": "example@cusomer.com"
         }
 EOT;
-        $this->client->request('PUT', sprintf('/shop-api/checkout/%s/complete', $token), [], [], [
+        $this->client->request('PUT', sprintf('/shop-api/WEB_GB/checkout/%s/complete', $token), [], [], [
             'CONTENT_TYPE' => 'application/json',
             'ACCEPT' => 'application/json',
         ], $data);
@@ -109,7 +109,7 @@ EOT;
             "notes": "BRING IT AS FAST AS YOU CAN, PLEASE!"
         }
 EOT;
-        $this->client->request('PUT', sprintf('/shop-api/checkout/%s/complete', $token), [], [], [
+        $this->client->request('PUT', sprintf('/shop-api/WEB_GB/checkout/%s/complete', $token), [], [], [
             'CONTENT_TYPE' => 'application/json',
             'ACCEPT' => 'application/json',
         ], $data);
@@ -167,7 +167,7 @@ EOT;
         $response = json_decode($this->client->getResponse()->getContent(), true);
 
         $this->client->setServerParameter('HTTP_Authorization', sprintf('Bearer %s', $response['token']));
-        $this->client->request('PUT', sprintf('/shop-api/checkout/%s/complete', $token), [], [], [
+        $this->client->request('PUT', sprintf('/shop-api/WEB_GB/checkout/%s/complete', $token), [], [], [
             'CONTENT_TYPE' => 'application/json',
             'ACCEPT' => 'application/json',
         ]);

--- a/tests/Controller/CheckoutCompleteOrderApiTest.php
+++ b/tests/Controller/CheckoutCompleteOrderApiTest.php
@@ -175,4 +175,55 @@ EOT;
         $response = $this->client->getResponse();
         $this->assertResponseCode($response, Response::HTTP_NO_CONTENT);
     }
+
+    /**
+     * @test
+     */
+    public function it_does_not_allow_to_complete_order_in_non_existent_channel()
+    {
+        $this->loadFixturesFromFiles(['shop.yml', 'country.yml', 'shipping.yml', 'payment.yml']);
+
+        $token = 'SDAOSLEFNWU35H3QLI5325';
+
+        /** @var CommandBus $bus */
+        $bus = $this->get('tactician.commandbus');
+        $bus->handle(new PickupCart($token, 'WEB_GB'));
+        $bus->handle(new PutSimpleItemToCart($token, 'LOGAN_MUG_CODE', 5));
+        $bus->handle(new AddressOrder(
+            $token,
+            Address::createFromArray([
+                'firstName' => 'Sherlock',
+                'lastName' => 'Holmes',
+                'city' => 'London',
+                'street' => 'Baker Street 221b',
+                'countryCode' => 'GB',
+                'postcode' => 'NWB',
+                'provinceName' => 'Greater London',
+            ]), Address::createFromArray([
+                'firstName' => 'Sherlock',
+                'lastName' => 'Holmes',
+                'city' => 'London',
+                'street' => 'Baker Street 221b',
+                'countryCode' => 'GB',
+                'postcode' => 'NWB',
+                'provinceName' => 'Greater London',
+            ])
+        ));
+        $bus->handle(new ChooseShippingMethod($token, 0, 'DHL'));
+        $bus->handle(new ChoosePaymentMethod($token, 0, 'PBC'));
+
+        $data =
+<<<EOT
+        {
+            "email": "example@cusomer.com"
+        }
+EOT;
+        $this->client->request('PUT', sprintf('/shop-api/SPACE_KLINGON/checkout/%s/complete', $token), [], [], [
+            'CONTENT_TYPE' => 'application/json',
+            'ACCEPT' => 'application/json',
+        ], $data);
+
+        $response = $this->client->getResponse();
+        $this->assertResponse($response, 'channel_has_not_been_found_response', Response::HTTP_NOT_FOUND);
+    }
 }

--- a/tests/Controller/CheckoutShowAvailablePaymentMethodsShopApiTest.php
+++ b/tests/Controller/CheckoutShowAvailablePaymentMethodsShopApiTest.php
@@ -129,6 +129,6 @@ final class CheckoutShowAvailablePaymentMethodsShopApiTest extends JsonApiTestCa
      */
     private function getPaymentUrl($token)
     {
-        return sprintf('/shop-api/checkout/%s/payment', $token);
+        return sprintf('/shop-api/WEB_GB/checkout/%s/payment', $token);
     }
 }

--- a/tests/Controller/CheckoutShowAvailableShippingMethodsShopApiTest.php
+++ b/tests/Controller/CheckoutShowAvailableShippingMethodsShopApiTest.php
@@ -85,6 +85,6 @@ final class CheckoutShowAvailableShippingMethodsShopApiTest extends JsonApiTestC
      */
     private function getShippingUrl($token)
     {
-        return sprintf('/shop-api/checkout/%s/shipping', $token);
+        return sprintf('/shop-api/WEB_GB/checkout/%s/shipping', $token);
     }
 }

--- a/tests/Controller/CheckoutShowAvailableShippingMethodsShopApiTest.php
+++ b/tests/Controller/CheckoutShowAvailableShippingMethodsShopApiTest.php
@@ -13,6 +13,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 final class CheckoutShowAvailableShippingMethodsShopApiTest extends JsonApiTestCase
 {
+    /**
+     * @test
+     */
     public function it_does_not_provide_details_about_available_shipping_method_for_unexisting_cart()
     {
         $this->client->request('GET', $this->getShippingUrl(0), [], []);
@@ -61,6 +64,9 @@ final class CheckoutShowAvailableShippingMethodsShopApiTest extends JsonApiTestC
         $this->assertResponse($response, 'checkout/get_available_shipping_methods', Response::HTTP_OK);
     }
 
+    /**
+     * TODO check is it possible (test annotation make it fail)
+     */
     public function it_does_not_provide_details_about_available_shipping_method_before_addressing()
     {
         $this->loadFixturesFromFiles(['shop.yml']);
@@ -76,6 +82,46 @@ final class CheckoutShowAvailableShippingMethodsShopApiTest extends JsonApiTestC
 
         $response = $this->client->getResponse();
         $this->assertResponse($response, 'checkout/get_available_shipping_methods_failed', Response::HTTP_BAD_REQUEST);
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_provide_available_shipping_methods_in_non_existent_channel()
+    {
+        $this->loadFixturesFromFiles(['shop.yml', 'country.yml', 'shipping.yml']);
+
+        $token = 'SDAOSLEFNWU35H3QLI5325';
+
+        /** @var CommandBus $bus */
+        $bus = $this->get('tactician.commandbus');
+        $bus->handle(new PickupCart($token, 'WEB_GB'));
+        $bus->handle(new PutSimpleItemToCart($token, 'LOGAN_MUG_CODE', 5));
+        $bus->handle(new AddressOrder(
+            $token,
+            Address::createFromArray([
+                'firstName' => 'Sherlock',
+                'lastName' => 'Holmes',
+                'city' => 'London',
+                'street' => 'Baker Street 221b',
+                'countryCode' => 'GB',
+                'postcode' => 'NWB',
+                'provinceName' => 'Greater London',
+            ]), Address::createFromArray([
+                'firstName' => 'Sherlock',
+                'lastName' => 'Holmes',
+                'city' => 'London',
+                'street' => 'Baker Street 221b',
+                'countryCode' => 'GB',
+                'postcode' => 'NWB',
+                'provinceName' => 'Greater London',
+            ])
+        ));
+
+        $this->client->request('GET', sprintf('/shop-api/SPACE_KLINGON/checkout/%s/shipping', $token));
+
+        $response = $this->client->getResponse();
+        $this->assertResponse($response, 'channel_has_not_been_found_response', Response::HTTP_NOT_FOUND);
     }
 
     /**

--- a/tests/Controller/CheckoutSummarizeApiTest.php
+++ b/tests/Controller/CheckoutSummarizeApiTest.php
@@ -47,9 +47,9 @@ final class CheckoutSummarizeApiTest extends JsonApiTestCase
         }
 EOT;
 
-        $this->client->request('PUT', sprintf('/shop-api/checkout/%s/address', $token), [], [], static::$acceptAndContentTypeHeader, $data);
+        $this->client->request('PUT', sprintf('/shop-api/WEB_GB/checkout/%s/address', $token), [], [], static::$acceptAndContentTypeHeader, $data);
 
-        $this->client->request('GET', '/shop-api/checkout/' . $token, [], [], static::$acceptAndContentTypeHeader);
+        $this->client->request('GET', '/shop-api/WEB_GB/checkout/' . $token, [], [], static::$acceptAndContentTypeHeader);
 
         $response = $this->client->getResponse();
         $this->assertResponse($response, 'checkout/cart_addressed_response', Response::HTTP_OK);
@@ -93,9 +93,9 @@ EOT;
         }
 EOT;
 
-        $this->client->request('PUT', sprintf('/shop-api/checkout/%s/address', $token), [], [], static::$acceptAndContentTypeHeader, $data);
+        $this->client->request('PUT', sprintf('/shop-api/WEB_GB/checkout/%s/address', $token), [], [], static::$acceptAndContentTypeHeader, $data);
 
-        $this->client->request('GET', '/shop-api/checkout/' . $token, [], [], static::$acceptAndContentTypeHeader);
+        $this->client->request('GET', '/shop-api/WEB_GB/checkout/' . $token, [], [], static::$acceptAndContentTypeHeader);
 
         $response = $this->client->getResponse();
         $this->assertResponse($response, 'checkout/cart_addressed_with_different_shipping_and_billing_address_response', Response::HTTP_OK);
@@ -143,9 +143,9 @@ EOT;
         }
 EOT;
 
-        $this->client->request('PUT', sprintf('/shop-api/checkout/%s/shipping/0', $token), [], [], static::$acceptAndContentTypeHeader, $data);
+        $this->client->request('PUT', sprintf('/shop-api/WEB_GB/checkout/%s/shipping/0', $token), [], [], static::$acceptAndContentTypeHeader, $data);
 
-        $this->client->request('GET', '/shop-api/checkout/' . $token, [], [], static::$acceptAndContentTypeHeader);
+        $this->client->request('GET', '/shop-api/WEB_GB/checkout/' . $token, [], [], static::$acceptAndContentTypeHeader);
 
         $response = $this->client->getResponse();
         $this->assertResponse($response, 'checkout/cart_with_chosen_shipment_response', Response::HTTP_OK);
@@ -193,9 +193,9 @@ EOT;
         }
 EOT;
 
-        $this->client->request('PUT', sprintf('/shop-api/checkout/%s/shipping/0', $token), [], [], static::$acceptAndContentTypeHeader, $data);
+        $this->client->request('PUT', sprintf('/shop-api/WEB_GB/checkout/%s/shipping/0', $token), [], [], static::$acceptAndContentTypeHeader, $data);
 
-        $this->client->request('GET', '/shop-api/checkout/' . $token, [], [], static::$acceptAndContentTypeHeader);
+        $this->client->request('GET', '/shop-api/WEB_GB/checkout/' . $token, [], [], static::$acceptAndContentTypeHeader);
 
         $response = $this->client->getResponse();
         $this->assertResponse($response, 'checkout/cart_with_chosen_shipment_with_per_item_rate_response', Response::HTTP_OK);
@@ -214,7 +214,7 @@ EOT;
             "quantity": 2
         }
 EOT;
-        $this->client->request('PUT', sprintf('/shop-api/carts/%s/items/%d', $token, $orderItem->getId()), [], [], static::$acceptAndContentTypeHeader, $data);
+        $this->client->request('PUT', sprintf('/shop-api/WEB_GB/carts/%s/items/%d', $token, $orderItem->getId()), [], [], static::$acceptAndContentTypeHeader, $data);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'checkout/modified_cart_with_chosen_shipment_with_per_item_rate_response', Response::HTTP_OK);
@@ -263,9 +263,9 @@ EOT;
         }
 EOT;
 
-        $this->client->request('PUT', sprintf('/shop-api/checkout/%s/payment/0', $token), [], [], static::$acceptAndContentTypeHeader, $data);
+        $this->client->request('PUT', sprintf('/shop-api/WEB_GB/checkout/%s/payment/0', $token), [], [], static::$acceptAndContentTypeHeader, $data);
 
-        $this->client->request('GET', '/shop-api/checkout/' . $token, [], [], static::$acceptAndContentTypeHeader);
+        $this->client->request('GET', '/shop-api/WEB_GB/checkout/' . $token, [], [], static::$acceptAndContentTypeHeader);
 
         $response = $this->client->getResponse();
         $this->assertResponse($response, 'checkout/cart_with_chosen_payment_response', Response::HTTP_OK);

--- a/tests/Controller/CheckoutSummarizeApiTest.php
+++ b/tests/Controller/CheckoutSummarizeApiTest.php
@@ -270,6 +270,7 @@ EOT;
         $response = $this->client->getResponse();
         $this->assertResponse($response, 'checkout/cart_with_chosen_payment_response', Response::HTTP_OK);
     }
+
     /**
      * @test
      */

--- a/tests/Controller/CustomerLoginApiTest.php
+++ b/tests/Controller/CustomerLoginApiTest.php
@@ -56,7 +56,7 @@ EOT;
         }
 EOT;
 
-        $this->client->request('POST', '/shop-api/register', [], [], ['CONTENT_TYPE' => 'application/json', 'ACCEPT' => 'application/json'], $data);
+        $this->client->request('POST', '/shop-api/WEB_GB/register', [], [], ['CONTENT_TYPE' => 'application/json', 'ACCEPT' => 'application/json'], $data);
 
         $data =
 <<<EOT

--- a/tests/Controller/CustomerRegisterApiTest.php
+++ b/tests/Controller/CustomerRegisterApiTest.php
@@ -141,6 +141,30 @@ EOT;
         $this->assertResponse($response, 'customer/validation_registration_data_response', Response::HTTP_BAD_REQUEST);
     }
 
+    /**
+     * @test
+     */
+    public function it_does_not_allow_to_register_in_non_existent_channel()
+    {
+        $this->loadFixturesFromFiles(['channel.yml']);
+
+        $data =
+<<<EOT
+        {
+            "firstName": "Vin",
+            "lastName": "Diesel",
+            "plainPassword": "somepass",
+            "channel": "WEB_GB"
+        }
+EOT;
+
+        $this->client->request('POST', '/shop-api/SPACE_KLINGON/register', [], [], ['CONTENT_TYPE' => 'application/json', 'ACCEPT' => 'application/json'], $data);
+
+        $response = $this->client->getResponse();
+
+        $this->assertResponse($response, 'channel_has_not_been_found_response', Response::HTTP_NOT_FOUND);
+    }
+
     protected function getContainer(): ContainerInterface
     {
         return static::$sharedKernel->getContainer();

--- a/tests/Controller/CustomerRegisterApiTest.php
+++ b/tests/Controller/CustomerRegisterApiTest.php
@@ -33,7 +33,7 @@ final class CustomerRegisterApiTest extends JsonApiTestCase
         }
 EOT;
 
-        $this->client->request('POST', '/shop-api/register', [], [], ['CONTENT_TYPE' => 'application/json', 'ACCEPT' => 'application/json'], $data);
+        $this->client->request('POST', '/shop-api/WEB_GB/register', [], [], ['CONTENT_TYPE' => 'application/json', 'ACCEPT' => 'application/json'], $data);
 
         $response = $this->client->getResponse();
         $this->assertResponseCode($response, Response::HTTP_NO_CONTENT);
@@ -68,7 +68,7 @@ EOT;
         }
 EOT;
 
-        $this->client->request('POST', '/shop-api/register', [], [], ['CONTENT_TYPE' => 'application/json', 'ACCEPT' => 'application/json'], $data);
+        $this->client->request('POST', '/shop-api/WEB_GB/register', [], [], ['CONTENT_TYPE' => 'application/json', 'ACCEPT' => 'application/json'], $data);
 
         $response = $this->client->getResponse();
         $this->assertResponseCode($response, Response::HTTP_NO_CONTENT);
@@ -110,7 +110,7 @@ EOT;
         }
 EOT;
 
-        $this->client->request('POST', '/shop-api/register', [], [], ['CONTENT_TYPE' => 'application/json', 'ACCEPT' => 'application/json'], $data);
+        $this->client->request('POST', '/shop-api/WEB_GB/register', [], [], ['CONTENT_TYPE' => 'application/json', 'ACCEPT' => 'application/json'], $data);
 
         $response = $this->client->getResponse();
 
@@ -134,7 +134,7 @@ EOT;
         }
 EOT;
 
-        $this->client->request('POST', '/shop-api/register', [], [], ['CONTENT_TYPE' => 'application/json', 'ACCEPT' => 'application/json'], $data);
+        $this->client->request('POST', '/shop-api/WEB_GB/register', [], [], ['CONTENT_TYPE' => 'application/json', 'ACCEPT' => 'application/json'], $data);
 
         $response = $this->client->getResponse();
 

--- a/tests/Controller/CustomerRequestPasswordResettingApiTest.php
+++ b/tests/Controller/CustomerRequestPasswordResettingApiTest.php
@@ -18,7 +18,7 @@ final class CustomerRequestPasswordResettingApiTest extends JsonApiTestCase
      */
     public function it_allows_to_reset_user_password()
     {
-        $this->loadFixturesFromFiles(['customer.yml']);
+        $this->loadFixturesFromFiles(['channel.yml', 'customer.yml']);
 
         $data = '{"email": "oliver@queen.com"}';
 
@@ -31,6 +31,22 @@ final class CustomerRequestPasswordResettingApiTest extends JsonApiTestCase
         $emailChecker = $this->get('sylius.behat.email_checker');
 
         $this->assertTrue($emailChecker->hasRecipient('oliver@queen.com'));
+    }
+
+
+    /**
+     * @test
+     */
+    public function it_does_not_allow_to_reset_user_password_in_non_existent_channel()
+    {
+        $this->loadFixturesFromFiles(['channel.yml', 'customer.yml']);
+
+        $data = '{"email": "oliver@queen.com"}';
+
+        $this->client->request('PUT', '/shop-api/SPACE_KLINGON/request-password-reset', [], [], ['CONTENT_TYPE' => 'application/json', 'ACCEPT' => 'application/json'], $data);
+
+        $response = $this->client->getResponse();
+        $this->assertResponse($response, 'channel_has_not_been_found_response', Response::HTTP_NOT_FOUND);
     }
 
     protected function getContainer(): ContainerInterface

--- a/tests/Controller/CustomerRequestPasswordResettingApiTest.php
+++ b/tests/Controller/CustomerRequestPasswordResettingApiTest.php
@@ -22,7 +22,7 @@ final class CustomerRequestPasswordResettingApiTest extends JsonApiTestCase
 
         $data = '{"email": "oliver@queen.com"}';
 
-        $this->client->request('PUT', '/shop-api/request-password-reset', [], [], ['CONTENT_TYPE' => 'application/json', 'ACCEPT' => 'application/json'], $data);
+        $this->client->request('PUT', '/shop-api/WEB_GB/request-password-reset', [], [], ['CONTENT_TYPE' => 'application/json', 'ACCEPT' => 'application/json'], $data);
 
         $response = $this->client->getResponse();
         $this->assertResponseCode($response, Response::HTTP_NO_CONTENT);

--- a/tests/Controller/CustomerRequestPasswordResettingApiTest.php
+++ b/tests/Controller/CustomerRequestPasswordResettingApiTest.php
@@ -33,7 +33,6 @@ final class CustomerRequestPasswordResettingApiTest extends JsonApiTestCase
         $this->assertTrue($emailChecker->hasRecipient('oliver@queen.com'));
     }
 
-
     /**
      * @test
      */

--- a/tests/Controller/CustomerResendVerificationTokenApiTest.php
+++ b/tests/Controller/CustomerResendVerificationTokenApiTest.php
@@ -31,11 +31,11 @@ final class CustomerResendVerificationTokenApiTest extends JsonApiTestCase
         }
 EOT;
 
-        $this->client->request('POST', '/shop-api/register', [], [], ['CONTENT_TYPE' => 'application/json', 'ACCEPT' => 'application/json'], $data);
+        $this->client->request('POST', '/shop-api/WEB_GB/register', [], [], ['CONTENT_TYPE' => 'application/json', 'ACCEPT' => 'application/json'], $data);
 
         $resendForEmail = '{"email": "vinny@fandf.com"}';
 
-        $this->client->request('POST', '/shop-api/resend-verification-link', [], [], ['CONTENT_TYPE' => 'application/json', 'ACCEPT' => 'application/json'], $resendForEmail);
+        $this->client->request('POST', '/shop-api/WEB_GB/resend-verification-link', [], [], ['CONTENT_TYPE' => 'application/json', 'ACCEPT' => 'application/json'], $resendForEmail);
 
         $response = $this->client->getResponse();
         $this->assertResponseCode($response, Response::HTTP_CREATED);
@@ -51,7 +51,7 @@ EOT;
      */
     public function it_does_not_allow_to_resend_verification_email_if_email_is_not_defined()
     {
-        $this->client->request('POST', '/shop-api/resend-verification-link', [], [], ['CONTENT_TYPE' => 'application/json', 'ACCEPT' => 'application/json']);
+        $this->client->request('POST', '/shop-api/WEB_GB/resend-verification-link', [], [], ['CONTENT_TYPE' => 'application/json', 'ACCEPT' => 'application/json']);
 
         $response = $this->client->getResponse();
         $this->assertResponse($response, 'customer/validation_email_not_defined_response', Response::HTTP_BAD_REQUEST);
@@ -64,7 +64,7 @@ EOT;
     {
         $resendForEmail = '{"email": "vinnyfandf.com"}';
 
-        $this->client->request('POST', '/shop-api/resend-verification-link', [], [], ['CONTENT_TYPE' => 'application/json', 'ACCEPT' => 'application/json'], $resendForEmail);
+        $this->client->request('POST', '/shop-api/WEB_GB/resend-verification-link', [], [], ['CONTENT_TYPE' => 'application/json', 'ACCEPT' => 'application/json'], $resendForEmail);
 
         $response = $this->client->getResponse();
         $this->assertResponse($response, 'customer/validation_email_not_valid_response', Response::HTTP_BAD_REQUEST);
@@ -77,7 +77,7 @@ EOT;
     {
         $resendForEmail = '{"email": "vinny@fandf.com"}';
 
-        $this->client->request('POST', '/shop-api/resend-verification-link', [], [], ['CONTENT_TYPE' => 'application/json', 'ACCEPT' => 'application/json'], $resendForEmail);
+        $this->client->request('POST', '/shop-api/WEB_GB/resend-verification-link', [], [], ['CONTENT_TYPE' => 'application/json', 'ACCEPT' => 'application/json'], $resendForEmail);
 
         $response = $this->client->getResponse();
         $this->assertResponse($response, 'customer/validation_email_not_found_response', Response::HTTP_BAD_REQUEST);

--- a/tests/Controller/CustomerResendVerificationTokenApiTest.php
+++ b/tests/Controller/CustomerResendVerificationTokenApiTest.php
@@ -51,6 +51,8 @@ EOT;
      */
     public function it_does_not_allow_to_resend_verification_email_if_email_is_not_defined()
     {
+        $this->loadFixturesFromFiles(['channel.yml']);
+
         $this->client->request('POST', '/shop-api/WEB_GB/resend-verification-link', [], [], ['CONTENT_TYPE' => 'application/json', 'ACCEPT' => 'application/json']);
 
         $response = $this->client->getResponse();
@@ -62,6 +64,8 @@ EOT;
      */
     public function it_does_not_allow_to_resend_verification_email_if_email_is_not_malformed()
     {
+        $this->loadFixturesFromFiles(['channel.yml']);
+
         $resendForEmail = '{"email": "vinnyfandf.com"}';
 
         $this->client->request('POST', '/shop-api/WEB_GB/resend-verification-link', [], [], ['CONTENT_TYPE' => 'application/json', 'ACCEPT' => 'application/json'], $resendForEmail);
@@ -75,12 +79,29 @@ EOT;
      */
     public function it_does_not_allow_to_resend_verification_email_if_customer_does_not_exists()
     {
+        $this->loadFixturesFromFiles(['channel.yml']);
+
         $resendForEmail = '{"email": "vinny@fandf.com"}';
 
         $this->client->request('POST', '/shop-api/WEB_GB/resend-verification-link', [], [], ['CONTENT_TYPE' => 'application/json', 'ACCEPT' => 'application/json'], $resendForEmail);
 
         $response = $this->client->getResponse();
         $this->assertResponse($response, 'customer/validation_email_not_found_response', Response::HTTP_BAD_REQUEST);
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_allow_to_resend_verification_token_in_non_existent_channel()
+    {
+        $this->loadFixturesFromFiles(['channel.yml']);
+
+        $resendForEmail = '{"email": "vinny@fandf.com"}';
+
+        $this->client->request('POST', '/shop-api/SPACE_KLINGON/resend-verification-link', [], [], ['CONTENT_TYPE' => 'application/json', 'ACCEPT' => 'application/json'], $resendForEmail);
+
+        $response = $this->client->getResponse();
+        $this->assertResponse($response, 'channel_has_not_been_found_response', Response::HTTP_NOT_FOUND);
     }
 
     protected function getContainer(): ContainerInterface

--- a/tests/Controller/CustomerResetPasswordApiTest.php
+++ b/tests/Controller/CustomerResetPasswordApiTest.php
@@ -23,7 +23,7 @@ final class CustomerResetPasswordApiTest extends JsonApiTestCase
 
         $data = '{"email": "oliver@queen.com"}';
 
-        $this->client->request('PUT', '/shop-api/request-password-reset', [], [], ['CONTENT_TYPE' => 'application/json', 'ACCEPT' => 'application/json'], $data);
+        $this->client->request('PUT', '/shop-api/WEB_GB/request-password-reset', [], [], ['CONTENT_TYPE' => 'application/json', 'ACCEPT' => 'application/json'], $data);
 
         /** @var UserRepositoryInterface $userRepository */
         $userRepository = $this->get('sylius.repository.shop_user');
@@ -40,7 +40,7 @@ final class CustomerResetPasswordApiTest extends JsonApiTestCase
         }
 EOT;
 
-        $this->client->request('PUT', '/shop-api/password-reset/' . $user->getPasswordResetToken(), [], [], ['CONTENT_TYPE' => 'application/json', 'ACCEPT' => 'application/json'], $newPasswords);
+        $this->client->request('PUT', '/shop-api/WEB_GB/password-reset/' . $user->getPasswordResetToken(), [], [], ['CONTENT_TYPE' => 'application/json', 'ACCEPT' => 'application/json'], $newPasswords);
 
         $response = $this->client->getResponse();
         $this->assertResponseCode($response, Response::HTTP_NO_CONTENT);

--- a/tests/Controller/CustomerUpdateCustomerApiTest.php
+++ b/tests/Controller/CustomerUpdateCustomerApiTest.php
@@ -39,7 +39,7 @@ final class CustomerUpdateCustomerApiTest extends JsonApiTestCase
             "subscribedToNewsletter": true
         }
 EOT;
-        $this->client->request('PUT', '/shop-api/me', [], [], self::$contentTypeHeader, $data);
+        $this->client->request('PUT', '/shop-api/WEB_GB/me', [], [], self::$contentTypeHeader, $data);
         $response = $this->client->getResponse();
         $this->assertResponse($response, 'customer/update_customer', Response::HTTP_OK);
 
@@ -74,7 +74,7 @@ EOT;
             "subscribedToNewsletter": true
         }
 EOT;
-        $this->client->request('PUT', '/shop-api/me', [], [], self::$contentTypeHeader, $data);
+        $this->client->request('PUT', '/shop-api/WEB_GB/me', [], [], self::$contentTypeHeader, $data);
         $response = $this->client->getResponse();
         $this->assertResponseCode($response, Response::HTTP_INTERNAL_SERVER_ERROR);
     }
@@ -97,7 +97,7 @@ EOT;
             "phoneNumber": ""
         }
 EOT;
-        $this->client->request('PUT', '/shop-api/me', [], [], self::$contentTypeHeader, $data);
+        $this->client->request('PUT', '/shop-api/WEB_GB/me', [], [], self::$contentTypeHeader, $data);
         $response = $this->client->getResponse();
         $this->assertResponse($response, 'customer/validation_empty_data', Response::HTTP_BAD_REQUEST);
     }

--- a/tests/Controller/CustomerUpdateCustomerApiTest.php
+++ b/tests/Controller/CustomerUpdateCustomerApiTest.php
@@ -21,7 +21,7 @@ final class CustomerUpdateCustomerApiTest extends JsonApiTestCase
      */
     public function it_updates_customer()
     {
-        $this->loadFixturesFromFiles(['customer.yml']);
+        $this->loadFixturesFromFiles(['channel.yml', 'customer.yml']);
         $this->logInUser('oliver@queen.com', '123password');
 
         /** @var CustomerRepositoryInterface $customerRepository */
@@ -60,7 +60,7 @@ EOT;
      */
     public function it_does_not_allow_to_update_customer_without_being_logged_in()
     {
-        $this->loadFixturesFromFiles(['customer.yml']);
+        $this->loadFixturesFromFiles(['channel.yml', 'customer.yml']);
 
         $data =
 <<<EOT
@@ -84,7 +84,7 @@ EOT;
      */
     public function it_does_not_allow_to_update_customer_without_passing_required_data()
     {
-        $this->loadFixturesFromFiles(['customer.yml']);
+        $this->loadFixturesFromFiles(['channel.yml', 'customer.yml']);
         $this->logInUser('oliver@queen.com', '123password');
 
         $data =
@@ -100,5 +100,28 @@ EOT;
         $this->client->request('PUT', '/shop-api/WEB_GB/me', [], [], self::$contentTypeHeader, $data);
         $response = $this->client->getResponse();
         $this->assertResponse($response, 'customer/validation_empty_data', Response::HTTP_BAD_REQUEST);
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_allow_to_update_customer_in_non_existent_channel()
+    {
+        $this->loadFixturesFromFiles(['channel.yml', 'customer.yml']);
+        $this->logInUser('oliver@queen.com', '123password');
+
+        $data =
+<<<EOT
+        {
+            "firstName": "",
+            "lastName": "",
+            "email": "",
+            "gender": "",
+            "phoneNumber": ""
+        }
+EOT;
+        $this->client->request('PUT', '/shop-api/SPACE_KLINGON/me', [], [], self::$contentTypeHeader, $data);
+        $response = $this->client->getResponse();
+        $this->assertResponse($response, 'channel_has_not_been_found_response', Response::HTTP_NOT_FOUND);
     }
 }

--- a/tests/Controller/CustomerVerifyApiTest.php
+++ b/tests/Controller/CustomerVerifyApiTest.php
@@ -45,6 +45,38 @@ EOT;
         $this->assertResponseCode($response, Response::HTTP_NO_CONTENT);
     }
 
+    /**
+     * @test
+     */
+    public function it_does_not_allow_to_verify_customer_in_non_existent_channel()
+    {
+        $this->loadFixturesFromFiles(['channel.yml']);
+
+        $data =
+<<<EOT
+        {
+            "firstName": "Vin",
+            "lastName": "Diesel",
+            "email": "vinny@fandf.com",
+            "plainPassword": "somepass",
+            "channel": "WEB_GB"
+        }
+EOT;
+
+        $this->client->request('POST', '/shop-api/WEB_GB/register', [], [], ['CONTENT_TYPE' => 'application/json', 'ACCEPT' => 'application/json'], $data);
+
+        /** @var UserRepositoryInterface $userRepository */
+        $userRepository = $this->get('sylius.repository.shop_user');
+        $user = $userRepository->findOneByEmail('vinny@fandf.com');
+
+        $verifyEmail = sprintf('{"token": "%s"}', $user->getEmailVerificationToken());
+
+        $this->client->request('PUT', '/shop-api/SPACE_KLINGON/verify-account', [], [], ['CONTENT_TYPE' => 'application/json', 'ACCEPT' => 'application/json'], $verifyEmail);
+
+        $response = $this->client->getResponse();
+        $this->assertResponse($response, 'channel_has_not_been_found_response', Response::HTTP_NOT_FOUND);
+    }
+
     protected function getContainer(): ContainerInterface
     {
         return static::$sharedKernel->getContainer();

--- a/tests/Controller/CustomerVerifyApiTest.php
+++ b/tests/Controller/CustomerVerifyApiTest.php
@@ -31,7 +31,7 @@ final class CustomerVerifyApiTest extends JsonApiTestCase
         }
 EOT;
 
-        $this->client->request('POST', '/shop-api/register', [], [], ['CONTENT_TYPE' => 'application/json', 'ACCEPT' => 'application/json'], $data);
+        $this->client->request('POST', '/shop-api/WEB_GB/register', [], [], ['CONTENT_TYPE' => 'application/json', 'ACCEPT' => 'application/json'], $data);
 
         /** @var UserRepositoryInterface $userRepository */
         $userRepository = $this->get('sylius.repository.shop_user');
@@ -39,7 +39,7 @@ EOT;
 
         $verifyEmail = sprintf('{"token": "%s"}', $user->getEmailVerificationToken());
 
-        $this->client->request('PUT', '/shop-api/verify-account', [], [], ['CONTENT_TYPE' => 'application/json', 'ACCEPT' => 'application/json'], $verifyEmail);
+        $this->client->request('PUT', '/shop-api/WEB_GB/verify-account', [], [], ['CONTENT_TYPE' => 'application/json', 'ACCEPT' => 'application/json'], $verifyEmail);
 
         $response = $this->client->getResponse();
         $this->assertResponseCode($response, Response::HTTP_NO_CONTENT);

--- a/tests/Controller/LoggedInCustomerDetailsActionTest.php
+++ b/tests/Controller/LoggedInCustomerDetailsActionTest.php
@@ -28,7 +28,7 @@ EOT;
         $response = json_decode($this->client->getResponse()->getContent(), true);
         $this->client->setServerParameter('HTTP_Authorization', sprintf('Bearer %s', $response['token']));
 
-        $this->client->request('GET', '/shop-api/me', [], [], [
+        $this->client->request('GET', '/shop-api/WEB_GB/me', [], [], [
             'CONTENT_TYPE' => 'application/json',
             'ACCEPT' => 'application/json',
         ]);

--- a/tests/Controller/LoggedInCustomerDetailsActionTest.php
+++ b/tests/Controller/LoggedInCustomerDetailsActionTest.php
@@ -36,6 +36,7 @@ EOT;
         $response = $this->client->getResponse();
         $this->assertResponse($response, 'customer/logged_in_customer_details_response', Response::HTTP_OK);
     }
+
     /**
      * @test
      */

--- a/tests/Controller/LoggedInCustomerDetailsActionTest.php
+++ b/tests/Controller/LoggedInCustomerDetailsActionTest.php
@@ -13,7 +13,7 @@ final class LoggedInCustomerDetailsActionTest extends JsonApiTestCase
      */
     public function it_shows_currently_logged_in_customer_details()
     {
-        $this->loadFixturesFromFiles(['customer.yml']);
+        $this->loadFixturesFromFiles(['channel.yml', 'customer.yml']);
 
         $data =
 <<<EOT
@@ -35,5 +35,33 @@ EOT;
 
         $response = $this->client->getResponse();
         $this->assertResponse($response, 'customer/logged_in_customer_details_response', Response::HTTP_OK);
+    }
+    /**
+     * @test
+     */
+    public function it_does_not_show_currently_logged_in_customer_details_in_non_existent_channel()
+    {
+        $this->loadFixturesFromFiles(['channel.yml', 'customer.yml']);
+
+        $data =
+<<<EOT
+        {
+            "_username": "oliver@queen.com",
+            "_password": "123password"
+        }
+EOT;
+
+        $this->client->request('POST', '/shop-api/login_check', [], [], ['CONTENT_TYPE' => 'application/json', 'ACCEPT' => 'application/json'], $data);
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+        $this->client->setServerParameter('HTTP_Authorization', sprintf('Bearer %s', $response['token']));
+
+        $this->client->request('GET', '/shop-api/SPACE_KLINGON/me', [], [], [
+            'CONTENT_TYPE' => 'application/json',
+            'ACCEPT' => 'application/json',
+        ]);
+
+        $response = $this->client->getResponse();
+        $this->assertResponse($response, 'channel_has_not_been_found_response', Response::HTTP_NOT_FOUND);
     }
 }

--- a/tests/Controller/OrderShowApiTest.php
+++ b/tests/Controller/OrderShowApiTest.php
@@ -34,7 +34,7 @@ final class OrderShowApiTest extends JsonApiTestCase
      */
     public function it_returns_a_not_found_exception_if_there_is_no_placed_order_with_given_id(): void
     {
-        $this->loadFixturesFromFiles(['customer.yml']);
+        $this->loadFixturesFromFiles(['channel.yml', 'customer.yml']);
         $this->logInUser('oliver@queen.com', '123password');
 
         $this->client->request('GET', '/shop-api/WEB_GB/orders/13', [], [], ['ACCEPT' => 'application/json']);
@@ -48,9 +48,24 @@ final class OrderShowApiTest extends JsonApiTestCase
      */
     public function it_returns_an_unauthorized_exception_if_there_is_no_logged_in_user(): void
     {
+        $this->loadFixturesFromFiles(['channel.yml']);
+
         $this->client->request('GET', '/shop-api/WEB_GB/orders/2', [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponseCode($response, Response::HTTP_UNAUTHORIZED);
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_show_order_details_in_non_existent_channel()
+    {
+        $this->loadFixturesFromFiles(['channel.yml']);
+
+        $this->client->request('GET', '/shop-api/SPACE_KLINGON/orders/2', [], [], ['ACCEPT' => 'application/json']);
+        $response = $this->client->getResponse();
+
+        $this->assertResponse($response, 'channel_has_not_been_found_response', Response::HTTP_NOT_FOUND);
     }
 }

--- a/tests/Controller/OrderShowApiTest.php
+++ b/tests/Controller/OrderShowApiTest.php
@@ -23,7 +23,7 @@ final class OrderShowApiTest extends JsonApiTestCase
         /** @var OrderInterface $placedOrder */
         $placedOrder = $fixtures['placed_order'];
 
-        $this->client->request('GET', '/shop-api/orders/' . $placedOrder->getId(), [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('GET', '/shop-api/WEB_GB/orders/' . $placedOrder->getId(), [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'order/order_details_response', Response::HTTP_OK);
@@ -37,7 +37,7 @@ final class OrderShowApiTest extends JsonApiTestCase
         $this->loadFixturesFromFiles(['customer.yml']);
         $this->logInUser('oliver@queen.com', '123password');
 
-        $this->client->request('GET', '/shop-api/orders/13', [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('GET', '/shop-api/WEB_GB/orders/13', [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'order/order_not_found_response', Response::HTTP_NOT_FOUND);
@@ -48,7 +48,7 @@ final class OrderShowApiTest extends JsonApiTestCase
      */
     public function it_returns_an_unauthorized_exception_if_there_is_no_logged_in_user(): void
     {
-        $this->client->request('GET', '/shop-api/orders/2', [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('GET', '/shop-api/WEB_GB/orders/2', [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponseCode($response, Response::HTTP_UNAUTHORIZED);

--- a/tests/Controller/OrdersListApiTest.php
+++ b/tests/Controller/OrdersListApiTest.php
@@ -30,9 +30,24 @@ final class OrdersListApiTest extends JsonApiTestCase
      */
     public function it_returns_an_unauthorized_exception_if_there_is_no_logged_in_user(): void
     {
+        $this->loadFixturesFromFile('channel.yml');
+
         $this->client->request('GET', '/shop-api/WEB_GB/orders', [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponseCode($response, Response::HTTP_UNAUTHORIZED);
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_show_orders_list_in_non_existent_channel()
+    {
+        $this->loadFixturesFromFile('channel.yml');
+
+        $this->client->request('GET', '/shop-api/SPACE_KLINGON/orders', [], [], ['ACCEPT' => 'application/json']);
+        $response = $this->client->getResponse();
+
+        $this->assertResponse($response, 'channel_has_not_been_found_response', Response::HTTP_NOT_FOUND);
     }
 }

--- a/tests/Controller/OrdersListApiTest.php
+++ b/tests/Controller/OrdersListApiTest.php
@@ -19,7 +19,7 @@ final class OrdersListApiTest extends JsonApiTestCase
         $this->loadFixturesFromFiles(['customer.yml', 'country.yml', 'address.yml', 'shop.yml', 'payment.yml', 'shipping.yml', 'order.yml']);
         $this->logInUser('oliver@queen.com', '123password');
 
-        $this->client->request('GET', '/shop-api/orders', [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('GET', '/shop-api/WEB_GB/orders', [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'order/orders_list_response', Response::HTTP_OK);
@@ -30,7 +30,7 @@ final class OrdersListApiTest extends JsonApiTestCase
      */
     public function it_returns_an_unauthorized_exception_if_there_is_no_logged_in_user(): void
     {
-        $this->client->request('GET', '/shop-api/orders', [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('GET', '/shop-api/WEB_GB/orders', [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponseCode($response, Response::HTTP_UNAUTHORIZED);

--- a/tests/Controller/ProductAddReviewByCodeApiTest.php
+++ b/tests/Controller/ProductAddReviewByCodeApiTest.php
@@ -18,7 +18,7 @@ final class ProductAddReviewByCodeApiTest extends JsonApiTestCase
         $this->loadFixturesFromFiles(['shop.yml']);
 
         $data =
-<<<EOT
+            <<<EOT
         {
             "channelCode": "WEB_GB",
             "title": "Awesome product",
@@ -54,5 +54,28 @@ EOT;
         $response = $this->client->getResponse();
 
         $this->assertResponseCode($response, Response::HTTP_CREATED);
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_allow_to_add_product_review_by_code_in_non_existent_channel()
+    {
+        $this->loadFixturesFromFiles(['shop.yml']);
+
+        $data =
+<<<EOT
+        {
+            "channelCode": "WEB_GB",
+            "title": "Awesome product",
+            "rating": 5,
+            "comment": "If I were a mug, I would like to be like this one!",
+            "email": "oliver@example.com"
+        }
+EOT;
+        $this->client->request('POST', '/shop-api/SPACE_KLINGON/products/LOGAN_MUG_CODE/reviews', [], [], self::$acceptAndContentTypeHeader, $data);
+        $response = $this->client->getResponse();
+
+        $this->assertResponse($response, 'channel_has_not_been_found_response', Response::HTTP_NOT_FOUND);
     }
 }

--- a/tests/Controller/ProductAddReviewByCodeApiTest.php
+++ b/tests/Controller/ProductAddReviewByCodeApiTest.php
@@ -27,7 +27,7 @@ final class ProductAddReviewByCodeApiTest extends JsonApiTestCase
             "email": "oliver@example.com"
         }
 EOT;
-        $this->client->request('POST', '/shop-api/products/LOGAN_MUG_CODE/reviews', [], [], self::$acceptAndContentTypeHeader, $data);
+        $this->client->request('POST', '/shop-api/WEB_GB/products/LOGAN_MUG_CODE/reviews', [], [], self::$acceptAndContentTypeHeader, $data);
         $response = $this->client->getResponse();
 
         $this->assertResponseCode($response, Response::HTTP_CREATED);
@@ -50,7 +50,7 @@ EOT;
             "email": "oliver@example.com"
         }
 EOT;
-        $this->client->request('POST', '/shop-api/products/LOGAN_MUG_CODE/reviews', [], [], self::$acceptAndContentTypeHeader, $data);
+        $this->client->request('POST', '/shop-api/WEB_GB/products/LOGAN_MUG_CODE/reviews', [], [], self::$acceptAndContentTypeHeader, $data);
         $response = $this->client->getResponse();
 
         $this->assertResponseCode($response, Response::HTTP_CREATED);

--- a/tests/Controller/ProductAddReviewBySlugApiTest.php
+++ b/tests/Controller/ProductAddReviewBySlugApiTest.php
@@ -27,7 +27,7 @@ final class ProductAddReviewBySlugApiTest extends JsonApiTestCase
             "email": "oliver@example.com"
         }
 EOT;
-        $this->client->request('POST', '/shop-api/product-reviews-by-slug/logan-mug', [], [], self::$acceptAndContentTypeHeader, $data);
+        $this->client->request('POST', '/shop-api/WEB_GB/product-reviews-by-slug/logan-mug', [], [], self::$acceptAndContentTypeHeader, $data);
         $response = $this->client->getResponse();
 
         $this->assertResponseCode($response, Response::HTTP_CREATED);
@@ -50,7 +50,7 @@ EOT;
             "email": "oliver@example.com"
         }
 EOT;
-        $this->client->request('POST', '/shop-api/product-reviews-by-slug/logan-mug', [], [], self::$acceptAndContentTypeHeader, $data);
+        $this->client->request('POST', '/shop-api/WEB_GB/product-reviews-by-slug/logan-mug', [], [], self::$acceptAndContentTypeHeader, $data);
         $response = $this->client->getResponse();
 
         $this->assertResponseCode($response, Response::HTTP_CREATED);

--- a/tests/Controller/ProductAddReviewBySlugApiTest.php
+++ b/tests/Controller/ProductAddReviewBySlugApiTest.php
@@ -55,4 +55,27 @@ EOT;
 
         $this->assertResponseCode($response, Response::HTTP_CREATED);
     }
+
+    /**
+     * @test
+     */
+    public function it_does_not_allow_to_add_product_review_by_slug_in_non_existent_channel()
+    {
+        $this->loadFixturesFromFiles(['shop.yml']);
+
+        $data =
+<<<EOT
+        {
+            "channelCode": "WEB_GB",
+            "title": "Awesome product",
+            "rating": 5,
+            "comment": "If I were a mug, I would like to be like this one!",
+            "email": "oliver@example.com"
+        }
+EOT;
+        $this->client->request('POST', '/shop-api/SPACE_KLINGON/product-reviews-by-slug/logan-mug', [], [], self::$acceptAndContentTypeHeader, $data);
+        $response = $this->client->getResponse();
+
+        $this->assertResponse($response, 'channel_has_not_been_found_response', Response::HTTP_NOT_FOUND);
+    }
 }

--- a/tests/Controller/ProductShowCatalogByCodeApiTest.php
+++ b/tests/Controller/ProductShowCatalogByCodeApiTest.php
@@ -15,7 +15,7 @@ final class ProductShowCatalogByCodeApiTest extends JsonApiTestCase
     {
         $this->loadFixturesFromFiles(['shop.yml']);
 
-        $this->client->request('GET', '/shop-api/WEB_GB/taxon-products/BRAND?channel=WEB_GB', [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('GET', '/shop-api/WEB_GB/taxon-products/BRAND', [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'product/product_list_page_by_code_response', Response::HTTP_OK);
@@ -28,7 +28,7 @@ final class ProductShowCatalogByCodeApiTest extends JsonApiTestCase
     {
         $this->loadFixturesFromFiles(['shop.yml']);
 
-        $this->client->request('GET', '/shop-api/WEB_GB/taxon-products/WOMEN_T_SHIRTS?channel=WEB_GB', [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('GET', '/shop-api/WEB_GB/taxon-products/WOMEN_T_SHIRTS', [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'product/product_t_shirt_list_page_by_code_response', Response::HTTP_OK);
@@ -41,7 +41,7 @@ final class ProductShowCatalogByCodeApiTest extends JsonApiTestCase
     {
         $this->loadFixturesFromFiles(['shop.yml']);
 
-        $this->client->request('GET', '/shop-api/WEB_GB/taxon-products/BRAND?channel=WEB_GB&locale=de_DE', [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('GET', '/shop-api/WEB_GB/taxon-products/BRAND?locale=de_DE', [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'product/german_product_list_page_by_code_response', Response::HTTP_OK);
@@ -54,7 +54,7 @@ final class ProductShowCatalogByCodeApiTest extends JsonApiTestCase
     {
         $this->loadFixturesFromFiles(['shop.yml']);
 
-        $this->client->request('GET', '/shop-api/WEB_GB/taxon-products/BRAND?channel=WEB_GB&limit=1&page=2', [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('GET', '/shop-api/WEB_GB/taxon-products/BRAND?limit=1&page=2', [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'product/limited_product_list_page_by_code_response', Response::HTTP_OK);
@@ -67,7 +67,7 @@ final class ProductShowCatalogByCodeApiTest extends JsonApiTestCase
     {
         $this->loadFixturesFromFiles(['shop.yml']);
 
-        $this->client->request('GET', '/shop-api/SPACE_KLINGON/taxon-products/BRAND?channel=WEB_GB', [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('GET', '/shop-api/SPACE_KLINGON/taxon-products/BRAND', [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'channel_has_not_been_found_response', Response::HTTP_NOT_FOUND);

--- a/tests/Controller/ProductShowCatalogByCodeApiTest.php
+++ b/tests/Controller/ProductShowCatalogByCodeApiTest.php
@@ -15,7 +15,7 @@ final class ProductShowCatalogByCodeApiTest extends JsonApiTestCase
     {
         $this->loadFixturesFromFiles(['shop.yml']);
 
-        $this->client->request('GET', '/shop-api/taxon-products/BRAND?channel=WEB_GB', [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('GET', '/shop-api/WEB_GB/taxon-products/BRAND?channel=WEB_GB', [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'product/product_list_page_by_code_response', Response::HTTP_OK);
@@ -28,7 +28,7 @@ final class ProductShowCatalogByCodeApiTest extends JsonApiTestCase
     {
         $this->loadFixturesFromFiles(['shop.yml']);
 
-        $this->client->request('GET', '/shop-api/taxon-products/WOMEN_T_SHIRTS?channel=WEB_GB', [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('GET', '/shop-api/WEB_GB/taxon-products/WOMEN_T_SHIRTS?channel=WEB_GB', [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'product/product_t_shirt_list_page_by_code_response', Response::HTTP_OK);
@@ -41,7 +41,7 @@ final class ProductShowCatalogByCodeApiTest extends JsonApiTestCase
     {
         $this->loadFixturesFromFiles(['shop.yml']);
 
-        $this->client->request('GET', '/shop-api/taxon-products/BRAND?channel=WEB_GB&locale=de_DE', [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('GET', '/shop-api/WEB_GB/taxon-products/BRAND?channel=WEB_GB&locale=de_DE', [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'product/german_product_list_page_by_code_response', Response::HTTP_OK);
@@ -54,7 +54,7 @@ final class ProductShowCatalogByCodeApiTest extends JsonApiTestCase
     {
         $this->loadFixturesFromFiles(['shop.yml']);
 
-        $this->client->request('GET', '/shop-api/taxon-products/BRAND?channel=WEB_GB&limit=1&page=2', [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('GET', '/shop-api/WEB_GB/taxon-products/BRAND?channel=WEB_GB&limit=1&page=2', [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'product/limited_product_list_page_by_code_response', Response::HTTP_OK);

--- a/tests/Controller/ProductShowCatalogByCodeApiTest.php
+++ b/tests/Controller/ProductShowCatalogByCodeApiTest.php
@@ -59,4 +59,17 @@ final class ProductShowCatalogByCodeApiTest extends JsonApiTestCase
 
         $this->assertResponse($response, 'product/limited_product_list_page_by_code_response', Response::HTTP_OK);
     }
+
+    /**
+     * @test
+     */
+    public function it_does_not_show_product_catalog_by_code_in_non_existent_channel()
+    {
+        $this->loadFixturesFromFiles(['shop.yml']);
+
+        $this->client->request('GET', '/shop-api/SPACE_KLINGON/taxon-products/BRAND?channel=WEB_GB', [], [], ['ACCEPT' => 'application/json']);
+        $response = $this->client->getResponse();
+
+        $this->assertResponse($response, 'channel_has_not_been_found_response', Response::HTTP_NOT_FOUND);
+    }
 }

--- a/tests/Controller/ProductShowCatalogBySlugApiTest.php
+++ b/tests/Controller/ProductShowCatalogBySlugApiTest.php
@@ -15,7 +15,7 @@ final class ProductShowCatalogBySlugApiTest extends JsonApiTestCase
     {
         $this->loadFixturesFromFiles(['shop.yml']);
 
-        $this->client->request('GET', '/shop-api/WEB_GB/taxon-products-by-slug/brands?channel=WEB_GB', [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('GET', '/shop-api/WEB_GB/taxon-products-by-slug/brands', [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'product/product_list_page_by_slug_response', Response::HTTP_OK);
@@ -28,7 +28,7 @@ final class ProductShowCatalogBySlugApiTest extends JsonApiTestCase
     {
         $this->loadFixturesFromFiles(['shop.yml']);
 
-        $this->client->request('GET', '/shop-api/WEB_GB/taxon-products-by-slug/categories/t-shirts/women-t-shirts?channel=WEB_GB', [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('GET', '/shop-api/WEB_GB/taxon-products-by-slug/categories/t-shirts/women-t-shirts', [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'product/product_t_shirt_list_page_by_slug_response', Response::HTTP_OK);
@@ -41,7 +41,7 @@ final class ProductShowCatalogBySlugApiTest extends JsonApiTestCase
     {
         $this->loadFixturesFromFiles(['shop.yml']);
 
-        $this->client->request('GET', '/shop-api/WEB_GB/taxon-products-by-slug/marken?channel=WEB_GB&locale=de_DE', [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('GET', '/shop-api/WEB_GB/taxon-products-by-slug/marken?locale=de_DE', [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'product/german_product_list_page_by_slug_response', Response::HTTP_OK);
@@ -54,7 +54,7 @@ final class ProductShowCatalogBySlugApiTest extends JsonApiTestCase
     {
         $this->loadFixturesFromFiles(['shop.yml']);
 
-        $this->client->request('GET', '/shop-api/WEB_GB/taxon-products-by-slug/brands?channel=WEB_GB&limit=1&page=2', [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('GET', '/shop-api/WEB_GB/taxon-products-by-slug/brands?limit=1&page=2', [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'product/limited_product_list_page_by_slug_response', Response::HTTP_OK);
@@ -67,7 +67,7 @@ final class ProductShowCatalogBySlugApiTest extends JsonApiTestCase
     {
         $this->loadFixturesFromFiles(['shop.yml']);
 
-        $this->client->request('GET', '/shop-api/WEB_GB/taxon-products-by-slug/x-man?channel=WEB_GB&sorting[createdAt]=desc', [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('GET', '/shop-api/WEB_GB/taxon-products-by-slug/x-man?sorting[createdAt]=desc', [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'product/product_list_page_by_slug_response', Response::HTTP_OK);
@@ -80,7 +80,7 @@ final class ProductShowCatalogBySlugApiTest extends JsonApiTestCase
     {
         $this->loadFixturesFromFiles(['shop.yml']);
 
-        $this->client->request('GET', '/shop-api/WEB_GB/taxon-products-by-slug/x-man?channel=WEB_GB&criteria[search][value]=Logans+Hat', [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('GET', '/shop-api/WEB_GB/taxon-products-by-slug/x-man?criteria[search][value]=Logans+Hat', [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'product/product_list_page_by_slug_response', Response::HTTP_OK);
@@ -93,7 +93,7 @@ final class ProductShowCatalogBySlugApiTest extends JsonApiTestCase
     {
         $this->loadFixturesFromFiles(['shop.yml']);
 
-        $this->client->request('GET', '/shop-api/SPACE_KLINGON/taxon-products-by-slug/brands?channel=WEB_GB', [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('GET', '/shop-api/SPACE_KLINGON/taxon-products-by-slug/brands', [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'channel_has_not_been_found_response', Response::HTTP_NOT_FOUND);

--- a/tests/Controller/ProductShowCatalogBySlugApiTest.php
+++ b/tests/Controller/ProductShowCatalogBySlugApiTest.php
@@ -60,19 +60,42 @@ final class ProductShowCatalogBySlugApiTest extends JsonApiTestCase
         $this->assertResponse($response, 'product/limited_product_list_page_by_slug_response', Response::HTTP_OK);
     }
 
+    /**
+     * TODO check is it possible (test annotation make it fail)
+     */
     public function it_shows_sorted_product_list()
     {
+        $this->loadFixturesFromFiles(['shop.yml']);
+
         $this->client->request('GET', '/shop-api/WEB_GB/taxon-products-by-slug/x-man?channel=WEB_GB&sorting[createdAt]=desc', [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'product/product_list_page_by_slug_response', Response::HTTP_OK);
     }
 
+    /**
+     * TODO check is it possible (test annotation make it fail)
+     */
     public function it_expose_only_some_of_products_in_the_list()
     {
+        $this->loadFixturesFromFiles(['shop.yml']);
+
         $this->client->request('GET', '/shop-api/WEB_GB/taxon-products-by-slug/x-man?channel=WEB_GB&criteria[search][value]=Logans+Hat', [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'product/product_list_page_by_slug_response', Response::HTTP_OK);
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_show_product_catalog_by_slug_in_non_existent_channel()
+    {
+        $this->loadFixturesFromFiles(['shop.yml']);
+
+        $this->client->request('GET', '/shop-api/SPACE_KLINGON/taxon-products-by-slug/brands?channel=WEB_GB', [], [], ['ACCEPT' => 'application/json']);
+        $response = $this->client->getResponse();
+
+        $this->assertResponse($response, 'channel_has_not_been_found_response', Response::HTTP_NOT_FOUND);
     }
 }

--- a/tests/Controller/ProductShowCatalogBySlugApiTest.php
+++ b/tests/Controller/ProductShowCatalogBySlugApiTest.php
@@ -15,7 +15,7 @@ final class ProductShowCatalogBySlugApiTest extends JsonApiTestCase
     {
         $this->loadFixturesFromFiles(['shop.yml']);
 
-        $this->client->request('GET', '/shop-api/taxon-products-by-slug/brands?channel=WEB_GB', [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('GET', '/shop-api/WEB_GB/taxon-products-by-slug/brands?channel=WEB_GB', [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'product/product_list_page_by_slug_response', Response::HTTP_OK);
@@ -28,7 +28,7 @@ final class ProductShowCatalogBySlugApiTest extends JsonApiTestCase
     {
         $this->loadFixturesFromFiles(['shop.yml']);
 
-        $this->client->request('GET', '/shop-api/taxon-products-by-slug/categories/t-shirts/women-t-shirts?channel=WEB_GB', [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('GET', '/shop-api/WEB_GB/taxon-products-by-slug/categories/t-shirts/women-t-shirts?channel=WEB_GB', [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'product/product_t_shirt_list_page_by_slug_response', Response::HTTP_OK);
@@ -41,7 +41,7 @@ final class ProductShowCatalogBySlugApiTest extends JsonApiTestCase
     {
         $this->loadFixturesFromFiles(['shop.yml']);
 
-        $this->client->request('GET', '/shop-api/taxon-products-by-slug/marken?channel=WEB_GB&locale=de_DE', [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('GET', '/shop-api/WEB_GB/taxon-products-by-slug/marken?channel=WEB_GB&locale=de_DE', [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'product/german_product_list_page_by_slug_response', Response::HTTP_OK);
@@ -54,7 +54,7 @@ final class ProductShowCatalogBySlugApiTest extends JsonApiTestCase
     {
         $this->loadFixturesFromFiles(['shop.yml']);
 
-        $this->client->request('GET', '/shop-api/taxon-products-by-slug/brands?channel=WEB_GB&limit=1&page=2', [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('GET', '/shop-api/WEB_GB/taxon-products-by-slug/brands?channel=WEB_GB&limit=1&page=2', [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'product/limited_product_list_page_by_slug_response', Response::HTTP_OK);
@@ -62,7 +62,7 @@ final class ProductShowCatalogBySlugApiTest extends JsonApiTestCase
 
     public function it_shows_sorted_product_list()
     {
-        $this->client->request('GET', '/shop-api/taxon-products-by-slug/x-man?channel=WEB_GB&sorting[createdAt]=desc', [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('GET', '/shop-api/WEB_GB/taxon-products-by-slug/x-man?channel=WEB_GB&sorting[createdAt]=desc', [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'product/product_list_page_by_slug_response', Response::HTTP_OK);
@@ -70,7 +70,7 @@ final class ProductShowCatalogBySlugApiTest extends JsonApiTestCase
 
     public function it_expose_only_some_of_products_in_the_list()
     {
-        $this->client->request('GET', '/shop-api/taxon-products-by-slug/x-man?channel=WEB_GB&criteria[search][value]=Logans+Hat', [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('GET', '/shop-api/WEB_GB/taxon-products-by-slug/x-man?channel=WEB_GB&criteria[search][value]=Logans+Hat', [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'product/product_list_page_by_slug_response', Response::HTTP_OK);

--- a/tests/Controller/ProductShowDetailsByCodeApiTest.php
+++ b/tests/Controller/ProductShowDetailsByCodeApiTest.php
@@ -96,4 +96,17 @@ final class ProductShowDetailsByCodeApiTest extends JsonApiTestCase
 
         $this->assertResponse($response, 'product/german_product_with_options_details_page', Response::HTTP_OK);
     }
+
+    /**
+     * @test
+     */
+    public function it_does_not_show_product_details_by_code_in_non_existent_channel()
+    {
+        $this->loadFixturesFromFiles(['shop.yml']);
+
+        $this->client->request('GET', '/shop-api/SPACE_KLINGON/products/LOGAN_MUG_CODE?channel=WEB_GB', [], [], ['ACCEPT' => 'application/json']);
+        $response = $this->client->getResponse();
+
+        $this->assertResponse($response, 'channel_has_not_been_found_response', Response::HTTP_NOT_FOUND);
+    }
 }

--- a/tests/Controller/ProductShowDetailsByCodeApiTest.php
+++ b/tests/Controller/ProductShowDetailsByCodeApiTest.php
@@ -15,7 +15,7 @@ final class ProductShowDetailsByCodeApiTest extends JsonApiTestCase
     {
         $this->loadFixturesFromFiles(['shop.yml']);
 
-        $this->client->request('GET', '/shop-api/products/LOGAN_MUG_CODE?channel=WEB_GB', [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('GET', '/shop-api/WEB_GB/products/LOGAN_MUG_CODE?channel=WEB_GB', [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'product/simple_product_details_page', Response::HTTP_OK);
@@ -26,7 +26,7 @@ final class ProductShowDetailsByCodeApiTest extends JsonApiTestCase
      */
     public function it_throws_a_not_found_exception_if_channel_has_not_been_found()
     {
-        $this->client->request('GET', '/shop-api/products/LOGAN_MUG_CODE?channel=WEB_GB', [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('GET', '/shop-api/WEB_GB/products/LOGAN_MUG_CODE?channel=WEB_GB', [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'product/channel_has_not_been_found_response', Response::HTTP_NOT_FOUND);
@@ -39,7 +39,7 @@ final class ProductShowDetailsByCodeApiTest extends JsonApiTestCase
     {
         $this->loadFixturesFromFiles(['shop.yml']);
 
-        $this->client->request('GET', '/shop-api/products/WRONG_PRODUCT_CODE?channel=WEB_GB', [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('GET', '/shop-api/WEB_GB/products/WRONG_PRODUCT_CODE?channel=WEB_GB', [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'product/product_has_not_been_found_for_given_code_response', Response::HTTP_NOT_FOUND);
@@ -52,7 +52,7 @@ final class ProductShowDetailsByCodeApiTest extends JsonApiTestCase
     {
         $this->loadFixturesFromFiles(['shop.yml']);
 
-        $this->client->request('GET', '/shop-api/products/LOGAN_MUG_CODE?channel=WEB_GB&locale=de_DE', [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('GET', '/shop-api/WEB_GB/products/LOGAN_MUG_CODE?channel=WEB_GB&locale=de_DE', [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'product/german_simple_product_details_page', Response::HTTP_OK);
@@ -65,7 +65,7 @@ final class ProductShowDetailsByCodeApiTest extends JsonApiTestCase
     {
         $this->loadFixturesFromFiles(['shop.yml']);
 
-        $this->client->request('GET', '/shop-api/products/LOGAN_T_SHIRT_CODE?channel=WEB_GB', [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('GET', '/shop-api/WEB_GB/products/LOGAN_T_SHIRT_CODE?channel=WEB_GB', [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'product/product_with_variant_details_page', Response::HTTP_OK);
@@ -78,7 +78,7 @@ final class ProductShowDetailsByCodeApiTest extends JsonApiTestCase
     {
         $this->loadFixturesFromFiles(['shop.yml']);
 
-        $this->client->request('GET', '/shop-api/products/LOGAN_HAT_CODE?channel=WEB_GB', [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('GET', '/shop-api/WEB_GB/products/LOGAN_HAT_CODE?channel=WEB_GB', [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'product/product_with_options_details_page', Response::HTTP_OK);
@@ -91,7 +91,7 @@ final class ProductShowDetailsByCodeApiTest extends JsonApiTestCase
     {
         $this->loadFixturesFromFiles(['shop.yml']);
 
-        $this->client->request('GET', '/shop-api/products/LOGAN_HAT_CODE?channel=WEB_GB&locale=de_DE', [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('GET', '/shop-api/WEB_GB/products/LOGAN_HAT_CODE?channel=WEB_GB&locale=de_DE', [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'product/german_product_with_options_details_page', Response::HTTP_OK);

--- a/tests/Controller/ProductShowDetailsByCodeApiTest.php
+++ b/tests/Controller/ProductShowDetailsByCodeApiTest.php
@@ -15,7 +15,7 @@ final class ProductShowDetailsByCodeApiTest extends JsonApiTestCase
     {
         $this->loadFixturesFromFiles(['shop.yml']);
 
-        $this->client->request('GET', '/shop-api/WEB_GB/products/LOGAN_MUG_CODE?channel=WEB_GB', [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('GET', '/shop-api/WEB_GB/products/LOGAN_MUG_CODE', [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'product/simple_product_details_page', Response::HTTP_OK);
@@ -26,7 +26,7 @@ final class ProductShowDetailsByCodeApiTest extends JsonApiTestCase
      */
     public function it_throws_a_not_found_exception_if_channel_has_not_been_found()
     {
-        $this->client->request('GET', '/shop-api/WEB_GB/products/LOGAN_MUG_CODE?channel=WEB_GB', [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('GET', '/shop-api/WEB_GB/products/LOGAN_MUG_CODE', [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'product/channel_has_not_been_found_response', Response::HTTP_NOT_FOUND);
@@ -39,7 +39,7 @@ final class ProductShowDetailsByCodeApiTest extends JsonApiTestCase
     {
         $this->loadFixturesFromFiles(['shop.yml']);
 
-        $this->client->request('GET', '/shop-api/WEB_GB/products/WRONG_PRODUCT_CODE?channel=WEB_GB', [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('GET', '/shop-api/WEB_GB/products/WRONG_PRODUCT_CODE', [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'product/product_has_not_been_found_for_given_code_response', Response::HTTP_NOT_FOUND);
@@ -52,7 +52,7 @@ final class ProductShowDetailsByCodeApiTest extends JsonApiTestCase
     {
         $this->loadFixturesFromFiles(['shop.yml']);
 
-        $this->client->request('GET', '/shop-api/WEB_GB/products/LOGAN_MUG_CODE?channel=WEB_GB&locale=de_DE', [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('GET', '/shop-api/WEB_GB/products/LOGAN_MUG_CODE?locale=de_DE', [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'product/german_simple_product_details_page', Response::HTTP_OK);
@@ -65,7 +65,7 @@ final class ProductShowDetailsByCodeApiTest extends JsonApiTestCase
     {
         $this->loadFixturesFromFiles(['shop.yml']);
 
-        $this->client->request('GET', '/shop-api/WEB_GB/products/LOGAN_T_SHIRT_CODE?channel=WEB_GB', [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('GET', '/shop-api/WEB_GB/products/LOGAN_T_SHIRT_CODE', [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'product/product_with_variant_details_page', Response::HTTP_OK);
@@ -78,7 +78,7 @@ final class ProductShowDetailsByCodeApiTest extends JsonApiTestCase
     {
         $this->loadFixturesFromFiles(['shop.yml']);
 
-        $this->client->request('GET', '/shop-api/WEB_GB/products/LOGAN_HAT_CODE?channel=WEB_GB', [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('GET', '/shop-api/WEB_GB/products/LOGAN_HAT_CODE', [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'product/product_with_options_details_page', Response::HTTP_OK);
@@ -91,7 +91,7 @@ final class ProductShowDetailsByCodeApiTest extends JsonApiTestCase
     {
         $this->loadFixturesFromFiles(['shop.yml']);
 
-        $this->client->request('GET', '/shop-api/WEB_GB/products/LOGAN_HAT_CODE?channel=WEB_GB&locale=de_DE', [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('GET', '/shop-api/WEB_GB/products/LOGAN_HAT_CODE?locale=de_DE', [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'product/german_product_with_options_details_page', Response::HTTP_OK);
@@ -104,7 +104,7 @@ final class ProductShowDetailsByCodeApiTest extends JsonApiTestCase
     {
         $this->loadFixturesFromFiles(['shop.yml']);
 
-        $this->client->request('GET', '/shop-api/SPACE_KLINGON/products/LOGAN_MUG_CODE?channel=WEB_GB', [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('GET', '/shop-api/SPACE_KLINGON/products/LOGAN_MUG_CODE', [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'channel_has_not_been_found_response', Response::HTTP_NOT_FOUND);

--- a/tests/Controller/ProductShowDetailsBySlugApiTest.php
+++ b/tests/Controller/ProductShowDetailsBySlugApiTest.php
@@ -15,7 +15,7 @@ final class ProductShowDetailsBySlugApiTest extends JsonApiTestCase
     {
         $this->loadFixturesFromFiles(['shop.yml']);
 
-        $this->client->request('GET', '/shop-api/products-by-slug/logan-mug?channel=WEB_GB', [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('GET', '/shop-api/WEB_GB/products-by-slug/logan-mug?channel=WEB_GB', [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'product/simple_product_details_page', Response::HTTP_OK);
@@ -28,7 +28,7 @@ final class ProductShowDetailsBySlugApiTest extends JsonApiTestCase
     {
         $this->loadFixturesFromFiles(['shop.yml']);
 
-        $this->client->request('GET', '/shop-api/products-by-slug/logan-shoes?channel=WEB_GB', [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('GET', '/shop-api/WEB_GB/products-by-slug/logan-shoes?channel=WEB_GB', [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'product/product_without_taxons_details_page', Response::HTTP_OK);
@@ -39,7 +39,7 @@ final class ProductShowDetailsBySlugApiTest extends JsonApiTestCase
      */
     public function it_throws_a_not_found_exception_if_channel_has_not_been_found()
     {
-        $this->client->request('GET', '/shop-api/products-by-slug/logan-mug?channel=WEB_GB', [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('GET', '/shop-api/WEB_GB/products-by-slug/logan-mug?channel=WEB_GB', [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'product/channel_has_not_been_found_response', Response::HTTP_NOT_FOUND);
@@ -52,7 +52,7 @@ final class ProductShowDetailsBySlugApiTest extends JsonApiTestCase
     {
         $this->loadFixturesFromFiles(['shop.yml']);
 
-        $this->client->request('GET', '/shop-api/products-by-slug/some-weird-stuff?channel=WEB_GB', [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('GET', '/shop-api/WEB_GB/products-by-slug/some-weird-stuff?channel=WEB_GB', [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'product/product_has_not_been_found_for_given_slug_response', Response::HTTP_NOT_FOUND);
@@ -65,7 +65,7 @@ final class ProductShowDetailsBySlugApiTest extends JsonApiTestCase
     {
         $this->loadFixturesFromFiles(['shop.yml']);
 
-        $this->client->request('GET', '/shop-api/products-by-slug/logan-becher?channel=WEB_GB&locale=de_DE', [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('GET', '/shop-api/WEB_GB/products-by-slug/logan-becher?channel=WEB_GB&locale=de_DE', [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'product/german_simple_product_details_page', Response::HTTP_OK);
@@ -78,7 +78,7 @@ final class ProductShowDetailsBySlugApiTest extends JsonApiTestCase
     {
         $this->loadFixturesFromFiles(['shop.yml']);
 
-        $this->client->request('GET', '/shop-api/products-by-slug/logan-t-shirt?channel=WEB_GB', [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('GET', '/shop-api/WEB_GB/products-by-slug/logan-t-shirt?channel=WEB_GB', [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'product/product_with_variant_details_page', Response::HTTP_OK);
@@ -91,7 +91,7 @@ final class ProductShowDetailsBySlugApiTest extends JsonApiTestCase
     {
         $this->loadFixturesFromFiles(['shop.yml']);
 
-        $this->client->request('GET', '/shop-api/products-by-slug/logan-hat?channel=WEB_GB', [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('GET', '/shop-api/WEB_GB/products-by-slug/logan-hat?channel=WEB_GB', [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'product/product_with_options_details_page', Response::HTTP_OK);
@@ -104,7 +104,7 @@ final class ProductShowDetailsBySlugApiTest extends JsonApiTestCase
     {
         $this->loadFixturesFromFiles(['shop.yml']);
 
-        $this->client->request('GET', '/shop-api/products-by-slug/logan-hut?channel=WEB_GB&locale=de_DE', [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('GET', '/shop-api/WEB_GB/products-by-slug/logan-hut?channel=WEB_GB&locale=de_DE', [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'product/german_product_with_options_details_page', Response::HTTP_OK);

--- a/tests/Controller/ProductShowDetailsBySlugApiTest.php
+++ b/tests/Controller/ProductShowDetailsBySlugApiTest.php
@@ -15,7 +15,7 @@ final class ProductShowDetailsBySlugApiTest extends JsonApiTestCase
     {
         $this->loadFixturesFromFiles(['shop.yml']);
 
-        $this->client->request('GET', '/shop-api/WEB_GB/products-by-slug/logan-mug?channel=WEB_GB', [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('GET', '/shop-api/WEB_GB/products-by-slug/logan-mug', [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'product/simple_product_details_page', Response::HTTP_OK);
@@ -28,7 +28,7 @@ final class ProductShowDetailsBySlugApiTest extends JsonApiTestCase
     {
         $this->loadFixturesFromFiles(['shop.yml']);
 
-        $this->client->request('GET', '/shop-api/WEB_GB/products-by-slug/logan-shoes?channel=WEB_GB', [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('GET', '/shop-api/WEB_GB/products-by-slug/logan-shoes', [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'product/product_without_taxons_details_page', Response::HTTP_OK);
@@ -39,7 +39,7 @@ final class ProductShowDetailsBySlugApiTest extends JsonApiTestCase
      */
     public function it_throws_a_not_found_exception_if_channel_has_not_been_found()
     {
-        $this->client->request('GET', '/shop-api/WEB_GB/products-by-slug/logan-mug?channel=WEB_GB', [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('GET', '/shop-api/WEB_GB/products-by-slug/logan-mug', [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'product/channel_has_not_been_found_response', Response::HTTP_NOT_FOUND);
@@ -52,7 +52,7 @@ final class ProductShowDetailsBySlugApiTest extends JsonApiTestCase
     {
         $this->loadFixturesFromFiles(['shop.yml']);
 
-        $this->client->request('GET', '/shop-api/WEB_GB/products-by-slug/some-weird-stuff?channel=WEB_GB', [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('GET', '/shop-api/WEB_GB/products-by-slug/some-weird-stuff', [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'product/product_has_not_been_found_for_given_slug_response', Response::HTTP_NOT_FOUND);
@@ -65,7 +65,7 @@ final class ProductShowDetailsBySlugApiTest extends JsonApiTestCase
     {
         $this->loadFixturesFromFiles(['shop.yml']);
 
-        $this->client->request('GET', '/shop-api/WEB_GB/products-by-slug/logan-becher?channel=WEB_GB&locale=de_DE', [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('GET', '/shop-api/WEB_GB/products-by-slug/logan-becher?locale=de_DE', [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'product/german_simple_product_details_page', Response::HTTP_OK);
@@ -78,7 +78,7 @@ final class ProductShowDetailsBySlugApiTest extends JsonApiTestCase
     {
         $this->loadFixturesFromFiles(['shop.yml']);
 
-        $this->client->request('GET', '/shop-api/WEB_GB/products-by-slug/logan-t-shirt?channel=WEB_GB', [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('GET', '/shop-api/WEB_GB/products-by-slug/logan-t-shirt', [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'product/product_with_variant_details_page', Response::HTTP_OK);
@@ -91,7 +91,7 @@ final class ProductShowDetailsBySlugApiTest extends JsonApiTestCase
     {
         $this->loadFixturesFromFiles(['shop.yml']);
 
-        $this->client->request('GET', '/shop-api/WEB_GB/products-by-slug/logan-hat?channel=WEB_GB', [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('GET', '/shop-api/WEB_GB/products-by-slug/logan-hat', [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'product/product_with_options_details_page', Response::HTTP_OK);
@@ -104,7 +104,7 @@ final class ProductShowDetailsBySlugApiTest extends JsonApiTestCase
     {
         $this->loadFixturesFromFiles(['shop.yml']);
 
-        $this->client->request('GET', '/shop-api/WEB_GB/products-by-slug/logan-hut?channel=WEB_GB&locale=de_DE', [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('GET', '/shop-api/WEB_GB/products-by-slug/logan-hut?locale=de_DE', [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'product/german_product_with_options_details_page', Response::HTTP_OK);
@@ -117,7 +117,7 @@ final class ProductShowDetailsBySlugApiTest extends JsonApiTestCase
     {
         $this->loadFixturesFromFiles(['shop.yml']);
 
-        $this->client->request('GET', '/shop-api/SPACE_KLINGON/products-by-slug/logan-mug?channel=WEB_GB', [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('GET', '/shop-api/SPACE_KLINGON/products-by-slug/logan-mug', [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'channel_has_not_been_found_response', Response::HTTP_NOT_FOUND);

--- a/tests/Controller/ProductShowDetailsBySlugApiTest.php
+++ b/tests/Controller/ProductShowDetailsBySlugApiTest.php
@@ -109,4 +109,17 @@ final class ProductShowDetailsBySlugApiTest extends JsonApiTestCase
 
         $this->assertResponse($response, 'product/german_product_with_options_details_page', Response::HTTP_OK);
     }
+
+    /**
+     * @test
+     */
+    public function it_does_not_show_product_details_by_slug_in_non_existent_channel()
+    {
+        $this->loadFixturesFromFiles(['shop.yml']);
+
+        $this->client->request('GET', '/shop-api/SPACE_KLINGON/products-by-slug/logan-mug?channel=WEB_GB', [], [], ['ACCEPT' => 'application/json']);
+        $response = $this->client->getResponse();
+
+        $this->assertResponse($response, 'channel_has_not_been_found_response', Response::HTTP_NOT_FOUND);
+    }
 }

--- a/tests/Controller/ProductShowLatestApiTest.php
+++ b/tests/Controller/ProductShowLatestApiTest.php
@@ -15,7 +15,7 @@ final class ProductShowLatestApiTest extends JsonApiTestCase
     {
         $this->loadFixturesFromFiles(['shop.yml']);
 
-        $this->client->request('GET', '/shop-api/product-latest/', ['channel' => 'WEB_GB'], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('GET', '/shop-api/WEB_GB/product-latest/', ['channel' => 'WEB_GB'], [], ['ACCEPT' => 'application/json']);
 
         $response = $this->client->getResponse();
 
@@ -29,7 +29,7 @@ final class ProductShowLatestApiTest extends JsonApiTestCase
     {
         $this->loadFixturesFromFiles(['shop.yml']);
 
-        $this->client->request('GET', '/shop-api/product-latest/', ['channel' => 'WEB_GB', 'limit' => 2], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('GET', '/shop-api/WEB_GB/product-latest/', ['channel' => 'WEB_GB', 'limit' => 2], [], ['ACCEPT' => 'application/json']);
 
         $response = $this->client->getResponse();
 

--- a/tests/Controller/ProductShowLatestApiTest.php
+++ b/tests/Controller/ProductShowLatestApiTest.php
@@ -35,4 +35,18 @@ final class ProductShowLatestApiTest extends JsonApiTestCase
 
         $this->assertResponse($response, 'product/product_list_latest_2_response', Response::HTTP_OK);
     }
+
+    /**
+     * @test
+     */
+    public function it_does_not_show_latest_products_in_non_existent_channel()
+    {
+        $this->loadFixturesFromFiles(['shop.yml']);
+
+        $this->client->request('GET', '/shop-api/SPACE_KLINGON/product-latest/', ['channel' => 'WEB_GB'], [], ['ACCEPT' => 'application/json']);
+
+        $response = $this->client->getResponse();
+
+        $this->assertResponse($response, 'channel_has_not_been_found_response', Response::HTTP_NOT_FOUND);
+    }
 }

--- a/tests/Controller/ProductShowReviewsByCodeApiTest.php
+++ b/tests/Controller/ProductShowReviewsByCodeApiTest.php
@@ -15,7 +15,7 @@ final class ProductShowReviewsByCodeApiTest extends JsonApiTestCase
     {
         $this->loadFixturesFromFiles(['shop.yml', 'customer.yml', 'mug_review.yml']);
 
-        $this->client->request('GET', '/shop-api/WEB_GB/products/LOGAN_MUG_CODE/reviews?channel=WEB_GB', [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('GET', '/shop-api/WEB_GB/products/LOGAN_MUG_CODE/reviews', [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'product/product_review_list_page_by_code_response', Response::HTTP_OK);
@@ -28,7 +28,7 @@ final class ProductShowReviewsByCodeApiTest extends JsonApiTestCase
     {
         $this->loadFixturesFromFiles(['channel.yml']);
 
-        $this->client->request('GET', '/shop-api/SPACE_KLINGON/products/LOGAN_MUG_CODE/reviews?channel=WEB_GB', [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('GET', '/shop-api/SPACE_KLINGON/products/LOGAN_MUG_CODE/reviews', [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'channel_has_not_been_found_response', Response::HTTP_NOT_FOUND);

--- a/tests/Controller/ProductShowReviewsByCodeApiTest.php
+++ b/tests/Controller/ProductShowReviewsByCodeApiTest.php
@@ -20,4 +20,17 @@ final class ProductShowReviewsByCodeApiTest extends JsonApiTestCase
 
         $this->assertResponse($response, 'product/product_review_list_page_by_code_response', Response::HTTP_OK);
     }
+
+    /**
+     * @test
+     */
+    public function it_does_not_show_product_reviews_by_code_in_non_existent_channel()
+    {
+        $this->loadFixturesFromFiles(['channel.yml']);
+
+        $this->client->request('GET', '/shop-api/SPACE_KLINGON/products/LOGAN_MUG_CODE/reviews?channel=WEB_GB', [], [], ['ACCEPT' => 'application/json']);
+        $response = $this->client->getResponse();
+
+        $this->assertResponse($response, 'channel_has_not_been_found_response', Response::HTTP_NOT_FOUND);
+    }
 }

--- a/tests/Controller/ProductShowReviewsByCodeApiTest.php
+++ b/tests/Controller/ProductShowReviewsByCodeApiTest.php
@@ -15,7 +15,7 @@ final class ProductShowReviewsByCodeApiTest extends JsonApiTestCase
     {
         $this->loadFixturesFromFiles(['shop.yml', 'customer.yml', 'mug_review.yml']);
 
-        $this->client->request('GET', '/shop-api/products/LOGAN_MUG_CODE/reviews?channel=WEB_GB', [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('GET', '/shop-api/WEB_GB/products/LOGAN_MUG_CODE/reviews?channel=WEB_GB', [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'product/product_review_list_page_by_code_response', Response::HTTP_OK);

--- a/tests/Controller/ProductShowReviewsBySlugApiTest.php
+++ b/tests/Controller/ProductShowReviewsBySlugApiTest.php
@@ -15,7 +15,7 @@ final class ProductShowReviewsBySlugApiTest extends JsonApiTestCase
     {
         $this->loadFixturesFromFiles(['shop.yml', 'customer.yml', 'mug_review.yml']);
 
-        $this->client->request('GET', '/shop-api/WEB_GB/product-reviews-by-slug/logan-mug?channel=WEB_GB', [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('GET', '/shop-api/WEB_GB/product-reviews-by-slug/logan-mug', [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'product/product_review_list_page_by_slug_response', Response::HTTP_OK);
@@ -28,7 +28,7 @@ final class ProductShowReviewsBySlugApiTest extends JsonApiTestCase
     {
         $this->loadFixturesFromFiles(['channel.yml']);
 
-        $this->client->request('GET', '/shop-api/SPACE_KLINGON/product-reviews-by-slug/logan-mug?channel=WEB_GB', [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('GET', '/shop-api/SPACE_KLINGON/product-reviews-by-slug/logan-mug', [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'channel_has_not_been_found_response', Response::HTTP_NOT_FOUND);

--- a/tests/Controller/ProductShowReviewsBySlugApiTest.php
+++ b/tests/Controller/ProductShowReviewsBySlugApiTest.php
@@ -15,7 +15,7 @@ final class ProductShowReviewsBySlugApiTest extends JsonApiTestCase
     {
         $this->loadFixturesFromFiles(['shop.yml', 'customer.yml', 'mug_review.yml']);
 
-        $this->client->request('GET', '/shop-api/product-reviews-by-slug/logan-mug?channel=WEB_GB', [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('GET', '/shop-api/WEB_GB/product-reviews-by-slug/logan-mug?channel=WEB_GB', [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'product/product_review_list_page_by_slug_response', Response::HTTP_OK);

--- a/tests/Controller/ProductShowReviewsBySlugApiTest.php
+++ b/tests/Controller/ProductShowReviewsBySlugApiTest.php
@@ -20,4 +20,17 @@ final class ProductShowReviewsBySlugApiTest extends JsonApiTestCase
 
         $this->assertResponse($response, 'product/product_review_list_page_by_slug_response', Response::HTTP_OK);
     }
+
+    /**
+     * @test
+     */
+    public function it_does_not_show_product_reviews_by_slug_in_non_existent_channel()
+    {
+        $this->loadFixturesFromFiles(['channel.yml']);
+
+        $this->client->request('GET', '/shop-api/SPACE_KLINGON/product-reviews-by-slug/logan-mug?channel=WEB_GB', [], [], ['ACCEPT' => 'application/json']);
+        $response = $this->client->getResponse();
+
+        $this->assertResponse($response, 'channel_has_not_been_found_response', Response::HTTP_NOT_FOUND);
+    }
 }

--- a/tests/Controller/TaxonShowDetailsApiTest.php
+++ b/tests/Controller/TaxonShowDetailsApiTest.php
@@ -15,7 +15,7 @@ final class TaxonShowDetailsApiTest extends JsonApiTestCase
     {
         $this->loadFixturesFromFiles(['shop.yml']);
 
-        $this->client->request('GET', '/shop-api/taxons/T_SHIRTS?locale=en_GB', [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('GET', '/shop-api/WEB_GB/taxons/T_SHIRTS?locale=en_GB', [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'taxon/one_of_taxons_response', Response::HTTP_OK);
@@ -28,7 +28,7 @@ final class TaxonShowDetailsApiTest extends JsonApiTestCase
     {
         $this->loadFixturesFromFiles(['shop.yml']);
 
-        $this->client->request('GET', '/shop-api/taxons/de%3Flol%3Dxd%23boom?locale=en_GB', [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('GET', '/shop-api/WEB_GB/taxons/de%3Flol%3Dxd%23boom?locale=en_GB', [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'taxon/strange_taxon_code_response', Response::HTTP_OK);
@@ -41,7 +41,7 @@ final class TaxonShowDetailsApiTest extends JsonApiTestCase
     {
         $this->loadFixturesFromFiles(['shop.yml']);
 
-        $this->client->request('GET', '/shop-api/taxons/T_SHIRTS?locale=de_DE', [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('GET', '/shop-api/WEB_GB/taxons/T_SHIRTS?locale=de_DE', [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'taxon/german_one_of_taxons_response', Response::HTTP_OK);

--- a/tests/Controller/TaxonShowDetailsApiTest.php
+++ b/tests/Controller/TaxonShowDetailsApiTest.php
@@ -46,4 +46,17 @@ final class TaxonShowDetailsApiTest extends JsonApiTestCase
 
         $this->assertResponse($response, 'taxon/german_one_of_taxons_response', Response::HTTP_OK);
     }
+
+    /**
+     * @test
+     */
+    public function it_does_not_show_taxon_details_in_non_existent_channel()
+    {
+        $this->loadFixturesFromFiles(['shop.yml']);
+
+        $this->client->request('GET', '/shop-api/SPACE_KLINGON/taxons/T_SHIRTS?locale=en_GB', [], [], ['ACCEPT' => 'application/json']);
+        $response = $this->client->getResponse();
+
+        $this->assertResponse($response, 'channel_has_not_been_found_response', Response::HTTP_NOT_FOUND);
+    }
 }

--- a/tests/Controller/TaxonShowTreeApiTest.php
+++ b/tests/Controller/TaxonShowTreeApiTest.php
@@ -15,7 +15,7 @@ final class TaxonShowTreeApiTest extends JsonApiTestCase
     {
         $this->loadFixturesFromFiles(['shop.yml']);
 
-        $this->client->request('GET', '/shop-api/taxons/', [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('GET', '/shop-api/WEB_GB/taxons/', [], [], ['ACCEPT' => 'application/json']);
 
         $response = $this->client->getResponse();
 
@@ -29,7 +29,7 @@ final class TaxonShowTreeApiTest extends JsonApiTestCase
     {
         $this->loadFixturesFromFiles(['shop.yml']);
 
-        $this->client->request('GET', '/shop-api/taxons/?locale=de_DE', [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('GET', '/shop-api/WEB_GB/taxons/?locale=de_DE', [], [], ['ACCEPT' => 'application/json']);
 
         $response = $this->client->getResponse();
 

--- a/tests/Controller/TaxonShowTreeApiTest.php
+++ b/tests/Controller/TaxonShowTreeApiTest.php
@@ -35,4 +35,18 @@ final class TaxonShowTreeApiTest extends JsonApiTestCase
 
         $this->assertResponse($response, 'taxon/german_all_taxons_response', Response::HTTP_OK);
     }
+
+    /**
+     * @test
+     */
+    public function it_does_not_show_taxons_tree_in_non_existent_channel()
+    {
+        $this->loadFixturesFromFiles(['shop.yml']);
+
+        $this->client->request('GET', '/shop-api/SPACE_KLINGON/taxons/', [], [], ['ACCEPT' => 'application/json']);
+
+        $response = $this->client->getResponse();
+
+        $this->assertResponse($response, 'channel_has_not_been_found_response', Response::HTTP_NOT_FOUND);
+    }
 }

--- a/tests/Request/ResendVerificationTokenRequestTest.php
+++ b/tests/Request/ResendVerificationTokenRequestTest.php
@@ -16,8 +16,8 @@ final class ResendVerificationTokenRequestTest extends TestCase
      */
     public function it_creates_put_simple_item_to_cart_command()
     {
-        $putSimpleItemToCartRequest = new ResendVerificationTokenRequest(new Request([], ['email' => 'daffy@the-duck.com'], []));
+        $putSimpleItemToCartRequest = new ResendVerificationTokenRequest(new Request([], ['email' => 'daffy@the-duck.com'], ['channelCode' => 'WEB_GB']));
 
-        $this->assertEquals($putSimpleItemToCartRequest->getCommand(), new SendVerificationToken('daffy@the-duck.com'));
+        $this->assertEquals($putSimpleItemToCartRequest->getCommand(), new SendVerificationToken('daffy@the-duck.com', 'WEB_GB'));
     }
 }

--- a/tests/Responses/Expected/cart/add_multiple_products_to_cart_response.json
+++ b/tests/Responses/Expected/cart/add_multiple_products_to_cart_response.json
@@ -13,6 +13,7 @@
                 "code": "LOGAN_MUG_CODE",
                 "name": "Logan Mug",
                 "slug": "logan-mug",
+                "channelCode": "WEB_GB",
                 "description": "Some description Lorem ipsum dolor sit amet.",
                 "averageRating": 0,
                 "taxons": {
@@ -64,6 +65,7 @@
                 "code": "LOGAN_T_SHIRT_CODE",
                 "name": "Logan T-Shirt",
                 "slug": "logan-t-shirt",
+                "channelCode": "WEB_GB",
                 "description": "Some description Lorem ipsum dolor sit amet.",
                 "averageRating": 0,
                 "taxons": {
@@ -117,6 +119,7 @@
                 "code": "LOGAN_HAT_CODE",
                 "name": "Logan Hat",
                 "slug": "logan-hat",
+                "channelCode": "WEB_GB",
                 "description": "Some description Lorem ipsum dolor sit amet.",
                 "averageRating": 0,
                 "taxons": {

--- a/tests/Responses/Expected/cart/add_multiple_products_to_cart_response.json
+++ b/tests/Responses/Expected/cart/add_multiple_products_to_cart_response.json
@@ -51,7 +51,7 @@
                 ],
                 "_links": {
                     "self": {
-                        "href": "\/shop-api\/products-by-slug\/logan-mug"
+                        "href": "\/shop-api\/WEB_GB\/products-by-slug\/logan-mug"
                     }
                 }
             }
@@ -104,7 +104,7 @@
                 ],
                 "_links": {
                     "self": {
-                        "href": "\/shop-api\/products-by-slug\/logan-t-shirt"
+                        "href": "\/shop-api\/WEB_GB\/products-by-slug\/logan-t-shirt"
                     }
                 }
             }
@@ -150,7 +150,7 @@
                 "images": [],
                 "_links": {
                     "self": {
-                        "href": "\/shop-api\/products-by-slug\/logan-hat"
+                        "href": "\/shop-api\/WEB_GB\/products-by-slug\/logan-hat"
                     }
                 }
             }

--- a/tests/Responses/Expected/cart/add_product_variant_based_on_options_multiple_times_to_cart_response.json
+++ b/tests/Responses/Expected/cart/add_product_variant_based_on_options_multiple_times_to_cart_response.json
@@ -13,6 +13,7 @@
                 "code": "LOGAN_HAT_CODE",
                 "name": "Logan Hat",
                 "slug": "logan-hat",
+                "channelCode": "WEB_GB",
                 "description": "Some description Lorem ipsum dolor sit amet.",
                 "averageRating": 0,
                 "taxons": {

--- a/tests/Responses/Expected/cart/add_product_variant_based_on_options_multiple_times_to_cart_response.json
+++ b/tests/Responses/Expected/cart/add_product_variant_based_on_options_multiple_times_to_cart_response.json
@@ -46,7 +46,7 @@
                 "images": [],
                 "_links": {
                     "self": {
-                        "href": "\/shop-api\/products-by-slug\/logan-hat"
+                        "href": "\/shop-api\/WEB_GB\/products-by-slug\/logan-hat"
                     }
                 }
             }

--- a/tests/Responses/Expected/cart/add_product_variant_based_on_options_to_cart_response.json
+++ b/tests/Responses/Expected/cart/add_product_variant_based_on_options_to_cart_response.json
@@ -13,6 +13,7 @@
                 "code": "LOGAN_HAT_CODE",
                 "name": "Logan Hat",
                 "slug": "logan-hat",
+                "channelCode": "WEB_GB",
                 "description": "Some description Lorem ipsum dolor sit amet.",
                 "averageRating": 0,
                 "taxons": {

--- a/tests/Responses/Expected/cart/add_product_variant_based_on_options_to_cart_response.json
+++ b/tests/Responses/Expected/cart/add_product_variant_based_on_options_to_cart_response.json
@@ -46,7 +46,7 @@
                 "images": [],
                 "_links": {
                     "self": {
-                        "href": "\/shop-api\/products-by-slug\/logan-hat"
+                        "href": "\/shop-api\/WEB_GB\/products-by-slug\/logan-hat"
                     }
                 }
             }

--- a/tests/Responses/Expected/cart/add_product_variant_multiple_times_to_cart_response.json
+++ b/tests/Responses/Expected/cart/add_product_variant_multiple_times_to_cart_response.json
@@ -13,6 +13,7 @@
                 "code": "LOGAN_T_SHIRT_CODE",
                 "name": "Logan T-Shirt",
                 "slug": "logan-t-shirt",
+                "channelCode": "WEB_GB",
                 "description": "Some description Lorem ipsum dolor sit amet.",
                 "averageRating": 0,
                 "taxons": {

--- a/tests/Responses/Expected/cart/add_product_variant_multiple_times_to_cart_response.json
+++ b/tests/Responses/Expected/cart/add_product_variant_multiple_times_to_cart_response.json
@@ -53,7 +53,7 @@
                 ],
                 "_links": {
                     "self": {
-                        "href": "\/shop-api\/products-by-slug\/logan-t-shirt"
+                        "href": "\/shop-api\/WEB_GB\/products-by-slug\/logan-t-shirt"
                     }
                 }
             }

--- a/tests/Responses/Expected/cart/add_product_variant_to_cart_response.json
+++ b/tests/Responses/Expected/cart/add_product_variant_to_cart_response.json
@@ -13,6 +13,7 @@
                 "code": "LOGAN_T_SHIRT_CODE",
                 "name": "Logan T-Shirt",
                 "slug": "logan-t-shirt",
+                "channelCode": "WEB_GB",
                 "description": "Some description Lorem ipsum dolor sit amet.",
                 "averageRating": 0,
                 "taxons": {

--- a/tests/Responses/Expected/cart/add_product_variant_to_cart_response.json
+++ b/tests/Responses/Expected/cart/add_product_variant_to_cart_response.json
@@ -53,7 +53,7 @@
                 ],
                 "_links": {
                     "self": {
-                        "href": "\/shop-api\/products-by-slug\/logan-t-shirt"
+                        "href": "\/shop-api\/WEB_GB\/products-by-slug\/logan-t-shirt"
                     }
                 }
             }

--- a/tests/Responses/Expected/cart/add_simple_product_multiple_times_to_cart_response.json
+++ b/tests/Responses/Expected/cart/add_simple_product_multiple_times_to_cart_response.json
@@ -51,7 +51,7 @@
                 ],
                 "_links": {
                     "self": {
-                        "href": "\/shop-api\/products-by-slug\/logan-mug"
+                        "href": "\/shop-api\/WEB_GB\/products-by-slug\/logan-mug"
                     }
                 }
             }

--- a/tests/Responses/Expected/cart/add_simple_product_multiple_times_to_cart_response.json
+++ b/tests/Responses/Expected/cart/add_simple_product_multiple_times_to_cart_response.json
@@ -13,6 +13,7 @@
                 "code": "LOGAN_MUG_CODE",
                 "name": "Logan Mug",
                 "slug": "logan-mug",
+                "channelCode": "WEB_GB",
                 "description": "Some description Lorem ipsum dolor sit amet.",
                 "averageRating": 0,
                 "taxons": {

--- a/tests/Responses/Expected/cart/add_simple_product_to_cart_response.json
+++ b/tests/Responses/Expected/cart/add_simple_product_to_cart_response.json
@@ -51,7 +51,7 @@
                 ],
                 "_links": {
                     "self": {
-                        "href": "\/shop-api\/products-by-slug\/logan-mug"
+                        "href": "\/shop-api\/WEB_GB\/products-by-slug\/logan-mug"
                     }
                 }
             }

--- a/tests/Responses/Expected/cart/add_simple_product_to_cart_response.json
+++ b/tests/Responses/Expected/cart/add_simple_product_to_cart_response.json
@@ -13,6 +13,7 @@
                 "code": "LOGAN_MUG_CODE",
                 "name": "Logan Mug",
                 "slug": "logan-mug",
+                "channelCode": "WEB_GB",
                 "description": "Some description Lorem ipsum dolor sit amet.",
                 "averageRating": 0,
                 "taxons": {

--- a/tests/Responses/Expected/cart/cart_with_coupon_based_promotion_applied_response.json
+++ b/tests/Responses/Expected/cart/cart_with_coupon_based_promotion_applied_response.json
@@ -51,7 +51,7 @@
                 ],
                 "_links": {
                     "self": {
-                        "href": "\/shop-api\/products-by-slug\/logan-mug"
+                        "href": "\/shop-api\/WEB_GB\/products-by-slug\/logan-mug"
                     }
                 }
             }

--- a/tests/Responses/Expected/cart/cart_with_coupon_based_promotion_applied_response.json
+++ b/tests/Responses/Expected/cart/cart_with_coupon_based_promotion_applied_response.json
@@ -13,6 +13,7 @@
                 "code": "LOGAN_MUG_CODE",
                 "name": "Logan Mug",
                 "slug": "logan-mug",
+                "channelCode": "WEB_GB",
                 "description": "Some description Lorem ipsum dolor sit amet.",
                 "averageRating": 0,
                 "taxons": {

--- a/tests/Responses/Expected/cart/filled_cart_with_product_variant_summary_response.json
+++ b/tests/Responses/Expected/cart/filled_cart_with_product_variant_summary_response.json
@@ -13,6 +13,7 @@
                 "code": "LOGAN_T_SHIRT_CODE",
                 "name": "Logan T-Shirt",
                 "slug": "logan-t-shirt",
+                "channelCode": "WEB_GB",
                 "description": "Some description Lorem ipsum dolor sit amet.",
                 "averageRating": 0,
                 "taxons": {
@@ -66,6 +67,7 @@
                 "code": "LOGAN_HAT_CODE",
                 "name": "Logan Hat",
                 "slug": "logan-hat",
+                "channelCode": "WEB_GB",
                 "averageRating": 0,
                 "description": "Some description Lorem ipsum dolor sit amet.",
                 "taxons": {

--- a/tests/Responses/Expected/cart/filled_cart_with_product_variant_summary_response.json
+++ b/tests/Responses/Expected/cart/filled_cart_with_product_variant_summary_response.json
@@ -53,7 +53,7 @@
                 ],
                 "_links": {
                     "self": {
-                        "href": "\/shop-api\/products-by-slug\/logan-t-shirt"
+                        "href": "\/shop-api\/WEB_GB\/products-by-slug\/logan-t-shirt"
                     }
                 }
             }
@@ -99,7 +99,7 @@
                 "images": [],
                 "_links": {
                     "self": {
-                        "href": "\/shop-api\/products-by-slug\/logan-hat"
+                        "href": "\/shop-api\/WEB_GB\/products-by-slug\/logan-hat"
                     }
                 }
             }

--- a/tests/Responses/Expected/cart/filled_cart_with_simple_product_summary_response.json
+++ b/tests/Responses/Expected/cart/filled_cart_with_simple_product_summary_response.json
@@ -51,7 +51,7 @@
                 ],
                 "_links": {
                     "self": {
-                        "href": "\/shop-api\/products-by-slug\/logan-mug"
+                        "href": "\/shop-api\/WEB_GB\/products-by-slug\/logan-mug"
                     }
                 }
             }

--- a/tests/Responses/Expected/cart/filled_cart_with_simple_product_summary_response.json
+++ b/tests/Responses/Expected/cart/filled_cart_with_simple_product_summary_response.json
@@ -13,6 +13,7 @@
                 "code": "LOGAN_MUG_CODE",
                 "name": "Logan Mug",
                 "slug": "logan-mug",
+                "channelCode": "WEB_GB",
                 "description": "Some description Lorem ipsum dolor sit amet.",
                 "averageRating": 0,
                 "taxons": {

--- a/tests/Responses/Expected/cart/german_filled_cart_with_product_variant_summary_response.json
+++ b/tests/Responses/Expected/cart/german_filled_cart_with_product_variant_summary_response.json
@@ -13,6 +13,7 @@
                 "code": "LOGAN_HAT_CODE",
                 "name": "Logan Hut",
                 "slug": "logan-hut",
+                "channelCode": "WEB_DE",
                 "description": "Einige Beschreibung Lorem ipsum dolor sit amet.",
                 "averageRating": 0,
                 "taxons": {
@@ -46,7 +47,7 @@
                 "images": [],
                 "_links": {
                     "self": {
-                        "href": "\/shop-api\/WEB_GB\/products-by-slug\/logan-hut"
+                        "href": "\/shop-api\/WEB_DE\/products-by-slug\/logan-hut"
                     }
                 }
             }

--- a/tests/Responses/Expected/cart/german_filled_cart_with_product_variant_summary_response.json
+++ b/tests/Responses/Expected/cart/german_filled_cart_with_product_variant_summary_response.json
@@ -46,7 +46,7 @@
                 "images": [],
                 "_links": {
                     "self": {
-                        "href": "\/shop-api\/products-by-slug\/logan-hut"
+                        "href": "\/shop-api\/WEB_GB\/products-by-slug\/logan-hut"
                     }
                 }
             }

--- a/tests/Responses/Expected/cart/german_filled_cart_with_simple_product_summary_response.json
+++ b/tests/Responses/Expected/cart/german_filled_cart_with_simple_product_summary_response.json
@@ -13,6 +13,7 @@
                 "code": "LOGAN_MUG_CODE",
                 "name": "Logan Becher",
                 "slug": "logan-becher",
+                "channelCode": "WEB_DE",
                 "averageRating": 0,
                 "taxons": {
                     "main": "MUG",
@@ -50,7 +51,7 @@
                 ],
                 "_links": {
                     "self": {
-                        "href": "\/shop-api\/WEB_GB\/products-by-slug\/logan-becher"
+                        "href": "\/shop-api\/WEB_DE\/products-by-slug\/logan-becher"
                     }
                 }
             }

--- a/tests/Responses/Expected/cart/german_filled_cart_with_simple_product_summary_response.json
+++ b/tests/Responses/Expected/cart/german_filled_cart_with_simple_product_summary_response.json
@@ -50,7 +50,7 @@
                 ],
                 "_links": {
                     "self": {
-                        "href": "\/shop-api\/products-by-slug\/logan-becher"
+                        "href": "\/shop-api\/WEB_GB\/products-by-slug\/logan-becher"
                     }
                 }
             }

--- a/tests/Responses/Expected/cart/reprocessed_cart_after_deleting_an_item.json
+++ b/tests/Responses/Expected/cart/reprocessed_cart_after_deleting_an_item.json
@@ -51,7 +51,7 @@
                 ],
                 "_links": {
                     "self": {
-                        "href": "\/shop-api\/products-by-slug\/logan-mug"
+                        "href": "\/shop-api\/WEB_GB\/products-by-slug\/logan-mug"
                     }
                 }
             }

--- a/tests/Responses/Expected/cart/reprocessed_cart_after_deleting_an_item.json
+++ b/tests/Responses/Expected/cart/reprocessed_cart_after_deleting_an_item.json
@@ -13,6 +13,7 @@
                 "code": "LOGAN_MUG_CODE",
                 "name": "Logan Mug",
                 "slug": "logan-mug",
+                "channelCode": "WEB_GB",
                 "description": "Some description Lorem ipsum dolor sit amet.",
                 "averageRating": 0,
                 "taxons": {

--- a/tests/Responses/Expected/channel_has_not_been_found_response.json
+++ b/tests/Responses/Expected/channel_has_not_been_found_response.json
@@ -1,4 +1,4 @@
 {
     "code": 404,
-    "message": "Channel with code WEB_GB has not been found."
+    "message": "Channel with code SPACE_KLINGON has not been found."
 }

--- a/tests/Responses/Expected/channel_has_not_been_found_response.json
+++ b/tests/Responses/Expected/channel_has_not_been_found_response.json
@@ -1,0 +1,4 @@
+{
+    "code": 404,
+    "message": "Channel with code WEB_GB has not been found."
+}

--- a/tests/Responses/Expected/checkout/cart_addressed_response.json
+++ b/tests/Responses/Expected/checkout/cart_addressed_response.json
@@ -51,7 +51,7 @@
                 ],
                 "_links": {
                     "self": {
-                        "href": "\/shop-api\/products-by-slug\/logan-mug"
+                        "href": "\/shop-api\/WEB_GB\/products-by-slug\/logan-mug"
                     }
                 }
             }

--- a/tests/Responses/Expected/checkout/cart_addressed_response.json
+++ b/tests/Responses/Expected/checkout/cart_addressed_response.json
@@ -13,6 +13,7 @@
                 "code": "LOGAN_MUG_CODE",
                 "name": "Logan Mug",
                 "slug": "logan-mug",
+                "channelCode": "WEB_GB",
                 "description": "Some description Lorem ipsum dolor sit amet.",
                 "averageRating": 0,
                 "taxons": {

--- a/tests/Responses/Expected/checkout/cart_addressed_with_different_shipping_and_billing_address_response.json
+++ b/tests/Responses/Expected/checkout/cart_addressed_with_different_shipping_and_billing_address_response.json
@@ -51,7 +51,7 @@
                 ],
                 "_links": {
                     "self": {
-                        "href": "\/shop-api\/products-by-slug\/logan-mug"
+                        "href": "\/shop-api\/WEB_GB\/products-by-slug\/logan-mug"
                     }
                 }
             }

--- a/tests/Responses/Expected/checkout/cart_addressed_with_different_shipping_and_billing_address_response.json
+++ b/tests/Responses/Expected/checkout/cart_addressed_with_different_shipping_and_billing_address_response.json
@@ -13,6 +13,7 @@
                 "code": "LOGAN_MUG_CODE",
                 "name": "Logan Mug",
                 "slug": "logan-mug",
+                "channelCode": "WEB_GB",
                 "description": "Some description Lorem ipsum dolor sit amet.",
                 "averageRating": 0,
                 "taxons": {

--- a/tests/Responses/Expected/checkout/cart_with_chosen_payment_response.json
+++ b/tests/Responses/Expected/checkout/cart_with_chosen_payment_response.json
@@ -51,7 +51,7 @@
                 ],
                 "_links": {
                     "self": {
-                        "href": "\/shop-api\/products-by-slug\/logan-mug"
+                        "href": "\/shop-api\/WEB_GB\/products-by-slug\/logan-mug"
                     }
                 }
             }

--- a/tests/Responses/Expected/checkout/cart_with_chosen_payment_response.json
+++ b/tests/Responses/Expected/checkout/cart_with_chosen_payment_response.json
@@ -13,6 +13,7 @@
                 "code": "LOGAN_MUG_CODE",
                 "name": "Logan Mug",
                 "slug": "logan-mug",
+                "channelCode": "WEB_GB",
                 "description": "Some description Lorem ipsum dolor sit amet.",
                 "averageRating": 0,
                 "taxons": {

--- a/tests/Responses/Expected/checkout/cart_with_chosen_shipment_response.json
+++ b/tests/Responses/Expected/checkout/cart_with_chosen_shipment_response.json
@@ -51,7 +51,7 @@
                 ],
                 "_links": {
                     "self": {
-                        "href": "\/shop-api\/products-by-slug\/logan-mug"
+                        "href": "\/shop-api\/WEB_GB\/products-by-slug\/logan-mug"
                     }
                 }
             }

--- a/tests/Responses/Expected/checkout/cart_with_chosen_shipment_response.json
+++ b/tests/Responses/Expected/checkout/cart_with_chosen_shipment_response.json
@@ -13,6 +13,7 @@
                 "code": "LOGAN_MUG_CODE",
                 "name": "Logan Mug",
                 "slug": "logan-mug",
+                "channelCode": "WEB_GB",
                 "description": "Some description Lorem ipsum dolor sit amet.",
                 "averageRating": 0,
                 "taxons": {

--- a/tests/Responses/Expected/checkout/cart_with_chosen_shipment_with_per_item_rate_response.json
+++ b/tests/Responses/Expected/checkout/cart_with_chosen_shipment_with_per_item_rate_response.json
@@ -51,7 +51,7 @@
                 ],
                 "_links": {
                     "self": {
-                        "href": "\/shop-api\/products-by-slug\/logan-mug"
+                        "href": "\/shop-api\/WEB_GB\/products-by-slug\/logan-mug"
                     }
                 }
             }

--- a/tests/Responses/Expected/checkout/cart_with_chosen_shipment_with_per_item_rate_response.json
+++ b/tests/Responses/Expected/checkout/cart_with_chosen_shipment_with_per_item_rate_response.json
@@ -13,6 +13,7 @@
                 "code": "LOGAN_MUG_CODE",
                 "name": "Logan Mug",
                 "slug": "logan-mug",
+                "channelCode": "WEB_GB",
                 "description": "Some description Lorem ipsum dolor sit amet.",
                 "averageRating": 0,
                 "taxons": {

--- a/tests/Responses/Expected/checkout/modified_cart_with_chosen_shipment_with_per_item_rate_response.json
+++ b/tests/Responses/Expected/checkout/modified_cart_with_chosen_shipment_with_per_item_rate_response.json
@@ -51,7 +51,7 @@
                 ],
                 "_links": {
                     "self": {
-                        "href": "\/shop-api\/products-by-slug\/logan-mug"
+                        "href": "\/shop-api\/WEB_GB\/products-by-slug\/logan-mug"
                     }
                 }
             }

--- a/tests/Responses/Expected/checkout/modified_cart_with_chosen_shipment_with_per_item_rate_response.json
+++ b/tests/Responses/Expected/checkout/modified_cart_with_chosen_shipment_with_per_item_rate_response.json
@@ -13,6 +13,7 @@
                 "code": "LOGAN_MUG_CODE",
                 "name": "Logan Mug",
                 "slug": "logan-mug",
+                "channelCode": "WEB_GB",
                 "description": "Some description Lorem ipsum dolor sit amet.",
                 "averageRating": 0,
                 "taxons": {

--- a/tests/Responses/Expected/order/order_details_response.json
+++ b/tests/Responses/Expected/order/order_details_response.json
@@ -50,7 +50,7 @@
                 ],
                 "_links": {
                     "self": {
-                        "href": "\/shop-api\/products-by-slug\/logan-mug"
+                        "href": "\/shop-api\/WEB_GB\/products-by-slug\/logan-mug"
                     }
                 }
             }

--- a/tests/Responses/Expected/order/order_details_response.json
+++ b/tests/Responses/Expected/order/order_details_response.json
@@ -12,6 +12,7 @@
                 "code": "LOGAN_MUG_CODE",
                 "name": "Logan Mug",
                 "slug": "logan-mug",
+                "channelCode": "WEB_GB",
                 "description": "Some description Lorem ipsum dolor sit amet.",
                 "averageRating": 0,
                 "taxons": {

--- a/tests/Responses/Expected/order/orders_list_response.json
+++ b/tests/Responses/Expected/order/orders_list_response.json
@@ -13,6 +13,7 @@
                     "code": "LOGAN_MUG_CODE",
                     "name": "Logan Mug",
                     "slug": "logan-mug",
+                    "channelCode": "WEB_GB",
                     "description": "Some description Lorem ipsum dolor sit amet.",
                     "averageRating": 0,
                     "taxons": {

--- a/tests/Responses/Expected/order/orders_list_response.json
+++ b/tests/Responses/Expected/order/orders_list_response.json
@@ -51,7 +51,7 @@
                     ],
                     "_links": {
                         "self": {
-                            "href": "\/shop-api\/products-by-slug\/logan-mug"
+                            "href": "\/shop-api\/WEB_GB\/products-by-slug\/logan-mug"
                         }
                     }
                 }

--- a/tests/Responses/Expected/product/german_product_list_page_by_code_response.json
+++ b/tests/Responses/Expected/product/german_product_list_page_by_code_response.json
@@ -4,10 +4,10 @@
     "pages": 1,
     "total": 2,
     "_links": {
-        "self": "\/shop-api\/WEB_GB\/taxon-products\/BRAND?channel=WEB_GB&locale=de_DE&page=1&limit=10",
-        "first": "\/shop-api\/WEB_GB\/taxon-products\/BRAND?channel=WEB_GB&locale=de_DE&page=1&limit=10",
-        "last": "\/shop-api\/WEB_GB\/taxon-products\/BRAND?channel=WEB_GB&locale=de_DE&page=1&limit=10",
-        "next": "\/shop-api\/WEB_GB\/taxon-products\/BRAND?channel=WEB_GB&locale=de_DE&page=1&limit=10"
+        "self": "\/shop-api\/WEB_GB\/taxon-products\/BRAND?locale=de_DE&page=1&limit=10",
+        "first": "\/shop-api\/WEB_GB\/taxon-products\/BRAND?locale=de_DE&page=1&limit=10",
+        "last": "\/shop-api\/WEB_GB\/taxon-products\/BRAND?locale=de_DE&page=1&limit=10",
+        "next": "\/shop-api\/WEB_GB\/taxon-products\/BRAND?locale=de_DE&page=1&limit=10"
     },
     "items": [
         {

--- a/tests/Responses/Expected/product/german_product_list_page_by_code_response.json
+++ b/tests/Responses/Expected/product/german_product_list_page_by_code_response.json
@@ -4,10 +4,10 @@
     "pages": 1,
     "total": 2,
     "_links": {
-        "self": "\/shop-api\/taxon-products\/BRAND?channel=WEB_GB&locale=de_DE&page=1&limit=10",
-        "first": "\/shop-api\/taxon-products\/BRAND?channel=WEB_GB&locale=de_DE&page=1&limit=10",
-        "last": "\/shop-api\/taxon-products\/BRAND?channel=WEB_GB&locale=de_DE&page=1&limit=10",
-        "next": "\/shop-api\/taxon-products\/BRAND?channel=WEB_GB&locale=de_DE&page=1&limit=10"
+        "self": "\/shop-api\/WEB_GB\/taxon-products\/BRAND?channel=WEB_GB&locale=de_DE&page=1&limit=10",
+        "first": "\/shop-api\/WEB_GB\/taxon-products\/BRAND?channel=WEB_GB&locale=de_DE&page=1&limit=10",
+        "last": "\/shop-api\/WEB_GB\/taxon-products\/BRAND?channel=WEB_GB&locale=de_DE&page=1&limit=10",
+        "next": "\/shop-api\/WEB_GB\/taxon-products\/BRAND?channel=WEB_GB&locale=de_DE&page=1&limit=10"
     },
     "items": [
         {
@@ -56,7 +56,7 @@
             ],
             "_links": {
                 "self": {
-                    "href": "\/shop-api\/products-by-slug\/logan-becher"
+                    "href": "\/shop-api\/WEB_GB\/products-by-slug\/logan-becher"
                 }
             }
         },
@@ -192,7 +192,7 @@
                         ],
                         "_links": {
                             "self": {
-                                "href": "\/shop-api\/products-by-slug\/logan-becher"
+                                "href": "\/shop-api\/WEB_GB\/products-by-slug\/logan-becher"
                             }
                         }
                     },
@@ -261,7 +261,7 @@
                         ],
                         "_links": {
                             "self": {
-                                "href": "\/shop-api\/products-by-slug\/logan-t-shirt"
+                                "href": "\/shop-api\/WEB_GB\/products-by-slug\/logan-t-shirt"
                             }
                         }
                     }
@@ -270,7 +270,7 @@
             "images": [],
             "_links": {
                 "self": {
-                    "href": "\/shop-api\/products-by-slug\/logan-hut"
+                    "href": "\/shop-api\/WEB_GB\/products-by-slug\/logan-hut"
                 }
             }
         }

--- a/tests/Responses/Expected/product/german_product_list_page_by_code_response.json
+++ b/tests/Responses/Expected/product/german_product_list_page_by_code_response.json
@@ -14,6 +14,7 @@
             "code": "LOGAN_MUG_CODE",
             "name": "Logan Becher",
             "slug": "logan-becher",
+            "channelCode": "WEB_GB",
             "averageRating": 0,
             "taxons": {
                 "main": "MUG",
@@ -64,6 +65,7 @@
             "code": "LOGAN_HAT_CODE",
             "name": "Logan Hut",
             "slug": "logan-hut",
+            "channelCode": "WEB_GB",
             "description": "Einige Beschreibung Lorem ipsum dolor sit amet.",
             "averageRating": 0,
             "taxons": {
@@ -150,6 +152,7 @@
                         "code": "LOGAN_MUG_CODE",
                         "name": "Logan Becher",
                         "slug": "logan-becher",
+                        "channelCode": "WEB_GB",
                         "averageRating": 0,
                         "taxons": {
                             "main": "MUG",
@@ -200,6 +203,7 @@
                         "code": "LOGAN_T_SHIRT_CODE",
                         "name": "Logan T-Shirt",
                         "slug": "logan-t-shirt",
+                        "channelCode": "WEB_GB",
                         "description": "Some description Lorem ipsum dolor sit amet.",
                         "averageRating": 0,
                         "taxons": {

--- a/tests/Responses/Expected/product/german_product_list_page_by_slug_response.json
+++ b/tests/Responses/Expected/product/german_product_list_page_by_slug_response.json
@@ -4,10 +4,10 @@
     "pages": 1,
     "total": 2,
     "_links": {
-        "self": "\/shop-api\/WEB_GB\/taxon-products-by-slug\/marken?channel=WEB_GB&locale=de_DE&page=1&limit=10",
-        "first": "\/shop-api\/WEB_GB\/taxon-products-by-slug\/marken?channel=WEB_GB&locale=de_DE&page=1&limit=10",
-        "last": "\/shop-api\/WEB_GB\/taxon-products-by-slug\/marken?channel=WEB_GB&locale=de_DE&page=1&limit=10",
-        "next": "\/shop-api\/WEB_GB\/taxon-products-by-slug\/marken?channel=WEB_GB&locale=de_DE&page=1&limit=10"
+        "self": "\/shop-api\/WEB_GB\/taxon-products-by-slug\/marken?locale=de_DE&page=1&limit=10",
+        "first": "\/shop-api\/WEB_GB\/taxon-products-by-slug\/marken?locale=de_DE&page=1&limit=10",
+        "last": "\/shop-api\/WEB_GB\/taxon-products-by-slug\/marken?locale=de_DE&page=1&limit=10",
+        "next": "\/shop-api\/WEB_GB\/taxon-products-by-slug\/marken?locale=de_DE&page=1&limit=10"
     },
     "items": [
         {

--- a/tests/Responses/Expected/product/german_product_list_page_by_slug_response.json
+++ b/tests/Responses/Expected/product/german_product_list_page_by_slug_response.json
@@ -4,10 +4,10 @@
     "pages": 1,
     "total": 2,
     "_links": {
-        "self": "\/shop-api\/taxon-products-by-slug\/marken?channel=WEB_GB&locale=de_DE&page=1&limit=10",
-        "first": "\/shop-api\/taxon-products-by-slug\/marken?channel=WEB_GB&locale=de_DE&page=1&limit=10",
-        "last": "\/shop-api\/taxon-products-by-slug\/marken?channel=WEB_GB&locale=de_DE&page=1&limit=10",
-        "next": "\/shop-api\/taxon-products-by-slug\/marken?channel=WEB_GB&locale=de_DE&page=1&limit=10"
+        "self": "\/shop-api\/WEB_GB\/taxon-products-by-slug\/marken?channel=WEB_GB&locale=de_DE&page=1&limit=10",
+        "first": "\/shop-api\/WEB_GB\/taxon-products-by-slug\/marken?channel=WEB_GB&locale=de_DE&page=1&limit=10",
+        "last": "\/shop-api\/WEB_GB\/taxon-products-by-slug\/marken?channel=WEB_GB&locale=de_DE&page=1&limit=10",
+        "next": "\/shop-api\/WEB_GB\/taxon-products-by-slug\/marken?channel=WEB_GB&locale=de_DE&page=1&limit=10"
     },
     "items": [
         {
@@ -56,7 +56,7 @@
             ],
             "_links": {
                 "self": {
-                    "href": "\/shop-api\/products-by-slug\/logan-becher"
+                    "href": "\/shop-api\/WEB_GB\/products-by-slug\/logan-becher"
                 }
             }
         },
@@ -192,7 +192,7 @@
                         ],
                         "_links": {
                             "self": {
-                                "href": "\/shop-api\/products-by-slug\/logan-becher"
+                                "href": "\/shop-api\/WEB_GB\/products-by-slug\/logan-becher"
                             }
                         }
                     },
@@ -261,7 +261,7 @@
                         ],
                         "_links": {
                             "self": {
-                                "href": "\/shop-api\/products-by-slug\/logan-t-shirt"
+                                "href": "\/shop-api\/WEB_GB\/products-by-slug\/logan-t-shirt"
                             }
                         }
                     }
@@ -270,7 +270,7 @@
             "images": [],
             "_links": {
                 "self": {
-                    "href": "\/shop-api\/products-by-slug\/logan-hut"
+                    "href": "\/shop-api\/WEB_GB\/products-by-slug\/logan-hut"
                 }
             }
         }

--- a/tests/Responses/Expected/product/german_product_list_page_by_slug_response.json
+++ b/tests/Responses/Expected/product/german_product_list_page_by_slug_response.json
@@ -14,6 +14,7 @@
             "code": "LOGAN_MUG_CODE",
             "name": "Logan Becher",
             "slug": "logan-becher",
+            "channelCode": "WEB_GB",
             "averageRating": 0,
             "taxons": {
                 "main": "MUG",
@@ -64,6 +65,7 @@
             "code": "LOGAN_HAT_CODE",
             "name": "Logan Hut",
             "slug": "logan-hut",
+            "channelCode": "WEB_GB",
             "description": "Einige Beschreibung Lorem ipsum dolor sit amet.",
             "averageRating": 0,
             "taxons": {
@@ -150,6 +152,7 @@
                         "code": "LOGAN_MUG_CODE",
                         "name": "Logan Becher",
                         "slug": "logan-becher",
+                        "channelCode": "WEB_GB",
                         "averageRating": 0,
                         "taxons": {
                             "main": "MUG",
@@ -200,6 +203,7 @@
                         "code": "LOGAN_T_SHIRT_CODE",
                         "name": "Logan T-Shirt",
                         "slug": "logan-t-shirt",
+                        "channelCode": "WEB_GB",
                         "description": "Some description Lorem ipsum dolor sit amet.",
                         "averageRating": 0,
                         "taxons": {

--- a/tests/Responses/Expected/product/german_product_with_options_details_page.json
+++ b/tests/Responses/Expected/product/german_product_with_options_details_page.json
@@ -131,7 +131,7 @@
                 ],
                 "_links": {
                     "self": {
-                        "href": "\/shop-api\/products-by-slug\/logan-becher"
+                        "href": "\/shop-api\/WEB_GB\/products-by-slug\/logan-becher"
                     }
                 }
             },
@@ -200,7 +200,7 @@
                 ],
                 "_links": {
                     "self": {
-                        "href": "\/shop-api\/products-by-slug\/logan-t-shirt"
+                        "href": "\/shop-api\/WEB_GB\/products-by-slug\/logan-t-shirt"
                     }
                 }
             }
@@ -209,7 +209,7 @@
     "images": [],
     "_links": {
         "self": {
-            "href": "\/shop-api\/products-by-slug\/logan-hut"
+            "href": "\/shop-api\/WEB_GB\/products-by-slug\/logan-hut"
         }
     }
 }

--- a/tests/Responses/Expected/product/german_product_with_options_details_page.json
+++ b/tests/Responses/Expected/product/german_product_with_options_details_page.json
@@ -2,6 +2,7 @@
     "code": "LOGAN_HAT_CODE",
     "name": "Logan Hut",
     "slug": "logan-hut",
+    "channelCode": "WEB_GB",
     "breadcrumb": "hute\/logan-hut",
     "description": "Einige Beschreibung Lorem ipsum dolor sit amet.",
     "averageRating": 0,
@@ -89,6 +90,7 @@
                 "code": "LOGAN_MUG_CODE",
                 "name": "Logan Becher",
                 "slug": "logan-becher",
+                "channelCode": "WEB_GB",
                 "averageRating": 0,
                 "taxons": {
                     "main": "MUG",
@@ -139,6 +141,7 @@
                 "code": "LOGAN_T_SHIRT_CODE",
                 "name": "Logan T-Shirt",
                 "slug": "logan-t-shirt",
+                "channelCode": "WEB_GB",
                 "description": "Some description Lorem ipsum dolor sit amet.",
                 "averageRating": 0,
                 "taxons": {

--- a/tests/Responses/Expected/product/german_simple_product_details_page.json
+++ b/tests/Responses/Expected/product/german_simple_product_details_page.json
@@ -2,6 +2,7 @@
     "code": "LOGAN_MUG_CODE",
     "name": "Logan Becher",
     "slug": "logan-becher",
+    "channelCode": "WEB_GB",
     "breadcrumb": "tassen\/logan-becher",
     "averageRating": 0,
     "taxons": {

--- a/tests/Responses/Expected/product/german_simple_product_details_page.json
+++ b/tests/Responses/Expected/product/german_simple_product_details_page.json
@@ -45,7 +45,7 @@
     ],
     "_links": {
         "self": {
-            "href": "\/shop-api\/products-by-slug\/logan-becher"
+            "href": "\/shop-api\/WEB_GB\/products-by-slug\/logan-becher"
         }
     }
 }

--- a/tests/Responses/Expected/product/limited_product_list_page_by_code_response.json
+++ b/tests/Responses/Expected/product/limited_product_list_page_by_code_response.json
@@ -4,10 +4,10 @@
     "pages": 3,
     "total": 3,
     "_links": {
-        "self": "\/shop-api\/WEB_GB\/taxon-products\/BRAND?channel=WEB_GB&limit=1&page=2",
-        "first": "\/shop-api\/WEB_GB\/taxon-products\/BRAND?channel=WEB_GB&limit=1&page=1",
-        "last": "\/shop-api\/WEB_GB\/taxon-products\/BRAND?channel=WEB_GB&limit=1&page=3",
-        "next": "\/shop-api\/WEB_GB\/taxon-products\/BRAND?channel=WEB_GB&limit=1&page=3"
+        "self": "\/shop-api\/WEB_GB\/taxon-products\/BRAND?limit=1&page=2",
+        "first": "\/shop-api\/WEB_GB\/taxon-products\/BRAND?limit=1&page=1",
+        "last": "\/shop-api\/WEB_GB\/taxon-products\/BRAND?limit=1&page=3",
+        "next": "\/shop-api\/WEB_GB\/taxon-products\/BRAND?limit=1&page=3"
     },
     "items": [
         {

--- a/tests/Responses/Expected/product/limited_product_list_page_by_code_response.json
+++ b/tests/Responses/Expected/product/limited_product_list_page_by_code_response.json
@@ -4,10 +4,10 @@
     "pages": 3,
     "total": 3,
     "_links": {
-        "self": "\/shop-api\/taxon-products\/BRAND?channel=WEB_GB&limit=1&page=2",
-        "first": "\/shop-api\/taxon-products\/BRAND?channel=WEB_GB&limit=1&page=1",
-        "last": "\/shop-api\/taxon-products\/BRAND?channel=WEB_GB&limit=1&page=3",
-        "next": "\/shop-api\/taxon-products\/BRAND?channel=WEB_GB&limit=1&page=3"
+        "self": "\/shop-api\/WEB_GB\/taxon-products\/BRAND?channel=WEB_GB&limit=1&page=2",
+        "first": "\/shop-api\/WEB_GB\/taxon-products\/BRAND?channel=WEB_GB&limit=1&page=1",
+        "last": "\/shop-api\/WEB_GB\/taxon-products\/BRAND?channel=WEB_GB&limit=1&page=3",
+        "next": "\/shop-api\/WEB_GB\/taxon-products\/BRAND?channel=WEB_GB&limit=1&page=3"
     },
     "items": [
         {
@@ -75,7 +75,7 @@
             ],
             "_links": {
                 "self": {
-                    "href": "\/shop-api\/products-by-slug\/logan-t-shirt"
+                    "href": "\/shop-api\/WEB_GB\/products-by-slug\/logan-t-shirt"
                 }
             }
         }

--- a/tests/Responses/Expected/product/limited_product_list_page_by_code_response.json
+++ b/tests/Responses/Expected/product/limited_product_list_page_by_code_response.json
@@ -14,6 +14,7 @@
             "code": "LOGAN_T_SHIRT_CODE",
             "name": "Logan T-Shirt",
             "slug": "logan-t-shirt",
+            "channelCode": "WEB_GB",
             "description": "Some description Lorem ipsum dolor sit amet.",
             "averageRating": 0,
             "taxons": {

--- a/tests/Responses/Expected/product/limited_product_list_page_by_slug_response.json
+++ b/tests/Responses/Expected/product/limited_product_list_page_by_slug_response.json
@@ -4,10 +4,10 @@
     "pages": 3,
     "total": 3,
     "_links": {
-        "self": "\/shop-api\/WEB_GB\/taxon-products-by-slug\/brands?channel=WEB_GB&limit=1&page=2",
-        "first": "\/shop-api\/WEB_GB\/taxon-products-by-slug\/brands?channel=WEB_GB&limit=1&page=1",
-        "last": "\/shop-api\/WEB_GB\/taxon-products-by-slug\/brands?channel=WEB_GB&limit=1&page=3",
-        "next": "\/shop-api\/WEB_GB\/taxon-products-by-slug\/brands?channel=WEB_GB&limit=1&page=3"
+        "self": "\/shop-api\/WEB_GB\/taxon-products-by-slug\/brands?limit=1&page=2",
+        "first": "\/shop-api\/WEB_GB\/taxon-products-by-slug\/brands?limit=1&page=1",
+        "last": "\/shop-api\/WEB_GB\/taxon-products-by-slug\/brands?limit=1&page=3",
+        "next": "\/shop-api\/WEB_GB\/taxon-products-by-slug\/brands?limit=1&page=3"
     },
     "items": [
         {

--- a/tests/Responses/Expected/product/limited_product_list_page_by_slug_response.json
+++ b/tests/Responses/Expected/product/limited_product_list_page_by_slug_response.json
@@ -4,10 +4,10 @@
     "pages": 3,
     "total": 3,
     "_links": {
-        "self": "\/shop-api\/taxon-products-by-slug\/brands?channel=WEB_GB&limit=1&page=2",
-        "first": "\/shop-api\/taxon-products-by-slug\/brands?channel=WEB_GB&limit=1&page=1",
-        "last": "\/shop-api\/taxon-products-by-slug\/brands?channel=WEB_GB&limit=1&page=3",
-        "next": "\/shop-api\/taxon-products-by-slug\/brands?channel=WEB_GB&limit=1&page=3"
+        "self": "\/shop-api\/WEB_GB\/taxon-products-by-slug\/brands?channel=WEB_GB&limit=1&page=2",
+        "first": "\/shop-api\/WEB_GB\/taxon-products-by-slug\/brands?channel=WEB_GB&limit=1&page=1",
+        "last": "\/shop-api\/WEB_GB\/taxon-products-by-slug\/brands?channel=WEB_GB&limit=1&page=3",
+        "next": "\/shop-api\/WEB_GB\/taxon-products-by-slug\/brands?channel=WEB_GB&limit=1&page=3"
     },
     "items": [
         {
@@ -75,7 +75,7 @@
             ],
             "_links": {
                 "self": {
-                    "href": "\/shop-api\/products-by-slug\/logan-t-shirt"
+                    "href": "\/shop-api\/WEB_GB\/products-by-slug\/logan-t-shirt"
                 }
             }
         }

--- a/tests/Responses/Expected/product/limited_product_list_page_by_slug_response.json
+++ b/tests/Responses/Expected/product/limited_product_list_page_by_slug_response.json
@@ -14,6 +14,7 @@
             "code": "LOGAN_T_SHIRT_CODE",
             "name": "Logan T-Shirt",
             "slug": "logan-t-shirt",
+            "channelCode": "WEB_GB",
             "description": "Some description Lorem ipsum dolor sit amet.",
             "averageRating": 0,
             "taxons": {

--- a/tests/Responses/Expected/product/product_list_latest_2_response.json
+++ b/tests/Responses/Expected/product/product_list_latest_2_response.json
@@ -4,6 +4,7 @@
             "code": "LOGAN_HAT_CODE",
             "name": "Logan Hat",
             "slug": "logan-hat",
+            "channelCode": "WEB_GB",
             "description": "Some description Lorem ipsum dolor sit amet.",
             "averageRating": 0,
             "taxons": {
@@ -90,6 +91,7 @@
                         "code": "LOGAN_MUG_CODE",
                         "name": "Logan Mug",
                         "slug": "logan-mug",
+                        "channelCode": "WEB_GB",
                         "description": "Some description Lorem ipsum dolor sit amet.",
                         "averageRating": 0,
                         "taxons": {
@@ -141,6 +143,7 @@
                         "code": "LOGAN_T_SHIRT_CODE",
                         "name": "Logan T-Shirt",
                         "slug": "logan-t-shirt",
+                        "channelCode": "WEB_GB",
                         "description": "Some description Lorem ipsum dolor sit amet.",
                         "averageRating": 0,
                         "taxons": {
@@ -219,6 +222,7 @@
             "code": "LOGAN_MUG_CODE",
             "name": "Logan Mug",
             "slug": "logan-mug",
+            "channelCode": "WEB_GB",
             "description": "Some description Lorem ipsum dolor sit amet.",
             "averageRating": 0,
             "taxons": {

--- a/tests/Responses/Expected/product/product_list_latest_2_response.json
+++ b/tests/Responses/Expected/product/product_list_latest_2_response.json
@@ -133,7 +133,7 @@
                         ],
                         "_links": {
                             "self": {
-                                "href": "\/shop-api\/products-by-slug\/logan-mug"
+                                "href": "\/shop-api\/WEB_GB\/products-by-slug\/logan-mug"
                             }
                         }
                     },
@@ -202,7 +202,7 @@
                         ],
                         "_links": {
                             "self": {
-                                "href": "\/shop-api\/products-by-slug\/logan-t-shirt"
+                                "href": "\/shop-api\/WEB_GB\/products-by-slug\/logan-t-shirt"
                             }
                         }
                     }
@@ -211,7 +211,7 @@
             "images": [],
             "_links": {
                 "self": {
-                    "href": "\/shop-api\/products-by-slug\/logan-hat"
+                    "href": "\/shop-api\/WEB_GB\/products-by-slug\/logan-hat"
                 }
             }
         },
@@ -262,7 +262,7 @@
             ],
             "_links": {
                 "self": {
-                    "href": "\/shop-api\/products-by-slug\/logan-mug"
+                    "href": "\/shop-api\/WEB_GB\/products-by-slug\/logan-mug"
                 }
             }
         }

--- a/tests/Responses/Expected/product/product_list_latest_4_response.json
+++ b/tests/Responses/Expected/product/product_list_latest_4_response.json
@@ -4,6 +4,7 @@
             "code": "LOGAN_HAT_CODE",
             "name": "Logan Hat",
             "slug": "logan-hat",
+            "channelCode": "WEB_GB",
             "description": "Some description Lorem ipsum dolor sit amet.",
             "averageRating": 0,
             "taxons": {
@@ -90,6 +91,7 @@
                         "code": "LOGAN_MUG_CODE",
                         "name": "Logan Mug",
                         "slug": "logan-mug",
+                        "channelCode": "WEB_GB",
                         "description": "Some description Lorem ipsum dolor sit amet.",
                         "averageRating": 0,
                         "taxons": {
@@ -141,6 +143,7 @@
                         "code": "LOGAN_T_SHIRT_CODE",
                         "name": "Logan T-Shirt",
                         "slug": "logan-t-shirt",
+                        "channelCode": "WEB_GB",
                         "description": "Some description Lorem ipsum dolor sit amet.",
                         "averageRating": 0,
                         "taxons": {
@@ -219,6 +222,7 @@
             "code": "LOGAN_MUG_CODE",
             "name": "Logan Mug",
             "slug": "logan-mug",
+            "channelCode": "WEB_GB",
             "description": "Some description Lorem ipsum dolor sit amet.",
             "averageRating": 0,
             "taxons": {
@@ -270,6 +274,7 @@
             "code": "LOGAN_SHOES_CODE",
             "name": "Logan Shoes",
             "slug": "logan-shoes",
+            "channelCode": "WEB_GB",
             "description": "Some description Lorem ipsum dolor sit amet.",
             "averageRating": 0,
             "taxons": {
@@ -289,6 +294,7 @@
             "code": "LOGAN_T_SHIRT_CODE",
             "name": "Logan T-Shirt",
             "slug": "logan-t-shirt",
+            "channelCode": "WEB_GB",
             "description": "Some description Lorem ipsum dolor sit amet.",
             "averageRating": 0,
             "taxons": {

--- a/tests/Responses/Expected/product/product_list_latest_4_response.json
+++ b/tests/Responses/Expected/product/product_list_latest_4_response.json
@@ -133,7 +133,7 @@
                         ],
                         "_links": {
                             "self": {
-                                "href": "\/shop-api\/products-by-slug\/logan-mug"
+                                "href": "\/shop-api\/WEB_GB\/products-by-slug\/logan-mug"
                             }
                         }
                     },
@@ -202,7 +202,7 @@
                         ],
                         "_links": {
                             "self": {
-                                "href": "\/shop-api\/products-by-slug\/logan-t-shirt"
+                                "href": "\/shop-api\/WEB_GB\/products-by-slug\/logan-t-shirt"
                             }
                         }
                     }
@@ -211,7 +211,7 @@
             "images": [],
             "_links": {
                 "self": {
-                    "href": "\/shop-api\/products-by-slug\/logan-hat"
+                    "href": "\/shop-api\/WEB_GB\/products-by-slug\/logan-hat"
                 }
             }
         },
@@ -262,7 +262,7 @@
             ],
             "_links": {
                 "self": {
-                    "href": "\/shop-api\/products-by-slug\/logan-mug"
+                    "href": "\/shop-api\/WEB_GB\/products-by-slug\/logan-mug"
                 }
             }
         },
@@ -281,7 +281,7 @@
             "images": [],
             "_links": {
                 "self": {
-                    "href": "\/shop-api\/products-by-slug\/logan-shoes"
+                    "href": "\/shop-api\/WEB_GB\/products-by-slug\/logan-shoes"
                 }
             }
         },
@@ -350,7 +350,7 @@
             ],
             "_links": {
                 "self": {
-                    "href": "\/shop-api\/products-by-slug\/logan-t-shirt"
+                    "href": "\/shop-api\/WEB_GB\/products-by-slug\/logan-t-shirt"
                 }
             }
         }

--- a/tests/Responses/Expected/product/product_list_page_by_code_response.json
+++ b/tests/Responses/Expected/product/product_list_page_by_code_response.json
@@ -4,10 +4,10 @@
     "pages": 1,
     "total": 3,
     "_links": {
-        "self": "\/shop-api\/WEB_GB\/taxon-products\/BRAND?channel=WEB_GB&page=1&limit=10",
-        "first": "\/shop-api\/WEB_GB\/taxon-products\/BRAND?channel=WEB_GB&page=1&limit=10",
-        "last": "\/shop-api\/WEB_GB\/taxon-products\/BRAND?channel=WEB_GB&page=1&limit=10",
-        "next": "\/shop-api\/WEB_GB\/taxon-products\/BRAND?channel=WEB_GB&page=1&limit=10"
+        "self": "\/shop-api\/WEB_GB\/taxon-products\/BRAND?page=1&limit=10",
+        "first": "\/shop-api\/WEB_GB\/taxon-products\/BRAND?page=1&limit=10",
+        "last": "\/shop-api\/WEB_GB\/taxon-products\/BRAND?page=1&limit=10",
+        "next": "\/shop-api\/WEB_GB\/taxon-products\/BRAND?page=1&limit=10"
     },
     "items": [
         {

--- a/tests/Responses/Expected/product/product_list_page_by_code_response.json
+++ b/tests/Responses/Expected/product/product_list_page_by_code_response.json
@@ -14,6 +14,7 @@
             "code": "LOGAN_MUG_CODE",
             "name": "Logan Mug",
             "slug": "logan-mug",
+            "channelCode": "WEB_GB",
             "description": "Some description Lorem ipsum dolor sit amet.",
             "averageRating": 0,
             "taxons": {
@@ -65,6 +66,7 @@
             "code": "LOGAN_T_SHIRT_CODE",
             "name": "Logan T-Shirt",
             "slug": "logan-t-shirt",
+            "channelCode": "WEB_GB",
             "description": "Some description Lorem ipsum dolor sit amet.",
             "averageRating": 0,
             "taxons": {
@@ -134,6 +136,7 @@
             "code": "LOGAN_HAT_CODE",
             "name": "Logan Hat",
             "slug": "logan-hat",
+            "channelCode": "WEB_GB",
             "description": "Some description Lorem ipsum dolor sit amet.",
             "averageRating": 0,
             "taxons": {
@@ -220,6 +223,7 @@
                         "code": "LOGAN_MUG_CODE",
                         "name": "Logan Mug",
                         "slug": "logan-mug",
+                        "channelCode": "WEB_GB",
                         "description": "Some description Lorem ipsum dolor sit amet.",
                         "averageRating": 0,
                         "taxons": {
@@ -271,6 +275,7 @@
                         "code": "LOGAN_T_SHIRT_CODE",
                         "name": "Logan T-Shirt",
                         "slug": "logan-t-shirt",
+                        "channelCode": "WEB_GB",
                         "description": "Some description Lorem ipsum dolor sit amet.",
                         "averageRating": 0,
                         "taxons": {

--- a/tests/Responses/Expected/product/product_list_page_by_code_response.json
+++ b/tests/Responses/Expected/product/product_list_page_by_code_response.json
@@ -4,10 +4,10 @@
     "pages": 1,
     "total": 3,
     "_links": {
-        "self": "\/shop-api\/taxon-products\/BRAND?channel=WEB_GB&page=1&limit=10",
-        "first": "\/shop-api\/taxon-products\/BRAND?channel=WEB_GB&page=1&limit=10",
-        "last": "\/shop-api\/taxon-products\/BRAND?channel=WEB_GB&page=1&limit=10",
-        "next": "\/shop-api\/taxon-products\/BRAND?channel=WEB_GB&page=1&limit=10"
+        "self": "\/shop-api\/WEB_GB\/taxon-products\/BRAND?channel=WEB_GB&page=1&limit=10",
+        "first": "\/shop-api\/WEB_GB\/taxon-products\/BRAND?channel=WEB_GB&page=1&limit=10",
+        "last": "\/shop-api\/WEB_GB\/taxon-products\/BRAND?channel=WEB_GB&page=1&limit=10",
+        "next": "\/shop-api\/WEB_GB\/taxon-products\/BRAND?channel=WEB_GB&page=1&limit=10"
     },
     "items": [
         {
@@ -57,7 +57,7 @@
             ],
             "_links": {
                 "self": {
-                    "href": "\/shop-api\/products-by-slug\/logan-mug"
+                    "href": "\/shop-api\/WEB_GB\/products-by-slug\/logan-mug"
                 }
             }
         },
@@ -126,7 +126,7 @@
             ],
             "_links": {
                 "self": {
-                    "href": "\/shop-api\/products-by-slug\/logan-t-shirt"
+                    "href": "\/shop-api\/WEB_GB\/products-by-slug\/logan-t-shirt"
                 }
             }
         },
@@ -263,7 +263,7 @@
                         ],
                         "_links": {
                             "self": {
-                                "href": "\/shop-api\/products-by-slug\/logan-mug"
+                                "href": "\/shop-api\/WEB_GB\/products-by-slug\/logan-mug"
                             }
                         }
                     },
@@ -332,7 +332,7 @@
                         ],
                         "_links": {
                             "self": {
-                                "href": "\/shop-api\/products-by-slug\/logan-t-shirt"
+                                "href": "\/shop-api\/WEB_GB\/products-by-slug\/logan-t-shirt"
                             }
                         }
                     }
@@ -341,7 +341,7 @@
             "images": [],
             "_links": {
                 "self": {
-                    "href": "\/shop-api\/products-by-slug\/logan-hat"
+                    "href": "\/shop-api\/WEB_GB\/products-by-slug\/logan-hat"
                 }
             }
         }

--- a/tests/Responses/Expected/product/product_list_page_by_slug_response.json
+++ b/tests/Responses/Expected/product/product_list_page_by_slug_response.json
@@ -4,10 +4,10 @@
     "pages": 1,
     "total": 3,
     "_links": {
-        "self": "\/shop-api\/taxon-products-by-slug\/brands?channel=WEB_GB&page=1&limit=10",
-        "first": "\/shop-api\/taxon-products-by-slug\/brands?channel=WEB_GB&page=1&limit=10",
-        "last": "\/shop-api\/taxon-products-by-slug\/brands?channel=WEB_GB&page=1&limit=10",
-        "next": "\/shop-api\/taxon-products-by-slug\/brands?channel=WEB_GB&page=1&limit=10"
+        "self": "\/shop-api\/WEB_GB\/taxon-products-by-slug\/brands?channel=WEB_GB&page=1&limit=10",
+        "first": "\/shop-api\/WEB_GB\/taxon-products-by-slug\/brands?channel=WEB_GB&page=1&limit=10",
+        "last": "\/shop-api\/WEB_GB\/taxon-products-by-slug\/brands?channel=WEB_GB&page=1&limit=10",
+        "next": "\/shop-api\/WEB_GB\/taxon-products-by-slug\/brands?channel=WEB_GB&page=1&limit=10"
     },
     "items": [
         {
@@ -57,7 +57,7 @@
             ],
             "_links": {
                 "self": {
-                    "href": "\/shop-api\/products-by-slug\/logan-mug"
+                    "href": "\/shop-api\/WEB_GB\/products-by-slug\/logan-mug"
                 }
             }
         },
@@ -126,7 +126,7 @@
             ],
             "_links": {
                 "self": {
-                    "href": "\/shop-api\/products-by-slug\/logan-t-shirt"
+                    "href": "\/shop-api\/WEB_GB\/products-by-slug\/logan-t-shirt"
                 }
             }
         },
@@ -263,7 +263,7 @@
                         ],
                         "_links": {
                             "self": {
-                                "href": "\/shop-api\/products-by-slug\/logan-mug"
+                                "href": "\/shop-api\/WEB_GB\/products-by-slug\/logan-mug"
                             }
                         }
                     },
@@ -332,7 +332,7 @@
                         ],
                         "_links": {
                             "self": {
-                                "href": "\/shop-api\/products-by-slug\/logan-t-shirt"
+                                "href": "\/shop-api\/WEB_GB\/products-by-slug\/logan-t-shirt"
                             }
                         }
                     }
@@ -341,7 +341,7 @@
             "images": [],
             "_links": {
                 "self": {
-                    "href": "\/shop-api\/products-by-slug\/logan-hat"
+                    "href": "\/shop-api\/WEB_GB\/products-by-slug\/logan-hat"
                 }
             }
         }

--- a/tests/Responses/Expected/product/product_list_page_by_slug_response.json
+++ b/tests/Responses/Expected/product/product_list_page_by_slug_response.json
@@ -14,6 +14,7 @@
             "code": "LOGAN_MUG_CODE",
             "name": "Logan Mug",
             "slug": "logan-mug",
+            "channelCode": "WEB_GB",
             "description": "Some description Lorem ipsum dolor sit amet.",
             "averageRating": 0,
             "taxons": {
@@ -65,6 +66,7 @@
             "code": "LOGAN_T_SHIRT_CODE",
             "name": "Logan T-Shirt",
             "slug": "logan-t-shirt",
+            "channelCode": "WEB_GB",
             "description": "Some description Lorem ipsum dolor sit amet.",
             "averageRating": 0,
             "taxons": {
@@ -134,6 +136,7 @@
             "code": "LOGAN_HAT_CODE",
             "name": "Logan Hat",
             "slug": "logan-hat",
+            "channelCode": "WEB_GB",
             "description": "Some description Lorem ipsum dolor sit amet.",
             "averageRating": 0,
             "taxons": {
@@ -220,6 +223,7 @@
                         "code": "LOGAN_MUG_CODE",
                         "name": "Logan Mug",
                         "slug": "logan-mug",
+                        "channelCode": "WEB_GB",
                         "description": "Some description Lorem ipsum dolor sit amet.",
                         "averageRating": 0,
                         "taxons": {
@@ -271,6 +275,7 @@
                         "code": "LOGAN_T_SHIRT_CODE",
                         "name": "Logan T-Shirt",
                         "slug": "logan-t-shirt",
+                        "channelCode": "WEB_GB",
                         "description": "Some description Lorem ipsum dolor sit amet.",
                         "averageRating": 0,
                         "taxons": {

--- a/tests/Responses/Expected/product/product_list_page_by_slug_response.json
+++ b/tests/Responses/Expected/product/product_list_page_by_slug_response.json
@@ -4,10 +4,10 @@
     "pages": 1,
     "total": 3,
     "_links": {
-        "self": "\/shop-api\/WEB_GB\/taxon-products-by-slug\/brands?channel=WEB_GB&page=1&limit=10",
-        "first": "\/shop-api\/WEB_GB\/taxon-products-by-slug\/brands?channel=WEB_GB&page=1&limit=10",
-        "last": "\/shop-api\/WEB_GB\/taxon-products-by-slug\/brands?channel=WEB_GB&page=1&limit=10",
-        "next": "\/shop-api\/WEB_GB\/taxon-products-by-slug\/brands?channel=WEB_GB&page=1&limit=10"
+        "self": "\/shop-api\/WEB_GB\/taxon-products-by-slug\/brands?page=1&limit=10",
+        "first": "\/shop-api\/WEB_GB\/taxon-products-by-slug\/brands?page=1&limit=10",
+        "last": "\/shop-api\/WEB_GB\/taxon-products-by-slug\/brands?page=1&limit=10",
+        "next": "\/shop-api\/WEB_GB\/taxon-products-by-slug\/brands?page=1&limit=10"
     },
     "items": [
         {

--- a/tests/Responses/Expected/product/product_review_list_page_by_code_response.json
+++ b/tests/Responses/Expected/product/product_review_list_page_by_code_response.json
@@ -4,10 +4,10 @@
     "pages": 3,
     "total": 25,
     "_links": {
-        "self": "\/shop-api\/WEB_GB\/products\/LOGAN_MUG_CODE\/reviews?channel=WEB_GB&page=1&limit=10",
-        "first": "\/shop-api\/WEB_GB\/products\/LOGAN_MUG_CODE\/reviews?channel=WEB_GB&page=1&limit=10",
-        "last": "\/shop-api\/WEB_GB\/products\/LOGAN_MUG_CODE\/reviews?channel=WEB_GB&page=3&limit=10",
-        "next": "\/shop-api\/WEB_GB\/products\/LOGAN_MUG_CODE\/reviews?channel=WEB_GB&page=2&limit=10"
+        "self": "\/shop-api\/WEB_GB\/products\/LOGAN_MUG_CODE\/reviews?page=1&limit=10",
+        "first": "\/shop-api\/WEB_GB\/products\/LOGAN_MUG_CODE\/reviews?page=1&limit=10",
+        "last": "\/shop-api\/WEB_GB\/products\/LOGAN_MUG_CODE\/reviews?page=3&limit=10",
+        "next": "\/shop-api\/WEB_GB\/products\/LOGAN_MUG_CODE\/reviews?page=2&limit=10"
     },
     "items": [
         {

--- a/tests/Responses/Expected/product/product_review_list_page_by_code_response.json
+++ b/tests/Responses/Expected/product/product_review_list_page_by_code_response.json
@@ -4,10 +4,10 @@
     "pages": 3,
     "total": 25,
     "_links": {
-        "self": "\/shop-api\/products\/LOGAN_MUG_CODE\/reviews?channel=WEB_GB&page=1&limit=10",
-        "first": "\/shop-api\/products\/LOGAN_MUG_CODE\/reviews?channel=WEB_GB&page=1&limit=10",
-        "last": "\/shop-api\/products\/LOGAN_MUG_CODE\/reviews?channel=WEB_GB&page=3&limit=10",
-        "next": "\/shop-api\/products\/LOGAN_MUG_CODE\/reviews?channel=WEB_GB&page=2&limit=10"
+        "self": "\/shop-api\/WEB_GB\/products\/LOGAN_MUG_CODE\/reviews?channel=WEB_GB&page=1&limit=10",
+        "first": "\/shop-api\/WEB_GB\/products\/LOGAN_MUG_CODE\/reviews?channel=WEB_GB&page=1&limit=10",
+        "last": "\/shop-api\/WEB_GB\/products\/LOGAN_MUG_CODE\/reviews?channel=WEB_GB&page=3&limit=10",
+        "next": "\/shop-api\/WEB_GB\/products\/LOGAN_MUG_CODE\/reviews?channel=WEB_GB&page=2&limit=10"
     },
     "items": [
         {

--- a/tests/Responses/Expected/product/product_review_list_page_by_slug_response.json
+++ b/tests/Responses/Expected/product/product_review_list_page_by_slug_response.json
@@ -4,10 +4,10 @@
     "pages": 3,
     "total": 25,
     "_links": {
-        "self": "\/shop-api\/product-reviews-by-slug\/logan-mug?channel=WEB_GB&page=1&limit=10",
-        "first": "\/shop-api\/product-reviews-by-slug\/logan-mug?channel=WEB_GB&page=1&limit=10",
-        "last": "\/shop-api\/product-reviews-by-slug\/logan-mug?channel=WEB_GB&page=3&limit=10",
-        "next": "\/shop-api\/product-reviews-by-slug\/logan-mug?channel=WEB_GB&page=2&limit=10"
+        "self": "\/shop-api\/WEB_GB\/product-reviews-by-slug\/logan-mug?channel=WEB_GB&page=1&limit=10",
+        "first": "\/shop-api\/WEB_GB\/product-reviews-by-slug\/logan-mug?channel=WEB_GB&page=1&limit=10",
+        "last": "\/shop-api\/WEB_GB\/product-reviews-by-slug\/logan-mug?channel=WEB_GB&page=3&limit=10",
+        "next": "\/shop-api\/WEB_GB\/product-reviews-by-slug\/logan-mug?channel=WEB_GB&page=2&limit=10"
     },
     "items": [
         {

--- a/tests/Responses/Expected/product/product_review_list_page_by_slug_response.json
+++ b/tests/Responses/Expected/product/product_review_list_page_by_slug_response.json
@@ -4,10 +4,10 @@
     "pages": 3,
     "total": 25,
     "_links": {
-        "self": "\/shop-api\/WEB_GB\/product-reviews-by-slug\/logan-mug?channel=WEB_GB&page=1&limit=10",
-        "first": "\/shop-api\/WEB_GB\/product-reviews-by-slug\/logan-mug?channel=WEB_GB&page=1&limit=10",
-        "last": "\/shop-api\/WEB_GB\/product-reviews-by-slug\/logan-mug?channel=WEB_GB&page=3&limit=10",
-        "next": "\/shop-api\/WEB_GB\/product-reviews-by-slug\/logan-mug?channel=WEB_GB&page=2&limit=10"
+        "self": "\/shop-api\/WEB_GB\/product-reviews-by-slug\/logan-mug?page=1&limit=10",
+        "first": "\/shop-api\/WEB_GB\/product-reviews-by-slug\/logan-mug?page=1&limit=10",
+        "last": "\/shop-api\/WEB_GB\/product-reviews-by-slug\/logan-mug?page=3&limit=10",
+        "next": "\/shop-api\/WEB_GB\/product-reviews-by-slug\/logan-mug?page=2&limit=10"
     },
     "items": [
         {

--- a/tests/Responses/Expected/product/product_t_shirt_list_page_by_code_response.json
+++ b/tests/Responses/Expected/product/product_t_shirt_list_page_by_code_response.json
@@ -4,10 +4,10 @@
     "pages": 1,
     "total": 1,
     "_links": {
-        "self": "\/shop-api\/WEB_GB\/taxon-products\/WOMEN_T_SHIRTS?channel=WEB_GB&page=1&limit=10",
-        "first": "\/shop-api\/WEB_GB\/taxon-products\/WOMEN_T_SHIRTS?channel=WEB_GB&page=1&limit=10",
-        "last": "\/shop-api\/WEB_GB\/taxon-products\/WOMEN_T_SHIRTS?channel=WEB_GB&page=1&limit=10",
-        "next": "\/shop-api\/WEB_GB\/taxon-products\/WOMEN_T_SHIRTS?channel=WEB_GB&page=1&limit=10"
+        "self": "\/shop-api\/WEB_GB\/taxon-products\/WOMEN_T_SHIRTS?page=1&limit=10",
+        "first": "\/shop-api\/WEB_GB\/taxon-products\/WOMEN_T_SHIRTS?page=1&limit=10",
+        "last": "\/shop-api\/WEB_GB\/taxon-products\/WOMEN_T_SHIRTS?page=1&limit=10",
+        "next": "\/shop-api\/WEB_GB\/taxon-products\/WOMEN_T_SHIRTS?page=1&limit=10"
     },
     "items": [
         {

--- a/tests/Responses/Expected/product/product_t_shirt_list_page_by_code_response.json
+++ b/tests/Responses/Expected/product/product_t_shirt_list_page_by_code_response.json
@@ -4,10 +4,10 @@
     "pages": 1,
     "total": 1,
     "_links": {
-        "self": "\/shop-api\/taxon-products\/WOMEN_T_SHIRTS?channel=WEB_GB&page=1&limit=10",
-        "first": "\/shop-api\/taxon-products\/WOMEN_T_SHIRTS?channel=WEB_GB&page=1&limit=10",
-        "last": "\/shop-api\/taxon-products\/WOMEN_T_SHIRTS?channel=WEB_GB&page=1&limit=10",
-        "next": "\/shop-api\/taxon-products\/WOMEN_T_SHIRTS?channel=WEB_GB&page=1&limit=10"
+        "self": "\/shop-api\/WEB_GB\/taxon-products\/WOMEN_T_SHIRTS?channel=WEB_GB&page=1&limit=10",
+        "first": "\/shop-api\/WEB_GB\/taxon-products\/WOMEN_T_SHIRTS?channel=WEB_GB&page=1&limit=10",
+        "last": "\/shop-api\/WEB_GB\/taxon-products\/WOMEN_T_SHIRTS?channel=WEB_GB&page=1&limit=10",
+        "next": "\/shop-api\/WEB_GB\/taxon-products\/WOMEN_T_SHIRTS?channel=WEB_GB&page=1&limit=10"
     },
     "items": [
         {
@@ -75,7 +75,7 @@
             ],
             "_links": {
                 "self": {
-                    "href": "\/shop-api\/products-by-slug\/logan-t-shirt"
+                    "href": "\/shop-api\/WEB_GB\/products-by-slug\/logan-t-shirt"
                 }
             }
         }

--- a/tests/Responses/Expected/product/product_t_shirt_list_page_by_code_response.json
+++ b/tests/Responses/Expected/product/product_t_shirt_list_page_by_code_response.json
@@ -14,6 +14,7 @@
             "code": "LOGAN_T_SHIRT_CODE",
             "name": "Logan T-Shirt",
             "slug": "logan-t-shirt",
+            "channelCode": "WEB_GB",
             "description": "Some description Lorem ipsum dolor sit amet.",
             "averageRating": 0,
             "taxons": {

--- a/tests/Responses/Expected/product/product_t_shirt_list_page_by_slug_response.json
+++ b/tests/Responses/Expected/product/product_t_shirt_list_page_by_slug_response.json
@@ -4,10 +4,10 @@
     "pages": 1,
     "total": 1,
     "_links": {
-        "self": "\/shop-api\/WEB_GB\/taxon-products-by-slug\/categories\/t-shirts\/women-t-shirts?channel=WEB_GB&page=1&limit=10",
-        "first": "\/shop-api\/WEB_GB\/taxon-products-by-slug\/categories\/t-shirts\/women-t-shirts?channel=WEB_GB&page=1&limit=10",
-        "last": "\/shop-api\/WEB_GB\/taxon-products-by-slug\/categories\/t-shirts\/women-t-shirts?channel=WEB_GB&page=1&limit=10",
-        "next": "\/shop-api\/WEB_GB\/taxon-products-by-slug\/categories\/t-shirts\/women-t-shirts?channel=WEB_GB&page=1&limit=10"
+        "self": "\/shop-api\/WEB_GB\/taxon-products-by-slug\/categories\/t-shirts\/women-t-shirts?page=1&limit=10",
+        "first": "\/shop-api\/WEB_GB\/taxon-products-by-slug\/categories\/t-shirts\/women-t-shirts?page=1&limit=10",
+        "last": "\/shop-api\/WEB_GB\/taxon-products-by-slug\/categories\/t-shirts\/women-t-shirts?page=1&limit=10",
+        "next": "\/shop-api\/WEB_GB\/taxon-products-by-slug\/categories\/t-shirts\/women-t-shirts?page=1&limit=10"
     },
     "items": [
         {

--- a/tests/Responses/Expected/product/product_t_shirt_list_page_by_slug_response.json
+++ b/tests/Responses/Expected/product/product_t_shirt_list_page_by_slug_response.json
@@ -4,10 +4,10 @@
     "pages": 1,
     "total": 1,
     "_links": {
-        "self": "\/shop-api\/taxon-products-by-slug\/categories\/t-shirts\/women-t-shirts?channel=WEB_GB&page=1&limit=10",
-        "first": "\/shop-api\/taxon-products-by-slug\/categories\/t-shirts\/women-t-shirts?channel=WEB_GB&page=1&limit=10",
-        "last": "\/shop-api\/taxon-products-by-slug\/categories\/t-shirts\/women-t-shirts?channel=WEB_GB&page=1&limit=10",
-        "next": "\/shop-api\/taxon-products-by-slug\/categories\/t-shirts\/women-t-shirts?channel=WEB_GB&page=1&limit=10"
+        "self": "\/shop-api\/WEB_GB\/taxon-products-by-slug\/categories\/t-shirts\/women-t-shirts?channel=WEB_GB&page=1&limit=10",
+        "first": "\/shop-api\/WEB_GB\/taxon-products-by-slug\/categories\/t-shirts\/women-t-shirts?channel=WEB_GB&page=1&limit=10",
+        "last": "\/shop-api\/WEB_GB\/taxon-products-by-slug\/categories\/t-shirts\/women-t-shirts?channel=WEB_GB&page=1&limit=10",
+        "next": "\/shop-api\/WEB_GB\/taxon-products-by-slug\/categories\/t-shirts\/women-t-shirts?channel=WEB_GB&page=1&limit=10"
     },
     "items": [
         {
@@ -75,7 +75,7 @@
             ],
             "_links": {
                 "self": {
-                    "href": "\/shop-api\/products-by-slug\/logan-t-shirt"
+                    "href": "\/shop-api\/WEB_GB\/products-by-slug\/logan-t-shirt"
                 }
             }
         }

--- a/tests/Responses/Expected/product/product_t_shirt_list_page_by_slug_response.json
+++ b/tests/Responses/Expected/product/product_t_shirt_list_page_by_slug_response.json
@@ -14,6 +14,7 @@
             "code": "LOGAN_T_SHIRT_CODE",
             "name": "Logan T-Shirt",
             "slug": "logan-t-shirt",
+            "channelCode": "WEB_GB",
             "description": "Some description Lorem ipsum dolor sit amet.",
             "averageRating": 0,
             "taxons": {

--- a/tests/Responses/Expected/product/product_with_options_details_page.json
+++ b/tests/Responses/Expected/product/product_with_options_details_page.json
@@ -2,6 +2,7 @@
     "code": "LOGAN_HAT_CODE",
     "name": "Logan Hat",
     "slug": "logan-hat",
+    "channelCode": "WEB_GB",
     "breadcrumb": "categories\/hats\/logan-hat",
     "description": "Some description Lorem ipsum dolor sit amet.",
     "averageRating": 0,
@@ -89,6 +90,7 @@
                 "code": "LOGAN_MUG_CODE",
                 "name": "Logan Mug",
                 "slug": "logan-mug",
+                "channelCode": "WEB_GB",
                 "description": "Some description Lorem ipsum dolor sit amet.",
                 "averageRating": 0,
                 "taxons": {
@@ -140,6 +142,7 @@
                 "code": "LOGAN_T_SHIRT_CODE",
                 "name": "Logan T-Shirt",
                 "slug": "logan-t-shirt",
+                "channelCode": "WEB_GB",
                 "description": "Some description Lorem ipsum dolor sit amet.",
                 "averageRating": 0,
                 "taxons": {

--- a/tests/Responses/Expected/product/product_with_options_details_page.json
+++ b/tests/Responses/Expected/product/product_with_options_details_page.json
@@ -132,7 +132,7 @@
                 ],
                 "_links": {
                     "self": {
-                        "href": "\/shop-api\/products-by-slug\/logan-mug"
+                        "href": "\/shop-api\/WEB_GB\/products-by-slug\/logan-mug"
                     }
                 }
             },
@@ -201,7 +201,7 @@
                 ],
                 "_links": {
                     "self": {
-                        "href": "\/shop-api\/products-by-slug\/logan-t-shirt"
+                        "href": "\/shop-api\/WEB_GB\/products-by-slug\/logan-t-shirt"
                     }
                 }
             }
@@ -210,7 +210,7 @@
     "images": [],
     "_links": {
         "self": {
-            "href": "\/shop-api\/products-by-slug\/logan-hat"
+            "href": "\/shop-api\/WEB_GB\/products-by-slug\/logan-hat"
         }
     }
 }

--- a/tests/Responses/Expected/product/product_with_variant_details_page.json
+++ b/tests/Responses/Expected/product/product_with_variant_details_page.json
@@ -2,6 +2,7 @@
     "code": "LOGAN_T_SHIRT_CODE",
     "name": "Logan T-Shirt",
     "slug": "logan-t-shirt",
+    "channelCode": "WEB_GB",
     "breadcrumb": "categories\/t-shirts\/logan-t-shirt",
     "description": "Some description Lorem ipsum dolor sit amet.",
     "averageRating": 0,

--- a/tests/Responses/Expected/product/product_with_variant_details_page.json
+++ b/tests/Responses/Expected/product/product_with_variant_details_page.json
@@ -64,7 +64,7 @@
     ],
     "_links": {
         "self": {
-            "href": "\/shop-api\/products-by-slug\/logan-t-shirt"
+            "href": "\/shop-api\/WEB_GB\/products-by-slug\/logan-t-shirt"
         }
     }
 }

--- a/tests/Responses/Expected/product/product_without_taxons_details_page.json
+++ b/tests/Responses/Expected/product/product_without_taxons_details_page.json
@@ -14,7 +14,7 @@
     "images": [],
     "_links": {
         "self": {
-            "href": "\/shop-api\/products-by-slug\/logan-shoes"
+            "href": "\/shop-api\/WEB_GB\/products-by-slug\/logan-shoes"
         }
     }
 }

--- a/tests/Responses/Expected/product/product_without_taxons_details_page.json
+++ b/tests/Responses/Expected/product/product_without_taxons_details_page.json
@@ -2,6 +2,7 @@
     "code": "LOGAN_SHOES_CODE",
     "name": "Logan Shoes",
     "slug": "logan-shoes",
+    "channelCode": "WEB_GB",
     "breadcrumb": "logan-shoes",
     "description": "Some description Lorem ipsum dolor sit amet.",
     "averageRating": 0,

--- a/tests/Responses/Expected/product/simple_product_details_page.json
+++ b/tests/Responses/Expected/product/simple_product_details_page.json
@@ -46,7 +46,7 @@
     ],
     "_links": {
         "self": {
-            "href": "\/shop-api\/products-by-slug\/logan-mug"
+            "href": "\/shop-api\/WEB_GB\/products-by-slug\/logan-mug"
         }
     }
 }

--- a/tests/Responses/Expected/product/simple_product_details_page.json
+++ b/tests/Responses/Expected/product/simple_product_details_page.json
@@ -2,6 +2,7 @@
     "code": "LOGAN_MUG_CODE",
     "name": "Logan Mug",
     "slug": "logan-mug",
+    "channelCode": "WEB_GB",
     "breadcrumb": "categories\/mugs\/logan-mug",
     "description": "Some description Lorem ipsum dolor sit amet.",
     "averageRating": 0,


### PR DESCRIPTION
💥 

To support multi-channeling better, we should include channel code in all plugin requests. This is the first step, the next would be including information about the channel to all commands, to be able to use it within the application.

There is lots of code changed, but the idea is quite straightforward 😄The main work is done in `RequestChannelSubscriber` that checks channel code before each request.

My only concern is how to reflect this change in Swagger docs file? I've put `{channelCode}` in `basePath` parameter, but can it be described or explained anywhere? cc @lchrusciel 