### PR TITLE
Support to get orders by tokenValue or id

### DIFF
--- a/doc/swagger.yml
+++ b/doc/swagger.yml
@@ -915,34 +915,56 @@ paths:
               500:
                 description: "Channel not found"
     /orders:
-        get:
-            tags:
-            - "order"
-            summary: "Shows a list of orders of the customer"
-            operationId: "showsOrderId"
-            responses:
-                200:
-                    description: "Shows a list of placed orders of the customer"
-                    type: "array"
-                    items:
-                        type: "object"
-                        $ref: "#/definitions/PlacedOrder"
-                401:
-                    description: "User token invalid"
+      get:
+        tags:
+        - "order"
+        summary: "Shows a list of orders of the customer"
+        operationId: "showsOrderId"
+        responses:
+          200:
+            description: "Shows a list of placed orders of the customer"
+            type: "array"
+            items:
+              type: "object"
+              $ref: "#/definitions/PlacedOrder"
+          401:
+            description: "User token invalid"
     /orders/{id}:
-        get:
-            tags:
-            - "order"
-            summary: "Shows details of specific customer's order"
-            responses:
-                200:
-                    description: "Shows details of specific customer's order with given ID"
-                    type: "object"
-                    $ref: "#/definitions/PlacedOrderDetails"
-                401:
-                    description: "User token invalid"
-                404:
-                    description: "Order with given ID not found"
+      get:
+        tags:
+        - "order"
+        summary: "Shows details of specific customer's order"
+        parameters:
+          - name: "id"
+            in: "request"
+            type: "string"
+        responses:
+          200:
+            description: "Shows details of specific customer's order with given ID"
+            type: "object"
+            $ref: "#/definitions/PlacedOrderDetails"
+          401:
+            description: "User token invalid"
+          404:
+            description: "Order with given ID not found"
+    /orders/{orderToken}:
+      get:
+        tags:
+        - "order"
+        summary: "Shows details of specific customer's order"
+        parameters:
+          - name: "orderToken"
+            in: "request"
+            type: "string"
+        responses:
+          200:
+            description: "Shows details of specific customer's order with given orderToken"
+            type: "object"
+            $ref: "#/definitions/PlacedOrderDetails"
+          401:
+            description: "User token invalid"
+          404:
+            description: "Order with given ID not found"
     /me:
         get:
             tags:

--- a/spec/Factory/PlacedOrderViewFactorySpec.php
+++ b/spec/Factory/PlacedOrderViewFactorySpec.php
@@ -101,6 +101,8 @@ final class PlacedOrderViewFactorySpec extends ObjectBehavior
         $placedOrderView->items = [new ItemView()];
         $placedOrderView->totals = new TotalsView();
         $placedOrderView->cartDiscounts = ['PROMOTION_CODE' => new AdjustmentView()];
+        $placedOrderView->tokenValue = 'ORDERTOKEN';
+        $placedOrderView->number = 'ORDERNUMBER';
 
         $this->create($cart, 'en_GB')->shouldBeLike($placedOrderView);
     }

--- a/spec/Factory/PlacedOrderViewFactorySpec.php
+++ b/spec/Factory/PlacedOrderViewFactorySpec.php
@@ -64,6 +64,7 @@ final class PlacedOrderViewFactorySpec extends ObjectBehavior
         $cart->getCurrencyCode()->willReturn('GBP');
         $cart->getCheckoutState()->willReturn(OrderCheckoutStates::STATE_COMPLETED);
         $cart->getTokenValue()->willReturn('ORDERTOKEN');
+        $cart->getNumber()->willReturn('ORDERNUMBER');
         $cart->getShippingTotal()->willReturn(500);
         $cart->getTaxTotal()->willReturn(600);
         $cart->getItems()->willReturn(new ArrayCollection([$orderItem->getWrappedObject()]));

--- a/src/Controller/Order/ShowOrderDetailsAction.php
+++ b/src/Controller/Order/ShowOrderDetailsAction.php
@@ -52,7 +52,7 @@ final class ShowOrderDetailsAction
                 $order = $this->placedOrderQuery
                     ->getOneCompletedByCustomerEmailAndToken(
                         $user->getCustomer()->getEmail(),
-                        $request->attributes->get('tokenValue')
+                        $request->attributes->get('orderToken')
                     );
             }
 

--- a/src/Controller/Order/ShowOrderDetailsAction.php
+++ b/src/Controller/Order/ShowOrderDetailsAction.php
@@ -30,9 +30,9 @@ final class ShowOrderDetailsAction
         LoggedInUserProviderInterface $loggedInUserProvider,
         PlacedOrderViewRepositoryInterface $placedOrderQuery
     ) {
-        $this->viewHandler          = $viewHandler;
+        $this->viewHandler = $viewHandler;
         $this->loggedInUserProvider = $loggedInUserProvider;
-        $this->placedOrderQuery     = $placedOrderQuery;
+        $this->placedOrderQuery = $placedOrderQuery;
     }
 
     public function __invoke(Request $request): Response
@@ -55,7 +55,6 @@ final class ShowOrderDetailsAction
                         $request->attributes->get('orderToken')
                     );
             }
-
         } catch (TokenNotFoundException $exception) {
             return $this->viewHandler->handle(View::create(null, Response::HTTP_UNAUTHORIZED));
         } catch (\InvalidArgumentException $exception) {

--- a/src/Factory/PlacedOrderViewFactory.php
+++ b/src/Factory/PlacedOrderViewFactory.php
@@ -42,26 +42,26 @@ final class PlacedOrderViewFactory implements PlacedOrderViewFactoryInterface
         AdjustmentViewFactoryInterface $adjustmentViewFactory,
         string $placedOrderViewClass
     ) {
-        $this->orderItemFactory      = $orderItemFactory;
-        $this->addressViewFactory    = $addressViewFactory;
-        $this->totalViewFactory      = $totalViewFactory;
-        $this->shipmentViewFactory   = $shipmentViewFactory;
-        $this->paymentViewFactory    = $paymentViewFactory;
+        $this->orderItemFactory = $orderItemFactory;
+        $this->addressViewFactory = $addressViewFactory;
+        $this->totalViewFactory = $totalViewFactory;
+        $this->shipmentViewFactory = $shipmentViewFactory;
+        $this->paymentViewFactory = $paymentViewFactory;
         $this->adjustmentViewFactory = $adjustmentViewFactory;
-        $this->placedOrderViewClass  = $placedOrderViewClass;
+        $this->placedOrderViewClass = $placedOrderViewClass;
     }
 
     public function create(OrderInterface $order, string $localeCode): PlacedOrderView
     {
         /** @var PlacedOrderView $placedOrderView */
-        $placedOrderView                = new $this->placedOrderViewClass();
-        $placedOrderView->channel       = $order->getChannel()->getCode();
-        $placedOrderView->currency      = $order->getCurrencyCode();
-        $placedOrderView->locale        = $localeCode;
+        $placedOrderView = new $this->placedOrderViewClass();
+        $placedOrderView->channel = $order->getChannel()->getCode();
+        $placedOrderView->currency = $order->getCurrencyCode();
+        $placedOrderView->locale = $localeCode;
         $placedOrderView->checkoutState = $order->getCheckoutState();
-        $placedOrderView->totals        = $this->totalViewFactory->create($order);
-        $placedOrderView->tokenValue    = $order->getTokenValue();
-        $placedOrderView->number        = $order->getNumber();
+        $placedOrderView->totals = $this->totalViewFactory->create($order);
+        $placedOrderView->tokenValue = $order->getTokenValue();
+        $placedOrderView->number = $order->getNumber();
 
         /** @var OrderItemInterface $item */
         foreach ($order->getItems() as $item) {
@@ -80,7 +80,7 @@ final class PlacedOrderViewFactory implements PlacedOrderViewFactoryInterface
         $cartDiscounts = [];
         /** @var AdjustmentInterface $adjustment */
         foreach ($order->getAdjustmentsRecursively(AdjustmentInterface::ORDER_PROMOTION_ADJUSTMENT) as $adjustment) {
-            $originCode       = $adjustment->getOriginCode();
+            $originCode = $adjustment->getOriginCode();
             $additionalAmount = isset($cartDiscounts[$originCode]) ? $cartDiscounts[$originCode]->amount->current : 0;
 
             $cartDiscounts[$originCode] = $this->adjustmentViewFactory->create($adjustment, $additionalAmount, $order->getCurrencyCode());

--- a/src/Factory/PlacedOrderViewFactoryInterface.php
+++ b/src/Factory/PlacedOrderViewFactoryInterface.php
@@ -9,5 +9,5 @@ use Sylius\ShopApiPlugin\View\PlacedOrderView;
 
 interface PlacedOrderViewFactoryInterface
 {
-    public function create(OrderInterface $cart, string $localeCode): PlacedOrderView;
+    public function create(OrderInterface $order, string $localeCode): PlacedOrderView;
 }

--- a/src/Resources/config/routing/order.yml
+++ b/src/Resources/config/routing/order.yml
@@ -4,7 +4,13 @@ sylius_shop_orders_list:
     defaults:
         _controller: sylius.shop_api_plugin.controller.order.show_orders_list_action
 
-sylius_shop_order_details:
+sylius_shop_order_details_token:
+    path: /orders/{orderToken}
+    methods: [GET]
+    defaults:
+        _controller: sylius.shop_api_plugin.controller.order.show_order_details_action
+
+sylius_shop_order_details_id:
     path: /orders/{id}
     methods: [GET]
     defaults:

--- a/src/View/PlacedOrderView.php
+++ b/src/View/PlacedOrderView.php
@@ -39,6 +39,12 @@ class PlacedOrderView
     /** @var array|AdjustmentView[] */
     public $cartDiscounts = [];
 
+    /** @var string */
+    public $tokenValue;
+
+    /** @var string */
+    public $number;
+
     public function __construct()
     {
         $this->totals = new TotalsView();

--- a/src/ViewRepository/PlacedOrderViewRepository.php
+++ b/src/ViewRepository/PlacedOrderViewRepository.php
@@ -29,8 +29,8 @@ final class PlacedOrderViewRepository implements PlacedOrderViewRepositoryInterf
         CustomerRepositoryInterface $customerRepository,
         PlacedOrderViewFactoryInterface $placedOrderViewFactory
     ) {
-        $this->orderRepository = $orderRepository;
-        $this->customerRepository = $customerRepository;
+        $this->orderRepository        = $orderRepository;
+        $this->customerRepository     = $customerRepository;
         $this->placedOrderViewFactory = $placedOrderViewFactory;
     }
 
@@ -66,6 +66,24 @@ final class PlacedOrderViewRepository implements PlacedOrderViewRepositoryInterf
         ;
 
         Assert::notNull($order, sprintf('There is no placed order with with id %d for customer with email %s', $id, $customerEmail));
+
+        return $this->placedOrderViewFactory->create($order, $order->getLocaleCode());
+    }
+
+    public function getOneCompletedByCustomerEmailAndToken(string $customerEmail, string $tokenValue): PlacedOrderView
+    {
+        /** @var CustomerInterface|null $customer */
+        $customer = $this->customerRepository->findOneBy(['email' => $customerEmail]);
+
+        Assert::notNull($customer);
+
+        /** @var OrderInterface|null $order */
+        $order = $this
+            ->orderRepository
+            ->findOneBy(['tokenValue' => $tokenValue, 'customer' => $customer, 'checkoutState' => OrderCheckoutStates::STATE_COMPLETED])
+        ;
+
+        Assert::notNull($order, sprintf('There is no placed order with with token %s for customer with email %s', $tokenValue, $customerEmail));
 
         return $this->placedOrderViewFactory->create($order, $order->getLocaleCode());
     }

--- a/src/ViewRepository/PlacedOrderViewRepository.php
+++ b/src/ViewRepository/PlacedOrderViewRepository.php
@@ -29,8 +29,8 @@ final class PlacedOrderViewRepository implements PlacedOrderViewRepositoryInterf
         CustomerRepositoryInterface $customerRepository,
         PlacedOrderViewFactoryInterface $placedOrderViewFactory
     ) {
-        $this->orderRepository        = $orderRepository;
-        $this->customerRepository     = $customerRepository;
+        $this->orderRepository = $orderRepository;
+        $this->customerRepository = $customerRepository;
         $this->placedOrderViewFactory = $placedOrderViewFactory;
     }
 

--- a/src/ViewRepository/PlacedOrderViewRepositoryInterface.php
+++ b/src/ViewRepository/PlacedOrderViewRepositoryInterface.php
@@ -12,4 +12,6 @@ interface PlacedOrderViewRepositoryInterface
     public function getAllCompletedByCustomerEmail(string $customerEmail): array;
 
     public function getOneCompletedByCustomerEmailAndId(string $customerEmail, int $id): PlacedOrderView;
+
+    public function getOneCompletedByCustomerEmailAndToken(string $customerEmail, string $tokenValue): PlacedOrderView;
 }


### PR DESCRIPTION
I made this, because the /orders and /orders/{id} endpoint are not useful in the current state. My approach is coming from a perspective that uses Sylius 100% headless.

So I modified the routes to accept either an ID or a tokenValue (which is the primary identifier used by the Shop-API-Plugin and present in the client).

This is also needed, because currently the ID of any order or cart is not obtainable through Shop-API. Since the cart and checkout are used with the token of an order, it is justifiable to use the same token to obtain any completed checkout/cart.