### PR TITLE
Add missing customer attributes to sylius_shop_api_me

### DIFF
--- a/doc/swagger.yml
+++ b/doc/swagger.yml
@@ -1547,6 +1547,19 @@ definitions:
             email:
                 type: "string"
                 example: "sherlock@holmes.com"
+            birthday:
+                type: "string"
+                example: "2017-08-12"
+            gender:
+                type: "string"
+                example: "m"
+            phoneNumber:
+                type: "string"
+                example: "+490000000000"
+            subscribedToNewsletter:
+                type: "boolean"
+                example: false
+
     LoggedInCustomerAddressBook:
         type: "array"
         items:

--- a/src/Controller/Customer/LoggedInCustomerDetailsAction.php
+++ b/src/Controller/Customer/LoggedInCustomerDetailsAction.php
@@ -39,6 +39,10 @@ final class LoggedInCustomerDetailsAction
             'firstName' => $customer->getFirstName(),
             'lastName' => $customer->getLastName(),
             'email' => $customer->getEmail(),
+            'gender' => $customer->getGender(),
+            'birthday' => $customer->getBirthday(),
+            'phoneNumber' => $customer->getPhoneNumber(),
+            'subscribedToNewsletter' => $customer->isSubscribedToNewsletter(),
         ], Response::HTTP_OK));
     }
 }

--- a/tests/Responses/Expected/customer/logged_in_customer_details_response.json
+++ b/tests/Responses/Expected/customer/logged_in_customer_details_response.json
@@ -1,5 +1,8 @@
 {
     "firstName": "Oliver",
     "lastName": "Queen",
-    "email": "oliver@queen.com"
+    "email": "oliver@queen.com",
+    "gender": "m",
+    "phoneNumber": "0212115512",
+    "subscribedToNewsletter": false
 }


### PR DESCRIPTION
In order to be able to load all user details through shopApi I suggest to change the response of `sylius_shop_api_me`, adding the missing customer attributes:  `birthday`, `gender`, `phoneNumber` and `subscribedToNewsletter`

Having this, we can get and edit all customer attributes and that will be useful if you want to use Sylius as headless system, e.g.