### PR TITLE
fix: persist cart items on order when you update or add item(s) to cart

### DIFF
--- a/spec/Modifier/OrderModifierSpec.php
+++ b/spec/Modifier/OrderModifierSpec.php
@@ -74,6 +74,8 @@ final class OrderModifierSpec extends ObjectBehavior
 
         $orderManager->persist($order)->shouldBeCalled();
 
+        $orderManager->flush()->shouldBeCalled();
+
         $this->modify($order, $productVariant, 4);
     }
 }

--- a/src/Modifier/OrderModifier.php
+++ b/src/Modifier/OrderModifier.php
@@ -57,6 +57,8 @@ final class OrderModifier implements OrderModifierInterface
         $this->orderProcessor->process($order);
 
         $this->orderManager->persist($order);
+
+        $this->orderManager->flush();
     }
 
     private function getCartItemToModify(OrderInterface $cart, ProductVariantInterface $productVariant): ?OrderItemInterface


### PR DESCRIPTION
When you add or update item(s) to a cart, the cart is not persisted in database.