### PR TITLE
Add item to cart should pick up a new cart if cart token is not passed

### DIFF
--- a/spec/Normalizer/RequestCartTokenNormalizerSpec.php
+++ b/spec/Normalizer/RequestCartTokenNormalizerSpec.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\Sylius\ShopApiPlugin\Normalizer;
+
+use League\Tactician\CommandBus;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Sylius\ShopApiPlugin\Command\PickupCart;
+use Sylius\ShopApiPlugin\Normalizer\RequestCartTokenNormalizerInterface;
+use Sylius\ShopApiPlugin\Request\PickupCartRequest;
+use Symfony\Component\HttpFoundation\ParameterBag;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+final class RequestCartTokenNormalizerSpec extends ObjectBehavior
+{
+    public function let(ValidatorInterface $validator, CommandBus $bus): void
+    {
+        $this->beConstructedWith($validator, $bus);
+    }
+
+    public function it_implements_request_cart_token_normalizer_interface(): void
+    {
+        $this->shouldImplement(RequestCartTokenNormalizerInterface::class);
+    }
+
+    public function it_returns_passed_request_if_cart_token_was_set(
+        Request $request,
+        ValidatorInterface $validator,
+        CommandBus $bus
+    ): void {
+        $request->attributes = new ParameterBag([
+            'token' => 'sample_cart_token',
+            'channel' => 'en_GB',
+        ]);
+
+        $validator->validate(Argument::any())->shouldNotBeCalled();
+        $bus->handle(Argument::any())->shouldNotBeCalled();
+
+        $this->__invoke($request)->shouldReturn($request);
+    }
+
+    public function it_throws_exception_when_pickup_cart_request_is_not_valid(
+        Request $request,
+        ValidatorInterface $validator,
+        CommandBus $bus,
+        ConstraintViolationListInterface $constraintViolationList
+    ): void {
+        $request->attributes = new ParameterBag([]);
+        $request->request = new ParameterBag(['channel' => 'non_existing_channel']);
+
+        $constraintViolationList->count()->willReturn(1);
+
+        $validator->validate(Argument::type(PickupCartRequest::class))->willReturn($constraintViolationList);
+
+        $bus->handle(Argument::any())->shouldNotBeCalled();
+
+        $this->shouldThrow(\InvalidArgumentException::class)->during('__invoke', [$request]);
+    }
+
+    public function it_picks_up_new_cart_and_sets_its_token_on_request_if_token_was_not_passed(
+        Request $request,
+        ValidatorInterface $validator,
+        CommandBus $bus,
+        ConstraintViolationListInterface $constraintViolationList
+    ): void {
+        $request->attributes = new ParameterBag([]);
+        $request->request = new ParameterBag(['channel' => 'en_GB']);
+
+        $constraintViolationList->count()->willReturn(0);
+
+        $validator->validate(Argument::type(PickupCartRequest::class))->willReturn($constraintViolationList);
+
+        $bus->handle(Argument::that(function(PickupCart $pickupCart): bool {
+            return
+                !empty($pickupCart->orderToken()) &&
+                $pickupCart->channelCode() === 'en_GB'
+            ;
+        }))->shouldBeCalled();
+
+        $this->__invoke($request);
+    }
+}

--- a/spec/Normalizer/RequestCartTokenNormalizerSpec.php
+++ b/spec/Normalizer/RequestCartTokenNormalizerSpec.php
@@ -40,7 +40,7 @@ final class RequestCartTokenNormalizerSpec extends ObjectBehavior
         $validator->validate(Argument::any())->shouldNotBeCalled();
         $bus->handle(Argument::any())->shouldNotBeCalled();
 
-        $this->__invoke($request)->shouldReturn($request);
+        $this->doNotAllowNullCartToken($request)->shouldReturn($request);
     }
 
     public function it_throws_exception_when_pickup_cart_request_is_not_valid(
@@ -58,7 +58,7 @@ final class RequestCartTokenNormalizerSpec extends ObjectBehavior
 
         $bus->handle(Argument::any())->shouldNotBeCalled();
 
-        $this->shouldThrow(\InvalidArgumentException::class)->during('__invoke', [$request]);
+        $this->shouldThrow(\InvalidArgumentException::class)->during('doNotAllowNullCartToken', [$request]);
     }
 
     public function it_picks_up_new_cart_and_sets_its_token_on_request_if_token_was_not_passed(
@@ -81,6 +81,6 @@ final class RequestCartTokenNormalizerSpec extends ObjectBehavior
             ;
         }))->shouldBeCalled();
 
-        $this->__invoke($request);
+        $this->doNotAllowNullCartToken($request);
     }
 }

--- a/spec/Normalizer/RequestCartTokenNormalizerSpec.php
+++ b/spec/Normalizer/RequestCartTokenNormalizerSpec.php
@@ -74,7 +74,7 @@ final class RequestCartTokenNormalizerSpec extends ObjectBehavior
 
         $validator->validate(Argument::type(PickupCartRequest::class))->willReturn($constraintViolationList);
 
-        $bus->handle(Argument::that(function(PickupCart $pickupCart): bool {
+        $bus->handle(Argument::that(function (PickupCart $pickupCart): bool {
             return
                 !empty($pickupCart->orderToken()) &&
                 $pickupCart->channelCode() === 'en_GB'

--- a/src/Controller/Cart/PutItemToCartAction.php
+++ b/src/Controller/Cart/PutItemToCartAction.php
@@ -58,7 +58,7 @@ final class PutItemToCartAction
     public function __invoke(Request $request): Response
     {
         try {
-            $request = $this->requestCartTokenNormalizer->__invoke($request);
+            $request = $this->requestCartTokenNormalizer->doNotAllowNullCartToken($request);
         } catch (\InvalidArgumentException $exception) {
             throw new BadRequestHttpException($exception->getMessage());
         }

--- a/src/Controller/Cart/PutItemsToCartAction.php
+++ b/src/Controller/Cart/PutItemsToCartAction.php
@@ -65,7 +65,7 @@ final class PutItemsToCartAction
         $commandsToExecute = [];
 
         try {
-            $request = $this->requestCartTokenNormalizer->__invoke($request);
+            $request = $this->requestCartTokenNormalizer->doNotAllowNullCartToken($request);
         } catch (\InvalidArgumentException $exception) {
             throw new BadRequestHttpException($exception->getMessage());
         }

--- a/src/Controller/Cart/PutItemsToCartAction.php
+++ b/src/Controller/Cart/PutItemsToCartAction.php
@@ -72,7 +72,7 @@ final class PutItemsToCartAction
 
         $token = $request->attributes->get('token');
 
-        foreach ($request->request->all() as $item) {
+        foreach ($request->request->get('items') as $item) {
             $item['token'] = $token;
             $commandRequests[] = $this->provideCommandRequest($item);
         }

--- a/src/Controller/Cart/PutItemsToCartAction.php
+++ b/src/Controller/Cart/PutItemsToCartAction.php
@@ -7,6 +7,7 @@ namespace Sylius\ShopApiPlugin\Controller\Cart;
 use FOS\RestBundle\View\View;
 use FOS\RestBundle\View\ViewHandlerInterface;
 use League\Tactician\CommandBus;
+use Sylius\ShopApiPlugin\Normalizer\RequestCartTokenNormalizerInterface;
 use Sylius\ShopApiPlugin\Request\PutOptionBasedConfigurableItemToCartRequest;
 use Sylius\ShopApiPlugin\Request\PutSimpleItemToCartRequest;
 use Sylius\ShopApiPlugin\Request\PutVariantBasedConfigurableItemToCartRequest;
@@ -37,17 +38,22 @@ final class PutItemsToCartAction
     /** @var string */
     private $validationErrorViewClass;
 
+    /** @var RequestCartTokenNormalizerInterface */
+    private $requestCartTokenNormalizer;
+
     public function __construct(
         ViewHandlerInterface $viewHandler,
         CommandBus $bus,
         ValidatorInterface $validator,
         CartViewRepositoryInterface $cartQuery,
+        RequestCartTokenNormalizerInterface $requestCartTokenNormalizer,
         string $validationErrorViewClass
     ) {
         $this->viewHandler = $viewHandler;
         $this->bus = $bus;
         $this->validator = $validator;
         $this->cartQuery = $cartQuery;
+        $this->requestCartTokenNormalizer = $requestCartTokenNormalizer;
         $this->validationErrorViewClass = $validationErrorViewClass;
     }
 
@@ -57,6 +63,13 @@ final class PutItemsToCartAction
         $validationResults = [];
         $commandRequests = [];
         $commandsToExecute = [];
+
+        try {
+            $request = $this->requestCartTokenNormalizer->__invoke($request);
+        } catch (\InvalidArgumentException $exception) {
+            throw new BadRequestHttpException($exception->getMessage());
+        }
+
         $token = $request->attributes->get('token');
 
         foreach ($request->request->all() as $item) {

--- a/src/Normalizer/RequestCartTokenNormalizer.php
+++ b/src/Normalizer/RequestCartTokenNormalizer.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\ShopApiPlugin\Normalizer;
+
+use League\Tactician\CommandBus;
+use Sylius\ShopApiPlugin\Request\PickupCartRequest;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+final class RequestCartTokenNormalizer implements RequestCartTokenNormalizerInterface
+{
+    /** @var ValidatorInterface */
+    private $validator;
+
+    /** @var CommandBus */
+    private $bus;
+
+    public function __construct(ValidatorInterface $validator, CommandBus $bus)
+    {
+        $this->validator = $validator;
+        $this->bus = $bus;
+    }
+
+    public function __invoke(Request $request): Request
+    {
+        if ($request->attributes->has('token')) {
+            return $request;
+        }
+
+        $pickupRequest = new PickupCartRequest($request);
+
+        $validationResults = $this->validator->validate($pickupRequest);
+
+        if (0 !== $validationResults->count()) {
+            throw new \InvalidArgumentException('Pickup request was not valid');
+        }
+
+        $pickupCartCommand = $pickupRequest->getCommand();
+
+        $this->bus->handle($pickupCartCommand);
+
+        $token = $pickupCartCommand->orderToken();
+
+        $request->attributes->set('token', $token);
+
+        return $request;
+    }
+}

--- a/src/Normalizer/RequestCartTokenNormalizer.php
+++ b/src/Normalizer/RequestCartTokenNormalizer.php
@@ -23,7 +23,7 @@ final class RequestCartTokenNormalizer implements RequestCartTokenNormalizerInte
         $this->bus = $bus;
     }
 
-    public function __invoke(Request $request): Request
+    public function doNotAllowNullCartToken(Request $request): Request
     {
         if ($request->attributes->has('token')) {
             return $request;
@@ -38,12 +38,9 @@ final class RequestCartTokenNormalizer implements RequestCartTokenNormalizerInte
         }
 
         $pickupCartCommand = $pickupRequest->getCommand();
-
         $this->bus->handle($pickupCartCommand);
 
-        $token = $pickupCartCommand->orderToken();
-
-        $request->attributes->set('token', $token);
+        $request->attributes->set('token', $pickupCartCommand->orderToken());
 
         return $request;
     }

--- a/src/Normalizer/RequestCartTokenNormalizerInterface.php
+++ b/src/Normalizer/RequestCartTokenNormalizerInterface.php
@@ -8,6 +8,5 @@ use Symfony\Component\HttpFoundation\Request;
 
 interface RequestCartTokenNormalizerInterface
 {
-    /** Should be used only when passing nullable cart token is an acceptable behavior */
-    public function __invoke(Request $request): Request;
+    public function doNotAllowNullCartToken(Request $request): Request;
 }

--- a/src/Normalizer/RequestCartTokenNormalizerInterface.php
+++ b/src/Normalizer/RequestCartTokenNormalizerInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\ShopApiPlugin\Normalizer;
+
+use Symfony\Component\HttpFoundation\Request;
+
+interface RequestCartTokenNormalizerInterface
+{
+    /** Should be used only when passing nullable cart token is an acceptable behavior */
+    public function __invoke(Request $request): Request;
+}

--- a/src/Resources/config/routing/cart.yml
+++ b/src/Resources/config/routing/cart.yml
@@ -16,11 +16,23 @@ sylius_shop_api_cart_summary:
     defaults:
         _controller: sylius.shop_api_plugin.controller.cart.summarize_action
 
+sylius_shop_api_add_to_new_cart:
+    path: /carts/new/items
+    methods: [POST]
+    defaults:
+        _controller: sylius.shop_api_plugin.controller.cart.put_item_to_cart_action
+
 sylius_shop_api_add_to_cart:
     path: /carts/{token}/items
     methods: [POST]
     defaults:
         _controller: sylius.shop_api_plugin.controller.cart.put_item_to_cart_action
+
+sylius_shop_api_add_multiple_items_to_new_cart:
+    path: /carts/new/multiple-items
+    methods: [POST]
+    defaults:
+        _controller: sylius.shop_api_plugin.controller.cart.put_items_to_cart_action
 
 sylius_shop_api_add_multiple_items_to_cart:
     path: /carts/{token}/multiple-items

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -60,5 +60,12 @@
             <argument type="service" id="sylius.manager.order" />
         </service>
 
+        <service id="sylius.shop_api_plugin.normalizer.request_cart_token_normalizer"
+                 class="Sylius\ShopApiPlugin\Normalizer\RequestCartTokenNormalizer"
+        >
+            <argument type="service" id="validator" />
+            <argument type="service" id="tactician.commandbus" />
+        </service>
+
     </services>
 </container>

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -60,12 +60,12 @@
             <argument type="service" id="sylius.manager.order" />
         </service>
 
-        <service id="sylius.shop_api_plugin.normalizer.request_cart_token_normalizer"
-                 class="Sylius\ShopApiPlugin\Normalizer\RequestCartTokenNormalizer"
+        <service
+                id="sylius.shop_api_plugin.normalizer.request_cart_token_normalizer"
+                class="Sylius\ShopApiPlugin\Normalizer\RequestCartTokenNormalizer"
         >
             <argument type="service" id="validator" />
             <argument type="service" id="tactician.commandbus" />
         </service>
-
     </services>
 </container>

--- a/src/Resources/config/services/actions/cart.xml
+++ b/src/Resources/config/services/actions/cart.xml
@@ -87,6 +87,7 @@
             <argument type="service" id="validator" />
             <argument type="service" id="sylius.shop_api_plugin.factory.validation_error_view_factory" />
             <argument type="service" id="sylius.shop_api_plugin.view_repository.cart_view_repository" />
+            <argument type="service" id="sylius.shop_api_plugin.normalizer.request_cart_token_normalizer" />
         </service>
 
         <service id="sylius.shop_api_plugin.controller.cart.put_items_to_cart_action"
@@ -96,6 +97,7 @@
             <argument type="service" id="tactician.commandbus" />
             <argument type="service" id="validator" />
             <argument type="service" id="sylius.shop_api_plugin.view_repository.cart_view_repository" />
+            <argument type="service" id="sylius.shop_api_plugin.normalizer.request_cart_token_normalizer" />
             <argument type="string">%sylius.shop_api.view.validation_error.class%</argument>
         </service>
     </services>

--- a/tests/Controller/CartPutItemToCartApiTest.php
+++ b/tests/Controller/CartPutItemToCartApiTest.php
@@ -605,4 +605,26 @@ EOT;
 
         $this->assertResponse($response, 'channel_has_not_been_found_response', Response::HTTP_NOT_FOUND);
     }
+
+    /**
+     * @test
+     */
+    public function it_creates_new_cart_when_token_is_not_passed(): void
+    {
+        $this->loadFixturesFromFiles(['shop.yml']);
+
+        $data =
+<<<EOT
+        {
+            "productCode": "LOGAN_MUG_CODE",
+            "quantity": 3,
+            "channel": "WEB_GB"
+        }
+EOT;
+        $this->client->request('POST', '/shop-api/carts/new/items', [], [], static::$acceptAndContentTypeHeader, $data);
+
+        $response = $this->client->getResponse();
+
+        $this->assertResponse($response, 'cart/add_simple_product_to_new_cart_response', Response::HTTP_CREATED);
+    }
 }

--- a/tests/Controller/CartPutItemToCartApiTest.php
+++ b/tests/Controller/CartPutItemToCartApiTest.php
@@ -621,7 +621,7 @@ EOT;
             "channel": "WEB_GB"
         }
 EOT;
-        $this->client->request('POST', '/shop-api/carts/new/items', [], [], static::$acceptAndContentTypeHeader, $data);
+        $this->client->request('POST', '/shop-api/WEB_GB/carts/new/items', [], [], static::$acceptAndContentTypeHeader, $data);
 
         $response = $this->client->getResponse();
 

--- a/tests/Controller/CartPutItemsToCartApiTest.php
+++ b/tests/Controller/CartPutItemsToCartApiTest.php
@@ -27,25 +27,27 @@ final class CartPutItemsToCartApiTest extends JsonApiTestCase
 
         $data =
 <<<EOT
-        [
-            {
-                "productCode": "LOGAN_MUG_CODE",
-                "quantity": 3
-            },
-            {
-                "productCode": "LOGAN_T_SHIRT_CODE",
-                "variantCode": "SMALL_LOGAN_T_SHIRT_CODE",
-                "quantity": 3
-            },
-            {
-                "productCode": "LOGAN_HAT_CODE",
-                "options": {
-                    "HAT_SIZE": "HAT_SIZE_S",
-                    "HAT_COLOR": "HAT_COLOR_RED"
+        {
+            "items": [
+                {
+                    "productCode": "LOGAN_MUG_CODE",
+                    "quantity": 3
                 },
-                "quantity": 3
-            }
-        ]
+                {
+                    "productCode": "LOGAN_T_SHIRT_CODE",
+                    "variantCode": "SMALL_LOGAN_T_SHIRT_CODE",
+                    "quantity": 3
+                },
+                {
+                    "productCode": "LOGAN_HAT_CODE",
+                    "options": {
+                        "HAT_SIZE": "HAT_SIZE_S",
+                        "HAT_COLOR": "HAT_COLOR_RED"
+                    },
+                    "quantity": 3
+                }
+            ]
+        }
 EOT;
         $this->client->request('POST', sprintf('/shop-api/WEB_GB/carts/%s/multiple-items', $token), [], [], static::$acceptAndContentTypeHeader, $data);
         $response = $this->client->getResponse();
@@ -68,24 +70,26 @@ EOT;
 
         $data =
 <<<EOT
-        [
-            {
-                "productCode": "LOGAN_MUG_CODE",
-                "quantity": 3
-            },
-            {
-                "productCode": "LOGAN_T_SHIRT_CODE",
-                "variantCode": "SMALL_LOGAN_T_SHIRT_CODE"
-            },
-            {
-                "productCode": "LOGAN_HAT_CODE",
-                "options": {
-                    "HAT_SIZE": "HAT_SIZE_S",
-                    "HAT_COLOR": "HAT_COLOR_RED"
+        {
+            "items": [
+                {
+                    "productCode": "LOGAN_MUG_CODE",
+                    "quantity": 3
                 },
-                "quantity": 3
-            }
-        ]
+                {
+                    "productCode": "LOGAN_T_SHIRT_CODE",
+                    "variantCode": "SMALL_LOGAN_T_SHIRT_CODE"
+                },
+                {
+                    "productCode": "LOGAN_HAT_CODE",
+                    "options": {
+                        "HAT_SIZE": "HAT_SIZE_S",
+                        "HAT_COLOR": "HAT_COLOR_RED"
+                    },
+                    "quantity": 3
+                }
+            ]
+        }
 EOT;
         $this->client->request('POST', sprintf('/shop-api/WEB_GB/carts/%s/multiple-items', $token), [], [], static::$acceptAndContentTypeHeader, $data);
         $this->client->request('GET', sprintf('/shop-api/WEB_GB/carts/%s', $token), [], [], static::$acceptAndContentTypeHeader, $data);
@@ -109,23 +113,25 @@ EOT;
 
         $data =
 <<<EOT
-        [
-            {
-                "productCode": "LOGAN_MUG_CODE",
-                "quantity": 3
-            },
-            {
-                "productCode": "LOGAN_T_SHIRT_CODE",
-                "variantCode": "SMALL_LOGAN_T_SHIRT_CODE"
-            },
-            {
-                "productCode": "LOGAN_HAT_CODE",
-                "options": {
-                    "HAT_SIZE": "HAT_SIZE_S",
-                    "HAT_COLOR": "HAT_COLOR_RED"
+        {
+            "items": [
+                {
+                    "productCode": "LOGAN_MUG_CODE",
+                    "quantity": 3
+                },
+                {
+                    "productCode": "LOGAN_T_SHIRT_CODE",
+                    "variantCode": "SMALL_LOGAN_T_SHIRT_CODE"
+                },
+                {
+                    "productCode": "LOGAN_HAT_CODE",
+                    "options": {
+                        "HAT_SIZE": "HAT_SIZE_S",
+                        "HAT_COLOR": "HAT_COLOR_RED"
+                    }
                 }
-            }
-        ]
+            ]
+        }
 EOT;
         $this->client->request('POST', sprintf('/shop-api/WEB_GB/carts/%s/multiple-items', $token), [], [], static::$acceptAndContentTypeHeader, $data);
         $response = $this->client->getResponse();
@@ -181,26 +187,26 @@ EOT;
 
         $data =
 <<<EOT
-        [
-            {
-                "productCode": "LOGAN_MUG_CODE",
-                "quantity": 3
-            },
-            {
-                "productCode": "LOGAN_T_SHIRT_CODE",
-                "variantCode": "SMALL_LOGAN_T_SHIRT_CODE",
-                "quantity": 3
-            },
-            {
-                "productCode": "LOGAN_HAT_CODE",
-                "options": {
-                    "HAT_SIZE": "HAT_SIZE_S",
-                    "HAT_COLOR": "HAT_COLOR_RED"
-                },
-                "quantity": 3
-            },
-        ],
         {
+            "items": [
+                {
+                    "productCode": "LOGAN_MUG_CODE",
+                    "quantity": 3
+                },
+                {
+                    "productCode": "LOGAN_T_SHIRT_CODE",
+                    "variantCode": "SMALL_LOGAN_T_SHIRT_CODE",
+                    "quantity": 3
+                },
+                {
+                    "productCode": "LOGAN_HAT_CODE",
+                    "options": {
+                        "HAT_SIZE": "HAT_SIZE_S",
+                        "HAT_COLOR": "HAT_COLOR_RED"
+                    },
+                    "quantity": 3
+                }
+            ],
             "channel": "WEB_GB"
         }
 EOT;

--- a/tests/Controller/CartPutItemsToCartApiTest.php
+++ b/tests/Controller/CartPutItemsToCartApiTest.php
@@ -171,4 +171,43 @@ EOT;
 
         $this->assertResponse($response, 'channel_has_not_been_found_response', Response::HTTP_NOT_FOUND);
     }
+
+    /**
+     * @test
+     */
+    public function it_creates_new_cart_when_token_is_not_passed(): void
+    {
+        $this->loadFixturesFromFiles(['shop.yml']);
+
+        $data =
+<<<EOT
+        [
+            {
+                "productCode": "LOGAN_MUG_CODE",
+                "quantity": 3
+            },
+            {
+                "productCode": "LOGAN_T_SHIRT_CODE",
+                "variantCode": "SMALL_LOGAN_T_SHIRT_CODE",
+                "quantity": 3
+            },
+            {
+                "productCode": "LOGAN_HAT_CODE",
+                "options": {
+                    "HAT_SIZE": "HAT_SIZE_S",
+                    "HAT_COLOR": "HAT_COLOR_RED"
+                },
+                "quantity": 3
+            },
+        ],
+        {
+            "channel": "WEB_GB"
+        }
+EOT;
+        $this->client->request('POST', '/shop-api/carts/new/multiple-items', [], [], static::$acceptAndContentTypeHeader, $data);
+
+        $response = $this->client->getResponse();
+
+        $this->assertResponse($response, 'cart/add_multiple_products_to_new_cart_response', Response::HTTP_CREATED);
+    }
 }

--- a/tests/Controller/CartPutItemsToCartApiTest.php
+++ b/tests/Controller/CartPutItemsToCartApiTest.php
@@ -210,7 +210,7 @@ EOT;
             "channel": "WEB_GB"
         }
 EOT;
-        $this->client->request('POST', '/shop-api/carts/new/multiple-items', [], [], static::$acceptAndContentTypeHeader, $data);
+        $this->client->request('POST', '/shop-api/WEB_GB/carts/new/multiple-items', [], [], static::$acceptAndContentTypeHeader, $data);
 
         $response = $this->client->getResponse();
 

--- a/tests/Responses/Expected/cart/add_multiple_products_to_new_cart_response.json
+++ b/tests/Responses/Expected/cart/add_multiple_products_to_new_cart_response.json
@@ -13,6 +13,7 @@
         "code": "LOGAN_MUG_CODE",
         "name": "Logan Mug",
         "slug": "logan-mug",
+        "channelCode": "WEB_GB",
         "description": "Some description Lorem ipsum dolor sit amet.",
         "averageRating": 0,
         "taxons": {
@@ -51,7 +52,7 @@
         ],
         "_links": {
           "self": {
-            "href": "\/shop-api\/products-by-slug\/logan-mug"
+            "href": "\/shop-api\/WEB_GB\/products-by-slug\/logan-mug"
           }
         }
       }
@@ -64,6 +65,7 @@
         "code": "LOGAN_T_SHIRT_CODE",
         "name": "Logan T-Shirt",
         "slug": "logan-t-shirt",
+        "channelCode": "WEB_GB",
         "description": "Some description Lorem ipsum dolor sit amet.",
         "averageRating": 0,
         "taxons": {
@@ -104,7 +106,7 @@
         ],
         "_links": {
           "self": {
-            "href": "\/shop-api\/products-by-slug\/logan-t-shirt"
+            "href": "\/shop-api\/WEB_GB\/products-by-slug\/logan-t-shirt"
           }
         }
       }
@@ -117,6 +119,7 @@
         "code": "LOGAN_HAT_CODE",
         "name": "Logan Hat",
         "slug": "logan-hat",
+        "channelCode": "WEB_GB",
         "description": "Some description Lorem ipsum dolor sit amet.",
         "averageRating": 0,
         "taxons": {
@@ -150,7 +153,7 @@
         "images": [],
         "_links": {
           "self": {
-            "href": "\/shop-api\/products-by-slug\/logan-hat"
+            "href": "\/shop-api\/WEB_GB\/products-by-slug\/logan-hat"
           }
         }
       }

--- a/tests/Responses/Expected/cart/add_multiple_products_to_new_cart_response.json
+++ b/tests/Responses/Expected/cart/add_multiple_products_to_new_cart_response.json
@@ -1,0 +1,169 @@
+{
+  "tokenValue": @string@,
+  "channel": "WEB_GB",
+  "currency": "GBP",
+  "locale": "en_GB",
+  "checkoutState": "cart",
+  "items": [
+    {
+      "id": @integer@,
+      "quantity": 3,
+      "total": 5997,
+      "product": {
+        "code": "LOGAN_MUG_CODE",
+        "name": "Logan Mug",
+        "slug": "logan-mug",
+        "description": "Some description Lorem ipsum dolor sit amet.",
+        "averageRating": 0,
+        "taxons": {
+          "main": "MUG",
+          "others": [
+            "MUG",
+            "BRAND"
+          ]
+        },
+        "variants": [
+          {
+            "code": "LOGAN_MUG_CODE",
+            "name": "Logan Mug",
+            "axis": [],
+            "nameAxis": {},
+            "price": {
+              "current": 1999,
+              "currency": "GBP"
+            },
+            "images": []
+          }
+        ],
+        "attributes": [
+          {
+            "code": "MUG_MATERIAL_CODE",
+            "name": "Mug material",
+            "value": "Wood"
+          }
+        ],
+        "associations": [],
+        "images": [
+          {
+            "code": "thumbnail",
+            "path": "\/uo\/mug.jpg"
+          }
+        ],
+        "_links": {
+          "self": {
+            "href": "\/shop-api\/products-by-slug\/logan-mug"
+          }
+        }
+      }
+    },
+    {
+      "id": @integer@,
+      "quantity": 3,
+      "total": 5997,
+      "product": {
+        "code": "LOGAN_T_SHIRT_CODE",
+        "name": "Logan T-Shirt",
+        "slug": "logan-t-shirt",
+        "description": "Some description Lorem ipsum dolor sit amet.",
+        "averageRating": 0,
+        "taxons": {
+          "main": "T_SHIRTS",
+          "others": [
+            "WOMEN_T_SHIRTS",
+            "BRAND"
+          ]
+        },
+        "variants": [
+          {
+            "code": "SMALL_LOGAN_T_SHIRT_CODE",
+            "name": "Small Logan T-Shirt",
+            "axis": [],
+            "nameAxis": {},
+            "price": {
+              "current": 1999,
+              "currency": "GBP"
+            },
+            "images": []
+          }
+        ],
+        "attributes": [],
+        "associations": [],
+        "images": [
+          {
+            "code": "thumbnail",
+            "path": "\/uo\/tshirt.jpg"
+          },
+          {
+            "code": "thumbnail",
+            "path": "\/uo\/small-tshirt.jpg"
+          },
+          {
+            "code": "thumbnail",
+            "path": "\/uo\/large-tshirt.jpg"
+          }
+        ],
+        "_links": {
+          "self": {
+            "href": "\/shop-api\/products-by-slug\/logan-t-shirt"
+          }
+        }
+      }
+    },
+    {
+      "id": @integer@,
+      "quantity": 3,
+      "total": 1500,
+      "product": {
+        "code": "LOGAN_HAT_CODE",
+        "name": "Logan Hat",
+        "slug": "logan-hat",
+        "description": "Some description Lorem ipsum dolor sit amet.",
+        "averageRating": 0,
+        "taxons": {
+          "main": "HAT",
+          "others": [
+            "HAT",
+            "BRAND"
+          ]
+        },
+        "variants": [
+          {
+            "code": "SMALL_RED_LOGAN_HAT_CODE",
+            "name": "Small Red Logan Hat",
+            "axis": [
+              "HAT_SIZE_S",
+              "HAT_COLOR_RED"
+            ],
+            "nameAxis": {
+              "HAT_SIZE_S": "Size S",
+              "HAT_COLOR_RED": "Color Red"
+            },
+            "price": {
+              "current": 500,
+              "currency": "GBP"
+            },
+            "images": []
+          }
+        ],
+        "attributes": [],
+        "associations": [],
+        "images": [],
+        "_links": {
+          "self": {
+            "href": "\/shop-api\/products-by-slug\/logan-hat"
+          }
+        }
+      }
+    }
+  ],
+  "totals": {
+    "total": 13494,
+    "items": 13494,
+    "taxes": 0,
+    "shipping": 0,
+    "promotion": 0
+  },
+  "payments": [],
+  "shipments": [],
+  "cartDiscounts": []
+}

--- a/tests/Responses/Expected/cart/add_simple_product_to_new_cart_response.json
+++ b/tests/Responses/Expected/cart/add_simple_product_to_new_cart_response.json
@@ -13,6 +13,7 @@
         "code": "LOGAN_MUG_CODE",
         "name": "Logan Mug",
         "slug": "logan-mug",
+        "channelCode": "WEB_GB",
         "description": "Some description Lorem ipsum dolor sit amet.",
         "averageRating": 0,
         "taxons": {
@@ -51,7 +52,7 @@
         ],
         "_links": {
           "self": {
-            "href": "\/shop-api\/products-by-slug\/logan-mug"
+            "href": "\/shop-api\/WEB_GB\/products-by-slug\/logan-mug"
           }
         }
       }

--- a/tests/Responses/Expected/cart/add_simple_product_to_new_cart_response.json
+++ b/tests/Responses/Expected/cart/add_simple_product_to_new_cart_response.json
@@ -1,0 +1,70 @@
+{
+  "tokenValue": @string@,
+  "channel": "WEB_GB",
+  "currency": "GBP",
+  "locale": "en_GB",
+  "checkoutState": "cart",
+  "items": [
+    {
+      "id": @integer@,
+      "quantity": 3,
+      "total": 5997,
+      "product": {
+        "code": "LOGAN_MUG_CODE",
+        "name": "Logan Mug",
+        "slug": "logan-mug",
+        "description": "Some description Lorem ipsum dolor sit amet.",
+        "averageRating": 0,
+        "taxons": {
+          "main": "MUG",
+          "others": [
+            "MUG",
+            "BRAND"
+          ]
+        },
+        "variants": [
+          {
+            "code": "LOGAN_MUG_CODE",
+            "name": "Logan Mug",
+            "axis": [],
+            "nameAxis": {},
+            "price": {
+              "current": 1999,
+              "currency": "GBP"
+            },
+            "images": []
+          }
+        ],
+        "attributes": [
+          {
+            "code": "MUG_MATERIAL_CODE",
+            "name": "Mug material",
+            "value": "Wood"
+          }
+        ],
+        "associations": [],
+        "images": [
+          {
+            "code": "thumbnail",
+            "path": "\/uo\/mug.jpg"
+          }
+        ],
+        "_links": {
+          "self": {
+            "href": "\/shop-api\/products-by-slug\/logan-mug"
+          }
+        }
+      }
+    }
+  ],
+  "totals": {
+    "total": 5997,
+    "items": 5997,
+    "taxes": 0,
+    "shipping": 0,
+    "promotion": 0
+  },
+  "payments": [],
+  "shipments": [],
+  "cartDiscounts": []
+}


### PR DESCRIPTION
🌵 Since https://github.com/Sylius/ShopApiPlugin/pull/342 is still in a PR state and picking a new cart requires channel, one BC break needed to be implemented in `PutItemsToCartAction` (line 75). 

We can merge this PR and wait for https://github.com/Sylius/ShopApiPlugin/pull/342 to be merged and then fix it or firstly wait for https://github.com/Sylius/ShopApiPlugin/pull/342 to be merged and then rebase - as a result channel will be present in all URLs. 🌵 