### PR TITLE
Unify request command objects

### DIFF
--- a/src/Request/RemoveAddressRequest.php
+++ b/src/Request/RemoveAddressRequest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Request;
 
+use Sylius\ShopApiPlugin\Command\RemoveAddress;
 use Symfony\Component\HttpFoundation\Request;
 
 class RemoveAddressRequest
@@ -11,14 +12,17 @@ class RemoveAddressRequest
     /** @var int|string */
     protected $id;
 
-    public function __construct(Request $request)
+    /** @var string */
+    protected $userEmail;
+
+    public function __construct(Request $request, string $userEmail)
     {
         $this->id = $request->attributes->get('id');
+        $this->userEmail = $userEmail;
     }
 
-    /** @return int|string */
-    public function id()
+    public function getCommand(): RemoveAddress
     {
-        return $this->id;
+        return new RemoveAddress($this->id, $this->userEmail);
     }
 }

--- a/src/Request/SetDefaultAddressRequest.php
+++ b/src/Request/SetDefaultAddressRequest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Request;
 
+use Sylius\ShopApiPlugin\Command\SetDefaultAddress;
 use Symfony\Component\HttpFoundation\Request;
 
 class SetDefaultAddressRequest
@@ -11,8 +12,17 @@ class SetDefaultAddressRequest
     /** @var mixed */
     protected $id;
 
-    public function __construct(Request $request)
+    /** @var string */
+    protected $userEmail;
+
+    public function __construct(Request $request, string $userEmail)
     {
         $this->id = $request->attributes->get('id');
+        $this->userEmail = $userEmail;
+    }
+
+    public function getCommand(): SetDefaultAddress
+    {
+        return new SetDefaultAddress($this->id, $this->userEmail);
     }
 }


### PR DESCRIPTION
These 2 `*Request`s didn't have `getCommand()` method due to some validation purposes. I think it can be done this way and it would be also easier to abstract commands from requests creation in the nearest future :)