### PR TITLE
Add security checker as dev dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         "phpstan/phpstan-shim": "^0.10.3",
         "phpstan/phpstan-webmozart-assert": "^0.10.0",
         "phpunit/phpunit": "^6.5",
+        "sensiolabs/security-checker": "^5.0",
         "sylius-labs/coding-standard": "^2.0",
         "symfony/debug-bundle": "^3.4|^4.1",
         "symfony/dotenv": "^3.4|^4.1",


### PR DESCRIPTION
Fixes error when running tests/Application/bin/console

In getSecurityCheckerCommandService.php line 9:
                                                                                                  
  Attempted to load class "SecurityCheckerCommand" from namespace "SensioLabs\Security\Command".  
  Did you forget a "use" statement for another namespace?