### PR TITLE
Re-done get order by tokenValue instead of ID

### DIFF
--- a/doc/swagger.yml
+++ b/doc/swagger.yml
@@ -929,20 +929,20 @@ paths:
                         $ref: "#/definitions/PlacedOrder"
                 401:
                     description: "User token invalid"
-    /orders/{id}:
+    /orders/{tokenValue}:
         get:
             tags:
             - "order"
             summary: "Shows details of specific customer's order"
             responses:
                 200:
-                    description: "Shows details of specific customer's order with given ID"
+                    description: "Shows details of specific customer's order with given tokenValue"
                     type: "object"
                     $ref: "#/definitions/PlacedOrderDetails"
                 401:
                     description: "User token invalid"
                 404:
-                    description: "Order with given ID not found"
+                    description: "Order with given tokenValue not found"
     /me:
         get:
             tags:

--- a/spec/Factory/PlacedOrderViewFactorySpec.php
+++ b/spec/Factory/PlacedOrderViewFactorySpec.php
@@ -64,6 +64,7 @@ final class PlacedOrderViewFactorySpec extends ObjectBehavior
         $cart->getCurrencyCode()->willReturn('GBP');
         $cart->getCheckoutState()->willReturn(OrderCheckoutStates::STATE_COMPLETED);
         $cart->getTokenValue()->willReturn('ORDERTOKEN');
+        $cart->getNumber()->willReturn('ORDERNUMBER');
         $cart->getShippingTotal()->willReturn(500);
         $cart->getTaxTotal()->willReturn(600);
         $cart->getItems()->willReturn(new ArrayCollection([$orderItem->getWrappedObject()]));
@@ -100,6 +101,8 @@ final class PlacedOrderViewFactorySpec extends ObjectBehavior
         $placedOrderView->items = [new ItemView()];
         $placedOrderView->totals = new TotalsView();
         $placedOrderView->cartDiscounts = ['PROMOTION_CODE' => new AdjustmentView()];
+        $placedOrderView->tokenValue = 'ORDERTOKEN';
+        $placedOrderView->number = 'ORDERNUMBER';
 
         $this->create($cart, 'en_GB')->shouldBeLike($placedOrderView);
     }

--- a/spec/ViewRepository/PlacedOrderViewRepositorySpec.php
+++ b/spec/ViewRepository/PlacedOrderViewRepositorySpec.php
@@ -98,12 +98,11 @@ final class PlacedOrderViewRepositorySpec extends ObjectBehavior
         OrderRepositoryInterface $orderRepository
     ): void {
         $customerRepository->findOneBy(['email' => 'test@example.com'])->willReturn(null, null);
+        $orderRepository->findOneBy(Argument::any())->shouldNotBeCalled();
 
         $this
             ->shouldThrow(\InvalidArgumentException::class)
             ->during('getAllCompletedByCustomerEmail', ['test@example.com'])
         ;
-
-        $orderRepository->findOneBy(Argument::any())->shouldNotBeCalled();
     }
 }

--- a/src/Controller/Order/ShowOrderDetailsAction.php
+++ b/src/Controller/Order/ShowOrderDetailsAction.php
@@ -43,7 +43,7 @@ final class ShowOrderDetailsAction
 
             $order = $this
                 ->placedOrderQuery
-                ->getOneCompletedByCustomerEmailAndId($user->getCustomer()->getEmail(), (int) $request->attributes->get('id'))
+                ->getOneCompletedByCustomerEmailAndToken($user->getCustomer()->getEmail(), (string) $request->attributes->get('tokenValue'))
             ;
         } catch (TokenNotFoundException $exception) {
             return $this->viewHandler->handle(View::create(null, Response::HTTP_UNAUTHORIZED));

--- a/src/Factory/PlacedOrderViewFactory.php
+++ b/src/Factory/PlacedOrderViewFactory.php
@@ -51,49 +51,51 @@ final class PlacedOrderViewFactory implements PlacedOrderViewFactoryInterface
         $this->placedOrderViewClass = $placedOrderViewClass;
     }
 
-    public function create(OrderInterface $cart, string $localeCode): PlacedOrderView
+    public function create(OrderInterface $order, string $localeCode): PlacedOrderView
     {
-        /** @var PlacedOrderView $cartView */
-        $cartView = new $this->placedOrderViewClass();
-        $cartView->channel = $cart->getChannel()->getCode();
-        $cartView->currency = $cart->getCurrencyCode();
-        $cartView->locale = $localeCode;
-        $cartView->checkoutState = $cart->getCheckoutState();
-        $cartView->totals = $this->totalViewFactory->create($cart);
+        /** @var PlacedOrderView $placedOrderView */
+        $placedOrderView = new $this->placedOrderViewClass();
+        $placedOrderView->channel = $order->getChannel()->getCode();
+        $placedOrderView->currency = $order->getCurrencyCode();
+        $placedOrderView->locale = $localeCode;
+        $placedOrderView->checkoutState = $order->getCheckoutState();
+        $placedOrderView->totals = $this->totalViewFactory->create($order);
+        $placedOrderView->tokenValue = $order->getTokenValue();
+        $placedOrderView->number = $order->getNumber();
 
         /** @var OrderItemInterface $item */
-        foreach ($cart->getItems() as $item) {
-            $cartView->items[] = $this->orderItemFactory->create($item, $cart->getChannel(), $localeCode);
+        foreach ($order->getItems() as $item) {
+            $placedOrderView->items[] = $this->orderItemFactory->create($item, $order->getChannel(), $localeCode);
         }
 
-        foreach ($cart->getShipments() as $shipment) {
-            $cartView->shipments[] = $this->shipmentViewFactory->create($shipment, $localeCode);
+        foreach ($order->getShipments() as $shipment) {
+            $placedOrderView->shipments[] = $this->shipmentViewFactory->create($shipment, $localeCode);
         }
 
-        foreach ($cart->getPayments() as $payment) {
-            $cartView->payments[] = $this->paymentViewFactory->create($payment, $localeCode);
+        foreach ($order->getPayments() as $payment) {
+            $placedOrderView->payments[] = $this->paymentViewFactory->create($payment, $localeCode);
         }
 
         /** @var AdjustmentView[] $cartDiscounts */
         $cartDiscounts = [];
         /** @var AdjustmentInterface $adjustment */
-        foreach ($cart->getAdjustmentsRecursively(AdjustmentInterface::ORDER_PROMOTION_ADJUSTMENT) as $adjustment) {
+        foreach ($order->getAdjustmentsRecursively(AdjustmentInterface::ORDER_PROMOTION_ADJUSTMENT) as $adjustment) {
             $originCode = $adjustment->getOriginCode();
             $additionalAmount = isset($cartDiscounts[$originCode]) ? $cartDiscounts[$originCode]->amount->current : 0;
 
-            $cartDiscounts[$originCode] = $this->adjustmentViewFactory->create($adjustment, $additionalAmount, $cart->getCurrencyCode());
+            $cartDiscounts[$originCode] = $this->adjustmentViewFactory->create($adjustment, $additionalAmount, $order->getCurrencyCode());
         }
 
-        $cartView->cartDiscounts = $cartDiscounts;
+        $placedOrderView->cartDiscounts = $cartDiscounts;
 
-        if (null !== $cart->getShippingAddress()) {
-            $cartView->shippingAddress = $this->addressViewFactory->create($cart->getShippingAddress());
+        if (null !== $order->getShippingAddress()) {
+            $placedOrderView->shippingAddress = $this->addressViewFactory->create($order->getShippingAddress());
         }
 
-        if (null !== $cart->getBillingAddress()) {
-            $cartView->billingAddress = $this->addressViewFactory->create($cart->getBillingAddress());
+        if (null !== $order->getBillingAddress()) {
+            $placedOrderView->billingAddress = $this->addressViewFactory->create($order->getBillingAddress());
         }
 
-        return $cartView;
+        return $placedOrderView;
     }
 }

--- a/src/Factory/PlacedOrderViewFactoryInterface.php
+++ b/src/Factory/PlacedOrderViewFactoryInterface.php
@@ -9,5 +9,5 @@ use Sylius\ShopApiPlugin\View\PlacedOrderView;
 
 interface PlacedOrderViewFactoryInterface
 {
-    public function create(OrderInterface $cart, string $localeCode): PlacedOrderView;
+    public function create(OrderInterface $order, string $localeCode): PlacedOrderView;
 }

--- a/src/Resources/config/routing/order.yml
+++ b/src/Resources/config/routing/order.yml
@@ -5,7 +5,7 @@ sylius_shop_orders_list:
         _controller: sylius.shop_api_plugin.controller.order.show_orders_list_action
 
 sylius_shop_order_details:
-    path: /orders/{id}
+    path: /orders/{tokenValue}
     methods: [GET]
     defaults:
         _controller: sylius.shop_api_plugin.controller.order.show_order_details_action

--- a/src/View/PlacedOrderView.php
+++ b/src/View/PlacedOrderView.php
@@ -39,6 +39,12 @@ class PlacedOrderView
     /** @var array|AdjustmentView[] */
     public $cartDiscounts = [];
 
+    /** @var string */
+    public $tokenValue;
+
+    /** @var string */
+    public $number;
+
     public function __construct()
     {
         $this->totals = new TotalsView();

--- a/src/ViewRepository/PlacedOrderViewRepository.php
+++ b/src/ViewRepository/PlacedOrderViewRepository.php
@@ -52,7 +52,7 @@ final class PlacedOrderViewRepository implements PlacedOrderViewRepositoryInterf
         return $cartViews;
     }
 
-    public function getOneCompletedByCustomerEmailAndId(string $customerEmail, int $id): PlacedOrderView
+    public function getOneCompletedByCustomerEmailAndToken(string $customerEmail, string $tokenValue): PlacedOrderView
     {
         /** @var CustomerInterface|null $customer */
         $customer = $this->customerRepository->findOneBy(['email' => $customerEmail]);
@@ -62,10 +62,10 @@ final class PlacedOrderViewRepository implements PlacedOrderViewRepositoryInterf
         /** @var OrderInterface|null $order */
         $order = $this
             ->orderRepository
-            ->findOneBy(['id' => $id, 'customer' => $customer, 'checkoutState' => OrderCheckoutStates::STATE_COMPLETED])
+            ->findOneBy(['tokenValue' => $tokenValue, 'customer' => $customer, 'checkoutState' => OrderCheckoutStates::STATE_COMPLETED])
         ;
 
-        Assert::notNull($order, sprintf('There is no placed order with with id %d for customer with email %s', $id, $customerEmail));
+        Assert::notNull($order, sprintf('There is no placed order with with token %s for customer with email %s', $tokenValue, $customerEmail));
 
         return $this->placedOrderViewFactory->create($order, $order->getLocaleCode());
     }

--- a/src/ViewRepository/PlacedOrderViewRepositoryInterface.php
+++ b/src/ViewRepository/PlacedOrderViewRepositoryInterface.php
@@ -11,5 +11,5 @@ interface PlacedOrderViewRepositoryInterface
     /** @return array|PlacedOrderView[] */
     public function getAllCompletedByCustomerEmail(string $customerEmail): array;
 
-    public function getOneCompletedByCustomerEmailAndId(string $customerEmail, int $id): PlacedOrderView;
+    public function getOneCompletedByCustomerEmailAndToken(string $customerEmail, string $tokenValue): PlacedOrderView;
 }

--- a/tests/Controller/OrderShowApiTest.php
+++ b/tests/Controller/OrderShowApiTest.php
@@ -23,7 +23,7 @@ final class OrderShowApiTest extends JsonApiTestCase
         /** @var OrderInterface $placedOrder */
         $placedOrder = $fixtures['placed_order'];
 
-        $this->client->request('GET', '/shop-api/WEB_GB/orders/' . $placedOrder->getId(), [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('GET', '/shop-api/WEB_GB/orders/' . $placedOrder->getTokenValue(), [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'order/order_details_response', Response::HTTP_OK);
@@ -32,12 +32,12 @@ final class OrderShowApiTest extends JsonApiTestCase
     /**
      * @test
      */
-    public function it_returns_a_not_found_exception_if_there_is_no_placed_order_with_given_id(): void
+    public function it_returns_a_not_found_exception_if_there_is_no_placed_order_with_given_token(): void
     {
         $this->loadFixturesFromFiles(['channel.yml', 'customer.yml']);
         $this->logInUser('oliver@queen.com', '123password');
 
-        $this->client->request('GET', '/shop-api/WEB_GB/orders/13', [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('GET', '/shop-api/WEB_GB/orders/NOT_EXISTING_TOKEN', [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'order/order_not_found_response', Response::HTTP_NOT_FOUND);
@@ -50,7 +50,7 @@ final class OrderShowApiTest extends JsonApiTestCase
     {
         $this->loadFixturesFromFiles(['channel.yml']);
 
-        $this->client->request('GET', '/shop-api/WEB_GB/orders/2', [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('GET', '/shop-api/WEB_GB/orders/ORDER_TOKEN', [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponseCode($response, Response::HTTP_UNAUTHORIZED);
@@ -63,7 +63,7 @@ final class OrderShowApiTest extends JsonApiTestCase
     {
         $this->loadFixturesFromFiles(['channel.yml']);
 
-        $this->client->request('GET', '/shop-api/SPACE_KLINGON/orders/2', [], [], ['ACCEPT' => 'application/json']);
+        $this->client->request('GET', '/shop-api/SPACE_KLINGON/orders/ORDER_TOKEN', [], [], ['ACCEPT' => 'application/json']);
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'channel_has_not_been_found_response', Response::HTTP_NOT_FOUND);

--- a/tests/DataFixtures/ORM/order.yml
+++ b/tests/DataFixtures/ORM/order.yml
@@ -11,6 +11,8 @@ Sylius\Component\Core\Model\Order:
         shipments: ["@placed_order_shipment"]
         shippingAddress: "@customer_oliver_home_address"
         billingAddress: "@customer_oliver_work_address"
+        number: "ORDERNUMBERPLACED"
+        tokenValue: "ORDERTOKENPLACED"
     not_placed_order:
         channel: "@gb_web_channel"
         items: ["@large_t_shirt_item"]
@@ -23,6 +25,8 @@ Sylius\Component\Core\Model\Order:
         shipments: ["@not_placed_order_shipment"]
         shippingAddress: "@customer_oliver_freelance_address"
         billingAddress: "@customer_hater_address"
+        number: "ORDERNUMBERUNPLACED"
+        tokenValue: "ORDERTOKENUNPLACED"
 
 Sylius\Component\Core\Model\OrderItem:
     mug_item:

--- a/tests/Responses/Expected/order/order_details_response.json
+++ b/tests/Responses/Expected/order/order_details_response.json
@@ -108,5 +108,7 @@
             }
         }
     ],
-    "cartDiscounts": []
+    "cartDiscounts": [],
+    "tokenValue": @string@,
+    "number": @string@
 }

--- a/tests/Responses/Expected/order/order_not_found_response.json
+++ b/tests/Responses/Expected/order/order_not_found_response.json
@@ -1,4 +1,4 @@
 {
     "code": 404,
-    "message": "There is no placed order with with id 13 for customer with email oliver@queen.com"
+    "message": "There is no placed order with with token NOT_EXISTING_TOKEN for customer with email oliver@queen.com"
 }

--- a/tests/Responses/Expected/order/orders_list_response.json
+++ b/tests/Responses/Expected/order/orders_list_response.json
@@ -109,6 +109,8 @@
                 }
             }
         ],
-        "cartDiscounts": []
+        "cartDiscounts": [],
+        "tokenValue": @string@,
+        "number": @string@
     }
 ]


### PR DESCRIPTION
This is a re-do of #347 

It is basically the same commit, but instead of allowing getting an order with ID or tokenValue, this time I switched to only use the tokenValue.

I think it is not good practice to expose the ID of an order, which is not obtainable by using the API in any way. Using the token only should be the way to go, because the token should already be present in all clients using the API and is also obtainable through picking up a cart.