### PR TITLE
[POC] New command providers (but a bit different than those below)

### DIFF
--- a/src/CommandProvider/CommandProviderInterface.php
+++ b/src/CommandProvider/CommandProviderInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\ShopApiPlugin\CommandProvider;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+
+interface CommandProviderInterface
+{
+    public function validate(Request $request): ConstraintViolationListInterface;
+
+    public function getCommand(Request $request): object;
+}

--- a/src/CommandProvider/CommandProviderInterface.php
+++ b/src/CommandProvider/CommandProviderInterface.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace Sylius\ShopApiPlugin\CommandProvider;
 
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Validator\ConstraintViolationListInterface;
 
 interface CommandProviderInterface
 {
-    public function validate(Request $request): ConstraintViolationListInterface;
-
-    public function getCommand(Request $request): object;
+    /**
+     * @throws ValidationFailedExceptionInterface
+     */
+    public function provide(Request $request): object;
 }

--- a/src/CommandProvider/DropCartCommandProvider.php
+++ b/src/CommandProvider/DropCartCommandProvider.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\ShopApiPlugin\CommandProvider;
+
+use Sylius\ShopApiPlugin\Command\DropCart;
+use Sylius\ShopApiPlugin\Validator\Constraints\CartExists;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Validator\Constraints as Assert;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+final class DropCartCommandProvider implements CommandProviderInterface
+{
+    /** @var ValidatorInterface */
+    private $validator;
+
+    public function __construct(ValidatorInterface $validator)
+    {
+        $this->validator = $validator;
+    }
+
+    public function validate(Request $request): ConstraintViolationListInterface
+    {
+        $constraint = new Assert\Collection([
+            'token' => [
+                new Assert\NotBlank(),
+                new CartExists(),
+            ],
+        ]);
+
+        return $this->validator->validate($this->provideRawData($request), $constraint);
+    }
+
+    public function getCommand(Request $request): object
+    {
+        $violationList = $this->validate($request);
+
+        if (0 === count($violationList)) {
+            $rawData = $this->provideRawData($request);
+
+            return new DropCart($rawData['token']);
+        }
+
+        throw new \InvalidArgumentException('Command cannot be created');
+    }
+
+    private function provideRawData(Request $request): array
+    {
+        return ['token' => $request->attributes->get('token')];
+    }
+}

--- a/src/CommandProvider/ValidationFailedException.php
+++ b/src/CommandProvider/ValidationFailedException.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\ShopApiPlugin\CommandProvider;
+
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+use Throwable;
+
+final class ValidationFailedException extends \InvalidArgumentException implements ValidationFailedExceptionInterface
+{
+    /** @var ConstraintViolationListInterface */
+    private $validationErrors;
+
+    private function __construct(string $message = '', int $code = 0, Throwable $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
+
+    public static function fromSymfonyConstraintValidationList(ConstraintViolationListInterface $violationList): self
+    {
+        $self = new self('Validation failed!');
+        $self->validationErrors = $violationList;
+
+        return $self;
+    }
+
+    public function getValidationErrors(): ConstraintViolationListInterface
+    {
+        return $this->validationErrors;
+    }
+}

--- a/src/CommandProvider/ValidationFailedExceptionInterface.php
+++ b/src/CommandProvider/ValidationFailedExceptionInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\ShopApiPlugin\CommandProvider;
+
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+
+interface ValidationFailedExceptionInterface extends \Throwable
+{
+    public function getValidationErrors(): ConstraintViolationListInterface;
+}

--- a/src/Factory/ValidationErrorViewFactory.php
+++ b/src/Factory/ValidationErrorViewFactory.php
@@ -29,7 +29,13 @@ final class ValidationErrorViewFactory implements ValidationErrorViewFactoryInte
         $errorMessage->message = 'Validation failed';
         /** @var ConstraintViolationInterface $result */
         foreach ($validationResults as $result) {
-            $errorMessage->errors[$result->getPropertyPath()][] = $result->getMessage();
+            // ACL because of new providers path surrounded with `[` and `]`
+            $property = $result->getPropertyPath();
+            if (\preg_match('/\\[.+\\]/', $property) === 1) {
+                $property = substr($property, 1, -1);
+            }
+
+            $errorMessage->errors[$property][] = $result->getMessage();
         }
 
         return $errorMessage;

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -13,6 +13,7 @@
 
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <imports>
+        <import resource="services/command_providers.xml"/>
         <import resource="services/command_requests.xml"/>
         <import resource="services/controllers.xml"/>
         <import resource="services/factories.xml"/>

--- a/src/Resources/config/services/actions/cart.xml
+++ b/src/Resources/config/services/actions/cart.xml
@@ -16,9 +16,8 @@
         >
             <argument type="service" id="fos_rest.view_handler" />
             <argument type="service" id="tactician.commandbus" />
-            <argument type="service" id="validator" />
             <argument type="service" id="sylius.shop_api_plugin.factory.validation_error_view_factory" />
-            <argument type="service" id="Sylius\ShopApiPlugin\Parser\CommandRequestParser" />
+            <argument type="service" id="Sylius\ShopApiPlugin\CommandProvider\DropCartCommandProvider" />
         </service>
 
         <service class="Sylius\ShopApiPlugin\Controller\Cart\EstimateShippingCostAction"

--- a/src/Resources/config/services/command_providers.xml
+++ b/src/Resources/config/services/command_providers.xml
@@ -1,0 +1,9 @@
+<container xmlns="http://symfony.com/schema/dic/services">
+    <services>
+        <defaults public="true" />
+
+        <service id="Sylius\ShopApiPlugin\CommandProvider\DropCartCommandProvider">
+            <argument type="service" id="validator" />
+        </service>
+    </services>
+</container>


### PR DESCRIPTION
Related to discussion in https://github.com/Sylius/ShopApiPlugin/pull/375#discussion_r250996350 and #380.

This is a POC on top of #380, it removed the `validate` method from the command provider and replaces it with an exception.

In the #380 every request is validated twice: for the first time when trying to return a friendly response from a controller and for the second time when creating a command object. This might hit the performance hard, especially when using the validators which gathers data from the database (like `CartExists`). Also, we need to be sure to call `validate` every time before calling `getCommand`. 

Replacing it with an exception solves these problems and it doesn't seem to have cons.