### PR TITLE
Unified route names again

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,7 @@
-# UPGRADE FROM 1.0.0-beta.18 to 1.0.0-beta.20
+# UPGRADE FROM 1.0.0-beta.21 to 1.0.0-beta.22
+
 * The configuration key for the shop api is now `sylius_shop_api`.
+* The route names of the address book and the order are now renames to fit the schema `sylius_shop_api...`
 
 # UPGRADE FROM 1.0.0-beta.17 to 1.0.0-beta.18
 

--- a/src/Resources/config/routing/address_book.yml
+++ b/src/Resources/config/routing/address_book.yml
@@ -1,28 +1,28 @@
-sylius_shop_show_address_book:
+sylius_shop_api_show_address_book:
     path: /address-book
     methods: [GET]
     defaults:
         _controller: sylius.shop_api_plugin.controller.address_book.show_address_book_action
 
-sylius_shop_create_address_book_entry:
+sylius_shop_api_create_address_book_entry:
     path: /address-book
     methods: [POST]
     defaults:
         _controller: sylius.shop_api_plugin.controller.address_book.create_address_action
 
-sylius_shop_remove_address_book_entry:
+sylius_shop_api_remove_address_book_entry:
     path: /address-book/{id}
     methods: [DELETE]
     defaults:
         _controller: sylius.shop_api_plugin.controller.address_book.remove_address_action
 
-sylius_shop_set_default_address:
+sylius_shop_api_set_default_address:
     path: /address-book/{id}/default
     methods: [PATCH]
     defaults:
         _controller: sylius.shop_api_plugin.controller.address_book.set_default_address_action
 
-sylius_shop_update_address_book_entry:
+sylius_shop_api_update_address_book_entry:
     path: /address-book/{id}
     methods: [PUT]
     defaults:

--- a/src/Resources/config/routing/customer.yml
+++ b/src/Resources/config/routing/customer.yml
@@ -4,7 +4,7 @@ sylius_shop_api_me:
     defaults:
         _controller: sylius.shop_api_plugin.controller.customer.logged_in_customer_details_action
 
-sylius_shop_update_customer:
+sylius_shop_api_update_customer:
      path: /me
      methods: [PUT]
      defaults:

--- a/src/Resources/config/routing/order.yml
+++ b/src/Resources/config/routing/order.yml
@@ -1,10 +1,10 @@
-sylius_shop_orders_list:
+sylius_shop_api_orders_list:
     path: /orders
     methods: [GET]
     defaults:
         _controller: sylius.shop_api_plugin.controller.order.show_orders_list_action
 
-sylius_shop_order_details:
+sylius_shop_api_order_details:
     path: /orders/{tokenValue}
     methods: [GET]
     defaults:


### PR DESCRIPTION
All other routes of the ShopApiPlugin start with `sylius_shop_api`. Some of the routes don't follow this pattern:
:rotating_light: BC BREAK.