### PR TITLE
Fixed shop api /verify-account route

### DIFF
--- a/src/Request/VerifyAccountRequest.php
+++ b/src/Request/VerifyAccountRequest.php
@@ -14,7 +14,7 @@ class VerifyAccountRequest
 
     public function __construct(Request $request)
     {
-        $this->token = $request->request->get('token');
+        $this->token = $request->get('token');
     }
 
     public function getCommand(): VerifyAccount

--- a/src/Request/VerifyAccountRequest.php
+++ b/src/Request/VerifyAccountRequest.php
@@ -14,7 +14,7 @@ class VerifyAccountRequest
 
     public function __construct(Request $request)
     {
-        $this->token = $request->get('token');
+        $this->token = $request->query->get('token');
     }
 
     public function getCommand(): VerifyAccount

--- a/src/Resources/config/routing/register.yml
+++ b/src/Resources/config/routing/register.yml
@@ -12,7 +12,7 @@ sylius_shop_api_resend_verification_token:
 
 sylius_shop_api_user_verification:
     path: /verify-account
-    methods: [PUT]
+    methods: [GET]
     defaults:
         _controller: sylius.shop_api_plugin.controller.customer.verify_account_action
 

--- a/tests/Controller/CustomerVerifyApiTest.php
+++ b/tests/Controller/CustomerVerifyApiTest.php
@@ -36,9 +36,9 @@ EOT;
         $userRepository = $this->get('sylius.repository.shop_user');
         $user = $userRepository->findOneByEmail('vinny@fandf.com');
 
-        $verifyEmail = sprintf('{"token": "%s"}', $user->getEmailVerificationToken());
+        $parameters = ['token' => $user->getEmailVerificationToken()];
 
-        $this->client->request('PUT', '/shop-api/WEB_GB/verify-account', [], [], ['CONTENT_TYPE' => 'application/json', 'ACCEPT' => 'application/json'], $verifyEmail);
+        $this->client->request('GET', '/shop-api/WEB_GB/verify-account', $parameters, [], ['ACCEPT' => 'application/json']);
 
         $response = $this->client->getResponse();
         $this->assertResponseCode($response, Response::HTTP_NO_CONTENT);
@@ -67,9 +67,9 @@ EOT;
         $userRepository = $this->get('sylius.repository.shop_user');
         $user = $userRepository->findOneByEmail('vinny@fandf.com');
 
-        $verifyEmail = sprintf('{"token": "%s"}', $user->getEmailVerificationToken());
+        $parameters = ['token' => $user->getEmailVerificationToken()];
 
-        $this->client->request('PUT', '/shop-api/SPACE_KLINGON/verify-account', [], [], ['CONTENT_TYPE' => 'application/json', 'ACCEPT' => 'application/json'], $verifyEmail);
+        $this->client->request('GET', '/shop-api/SPACE_KLINGON/verify-account', $parameters, [], ['CONTENT_TYPE' => 'application/json', 'ACCEPT' => 'application/json']);
 
         $response = $this->client->getResponse();
         $this->assertResponse($response, 'channel_has_not_been_found_response', Response::HTTP_NOT_FOUND);

--- a/tests/Request/VerifyAccountRequestTest.php
+++ b/tests/Request/VerifyAccountRequestTest.php
@@ -16,7 +16,7 @@ final class VerifyAccountRequestTest extends TestCase
      */
     public function it_creates_put_simple_item_to_cart_command()
     {
-        $verifyAccountRequest = new VerifyAccountRequest(new Request([], ['token' => 'RANDOMSTRINGAFAFAKASNFJAFAJ'], []));
+        $verifyAccountRequest = new VerifyAccountRequest(new Request(['token' => 'RANDOMSTRINGAFAFAKASNFJAFAJ'], [], []));
 
         $this->assertEquals($verifyAccountRequest->getCommand(), new VerifyAccount('RANDOMSTRINGAFAFAKASNFJAFAJ'));
     }


### PR DESCRIPTION
In order to complete the activation of new registered users I propose to change the method of `sylius_shop_api_user_verification` route to [GET] so we are able to access the activation url sent in ShopApiPlugin:Email:verification.html.twig template, when a user registers through shop api.