### PR TITLE
Fixed order addressing filling the database with garbage

### DIFF
--- a/src/Handler/Cart/AddressOrderHandler.php
+++ b/src/Handler/Cart/AddressOrderHandler.php
@@ -46,7 +46,7 @@ final class AddressOrderHandler
         Assert::true($stateMachine->can(OrderCheckoutTransitions::TRANSITION_ADDRESS), sprintf('Order with %s token cannot be addressed.', $addressOrder->orderToken()));
 
         /** @var AddressInterface $shippingAddress */
-        $shippingAddress = $this->addressFactory->createNew();
+        $shippingAddress = $order->getShippingAddress() ?? $this->addressFactory->createNew();
 
         $shippingAddress->setFirstName($addressOrder->shippingAddress()->firstName());
         $shippingAddress->setLastName($addressOrder->shippingAddress()->lastName());
@@ -57,7 +57,7 @@ final class AddressOrderHandler
         $shippingAddress->setProvinceName($addressOrder->shippingAddress()->provinceName());
 
         /** @var AddressInterface $billingAddress */
-        $billingAddress = $this->addressFactory->createNew();
+        $billingAddress = $order->getBillingAddress() ?? $this->addressFactory->createNew();
 
         $billingAddress->setFirstName($addressOrder->billingAddress()->firstName());
         $billingAddress->setLastName($addressOrder->billingAddress()->lastName());

--- a/tests/Controller/Checkout/CheckoutAddressApiTest.php
+++ b/tests/Controller/Checkout/CheckoutAddressApiTest.php
@@ -7,6 +7,7 @@ namespace Tests\Sylius\ShopApiPlugin\Controller\Checkout;
 use League\Tactician\CommandBus;
 use Sylius\ShopApiPlugin\Command\Cart\PickupCart;
 use Sylius\ShopApiPlugin\Command\Cart\PutSimpleItemToCart;
+use Sylius\Component\Core\Repository\AddressRepositoryInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Tests\Sylius\ShopApiPlugin\Controller\JsonApiTestCase;
 
@@ -169,5 +170,66 @@ EOT;
 
         $response = $this->client->getResponse();
         $this->assertResponseCode($response, Response::HTTP_NO_CONTENT);
+    }
+
+    /**
+     * @test
+     */
+    public function changing_address_does_not_fill_up_database()
+    {
+        $this->loadFixturesFromFiles(['shop.yml']);
+
+        $token = 'SDAOSLEFNWU35H3QLI5325';
+
+        /** @var AddressRepositoryInterface $addressRepository */
+        $addressRepository = $this->get('sylius.repository.address');
+
+        /** @var CommandBus $bus */
+        $bus = $this->get('tactician.commandbus');
+        $bus->handle(new PickupCart($token, 'WEB_GB'));
+        $bus->handle(new PutSimpleItemToCart($token, 'LOGAN_MUG_CODE', 5));
+
+        $data =
+            <<<EOT
+        {
+            "shippingAddress": {
+                "firstName": "Sherlock",
+                "lastName": "Holmes",
+                "countryCode": "GB",
+                "street": "Baker Street 221b",
+                "city": "London",
+                "postcode": "NW1",
+                "provinceName": "Greater London"
+            }
+        }
+EOT;
+
+        $this->client->request('PUT', sprintf('/shop-api/WEB_GB/checkout/%s/address', $token), [], [], static::$acceptAndContentTypeHeader, $data);
+
+        $firstAddressCount = count($addressRepository->findAll());
+
+        $data =
+            <<<EOT
+        {
+            "shippingAddress": {
+                "firstName": "John",
+                "lastName": "Watson",
+                "countryCode": "GB",
+                "street": "Baker Street 21b",
+                "city": "London",
+                "postcode": "NW1",
+                "provinceName": "Greater London"
+            }
+        }
+EOT;
+
+        $this->client->request('PUT', sprintf('/shop-api/WEB_GB/checkout/%s/address', $token), [], [], static::$acceptAndContentTypeHeader, $data);
+
+        $response = $this->client->getResponse();
+        $this->assertResponseCode($response, Response::HTTP_NO_CONTENT);
+
+        $secondAddressCount = count($addressRepository->findAll());
+
+        $this->assertSame($firstAddressCount, $secondAddressCount);
     }
 }

--- a/tests/Controller/Checkout/CheckoutAddressApiTest.php
+++ b/tests/Controller/Checkout/CheckoutAddressApiTest.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Tests\Sylius\ShopApiPlugin\Controller\Checkout;
 
 use League\Tactician\CommandBus;
+use Sylius\Component\Core\Repository\AddressRepositoryInterface;
 use Sylius\ShopApiPlugin\Command\Cart\PickupCart;
 use Sylius\ShopApiPlugin\Command\Cart\PutSimpleItemToCart;
-use Sylius\Component\Core\Repository\AddressRepositoryInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Tests\Sylius\ShopApiPlugin\Controller\JsonApiTestCase;
 
@@ -204,7 +204,7 @@ EOT;
         }
 EOT;
 
-        $this->client->request('PUT', sprintf('/shop-api/WEB_GB/checkout/%s/address', $token), [], [], static::$acceptAndContentTypeHeader, $data);
+        $this->client->request('PUT', sprintf('/shop-api/WEB_GB/checkout/%s/address', $token), [], [], static::CONTENT_TYPE_HEADER, $data);
 
         $firstAddressCount = count($addressRepository->findAll());
 
@@ -223,7 +223,7 @@ EOT;
         }
 EOT;
 
-        $this->client->request('PUT', sprintf('/shop-api/WEB_GB/checkout/%s/address', $token), [], [], static::$acceptAndContentTypeHeader, $data);
+        $this->client->request('PUT', sprintf('/shop-api/WEB_GB/checkout/%s/address', $token), [], [], static::CONTENT_TYPE_HEADER, $data);
 
         $response = $this->client->getResponse();
         $this->assertResponseCode($response, Response::HTTP_NO_CONTENT);


### PR DESCRIPTION
**Before:** Addressing an order would always create two new addresses, even when we just want to change the address of an order, which fills the database with a lot of unused addresses.

**After:** The order addressing handler looks for existing addresses on the order and updates them if possible.