### PR TITLE
Implemented order available payment methods and order update payment

### DIFF
--- a/doc/swagger.yml
+++ b/doc/swagger.yml
@@ -394,7 +394,7 @@ paths:
                     name: "content"
                     required: true
                     schema:
-                        $ref: "#/definitions/CheckoutChoosePaymentMethodRequest"
+                        $ref: "#/definitions/ChoosePaymentMethodRequest"
             responses:
                 204:
                     description: "Payment method has been chosen."
@@ -838,6 +838,51 @@ paths:
             security:
                 -   bearerAuth: []
 
+    /orders/{token}/payment:
+        parameters:
+            -   $ref: "#/parameters/CartToken"
+        get:
+            tags:
+                - "order"
+            summary: "Get available payment methods."
+            description: "This endpoint will show you available payment methods for an order."
+            operationId: "showAvailablePaymentMethods"
+            responses:
+                200:
+                    description: "Get available payment methods."
+                    schema:
+                        $ref: "#/definitions/AvailablePaymentMethods"
+                400:
+                    description: "Invalid input, validation failed."
+                    schema:
+                        $ref: "#/definitions/GeneralError"
+    /orders/{token}/payment/{id}:
+        parameters:
+            -   $ref: "#/parameters/CartToken"
+        put:
+            tags:
+                - "order"
+            summary: "Choosing cart payment method."
+            description: "This endpoint will allow you to update an order payment method."
+            operationId: "updatePaymentMethod"
+            parameters:
+                -   name: "id"
+                    in: "path"
+                    description: "Order number of payment for which payment method should be specified."
+                    required: true
+                    type: "string"
+                -   in: "body"
+                    name: "content"
+                    required: true
+                    schema:
+                        $ref: "#/definitions/ChoosePaymentMethodRequest"
+            responses:
+                204:
+                    description: "Payment method has been chosen."
+                400:
+                    description: "Invalid input, validation failed."
+                    schema:
+                        $ref: "#/definitions/GeneralError"
     /me:
         get:
             tags:
@@ -1116,7 +1161,7 @@ definitions:
                 type: "string"
                 description: "Code of chosen shipping method."
                 example: "DHL"
-    CheckoutChoosePaymentMethodRequest:
+    ChoosePaymentMethodRequest:
         type: "object"
         description: "Body of request used to choose payment method."
         required:
@@ -1808,6 +1853,20 @@ definitions:
                 description: "Date the order was completed in ISO 8601 format."
                 type: "string"
                 format: "date-time"
+            paymentState:
+                description: "Current payment state of an order."
+                type: "string"
+                example: "awaiting_payment"
+                enum:
+                    - "cart"
+                    - "awaiting_payment"
+                    - "partially_authorized"
+                    - "authorized"
+                    - "partially_paid"
+                    - "cancelled"
+                    - "paid"
+                    - "partially_refunded"
+                    - "refunded"
             items:
                 type: "array"
                 items:

--- a/spec/Command/Order/UpdatePaymentMethodSpec.php
+++ b/spec/Command/Order/UpdatePaymentMethodSpec.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace spec\Sylius\ShopApiPlugin\Command\Order;
 
 use PhpSpec\ObjectBehavior;
-use TypeError;
 
 final class UpdatePaymentMethodSpec extends ObjectBehavior
 {

--- a/spec/Command/Order/UpdatePaymentMethodSpec.php
+++ b/spec/Command/Order/UpdatePaymentMethodSpec.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\Sylius\ShopApiPlugin\Command\Order;
+
+use PhpSpec\ObjectBehavior;
+use TypeError;
+
+final class UpdatePaymentMethodSpec extends ObjectBehavior
+{
+    function let(): void
+    {
+        $this->beConstructedWith('ORDERTOKEN', 1, 'CASH_ON_DELIVERY_METHOD');
+    }
+
+    function it_has_order_token(): void
+    {
+        $this->orderToken()->shouldReturn('ORDERTOKEN');
+    }
+
+    function it_has_identifier_of_payment(): void
+    {
+        $this->paymentIdentifier()->shouldReturn(1);
+    }
+
+    function it_has_payment_method_defined(): void
+    {
+        $this->paymentMethod()->shouldReturn('CASH_ON_DELIVERY_METHOD');
+    }
+}

--- a/spec/Command/Order/UpdatePaymentMethodSpec.php
+++ b/spec/Command/Order/UpdatePaymentMethodSpec.php
@@ -20,11 +20,11 @@ final class UpdatePaymentMethodSpec extends ObjectBehavior
 
     function it_has_identifier_of_payment(): void
     {
-        $this->paymentIdentifier()->shouldReturn(1);
+        $this->paymentId()->shouldReturn(1);
     }
 
     function it_has_payment_method_defined(): void
     {
-        $this->paymentMethod()->shouldReturn('CASH_ON_DELIVERY_METHOD');
+        $this->paymentMethodCode()->shouldReturn('CASH_ON_DELIVERY_METHOD');
     }
 }

--- a/spec/Factory/Order/PlacedOrderViewFactorySpec.php
+++ b/spec/Factory/Order/PlacedOrderViewFactorySpec.php
@@ -11,6 +11,7 @@ use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\OrderItemInterface;
 use Sylius\Component\Core\OrderCheckoutStates;
+use Sylius\Component\Core\OrderPaymentStates;
 use Sylius\ShopApiPlugin\Factory\AddressBook\AddressViewFactoryInterface;
 use Sylius\ShopApiPlugin\Factory\Cart\AdjustmentViewFactoryInterface;
 use Sylius\ShopApiPlugin\Factory\Cart\CartItemViewFactoryInterface;
@@ -64,6 +65,7 @@ final class PlacedOrderViewFactorySpec extends ObjectBehavior
         $cart->getCurrencyCode()->willReturn('GBP');
         $cart->getCheckoutState()->willReturn(OrderCheckoutStates::STATE_COMPLETED);
         $cart->getCheckoutCompletedAt()->willReturn(new \DateTime('2019-02-15T15:00:00+00:00'));
+        $cart->getPaymentState()->willReturn(OrderPaymentStates::STATE_AWAITING_PAYMENT);
         $cart->getTokenValue()->willReturn('ORDER_TOKEN');
         $cart->getNumber()->willReturn('ORDER_NUMBER');
         $cart->getShippingTotal()->willReturn(500);
@@ -99,6 +101,7 @@ final class PlacedOrderViewFactorySpec extends ObjectBehavior
         $placedOrderView->locale = 'en_GB';
         $placedOrderView->checkoutState = OrderCheckoutStates::STATE_COMPLETED;
         $placedOrderView->checkoutCompletedAt = '2019-02-15T15:00:00+00:00';
+        $placedOrderView->paymentState = OrderPaymentStates::STATE_AWAITING_PAYMENT;
 
         $placedOrderView->items = [new ItemView()];
         $placedOrderView->totals = new TotalsView();

--- a/spec/Handler/Order/UpdatePaymentMethodHandlerSpec.php
+++ b/spec/Handler/Order/UpdatePaymentMethodHandlerSpec.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\Sylius\ShopApiPlugin\Handler\Order;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\PaymentInterface;
+use Sylius\Component\Core\Model\PaymentMethodInterface;
+use Sylius\Component\Core\OrderPaymentStates;
+use Sylius\Component\Core\Repository\OrderRepositoryInterface;
+use Sylius\Component\Core\Repository\PaymentMethodRepositoryInterface;
+use Sylius\ShopApiPlugin\Command\Order\UpdatePaymentMethod;
+
+final class UpdatePaymentMethodHandlerSpec extends ObjectBehavior
+{
+    function let(
+        OrderRepositoryInterface $orderRepository,
+        PaymentMethodRepositoryInterface $paymentMethodRepository
+    ): void {
+        $this->beConstructedWith($orderRepository, $paymentMethodRepository);
+    }
+
+    function it_assigns_chosen_payment_method_to_specified_payment(
+        OrderRepositoryInterface $orderRepository,
+        OrderInterface $order,
+        PaymentMethodRepositoryInterface $paymentMethodRepository,
+        PaymentMethodInterface $paymentMethod,
+        PaymentInterface $payment
+    ): void {
+        $orderRepository->findOneBy(['tokenValue' => 'ORDERTOKEN'])->willReturn($order);
+        $order->getState()->willReturn(OrderInterface::STATE_NEW);
+        $order->getPayments()->willReturn(new ArrayCollection([$payment->getWrappedObject()]));
+        $order->getPaymentState()->willReturn(OrderPaymentStates::STATE_AWAITING_PAYMENT);
+        $paymentMethodRepository->findOneBy(['code' => 'CASH_ON_DELIVERY_METHOD'])->willReturn($paymentMethod);
+        $payment->setMethod($paymentMethod)->shouldBeCalled();
+        $payment->getState()->willReturn(PaymentInterface::STATE_NEW);
+
+        $this(new UpdatePaymentMethod('ORDERTOKEN', 0, 'CASH_ON_DELIVERY_METHOD'));
+    }
+
+    function it_throws_an_exception_if_order_with_given_token_has_not_been_found(
+        OrderRepositoryInterface $orderRepository,
+        PaymentInterface $payment
+    ): void {
+        $orderRepository->findOneBy(['tokenValue' => 'ORDERTOKEN'])->willReturn(null);
+        $payment->setMethod(Argument::type(PaymentMethodInterface::class))->shouldNotBeCalled();
+
+        $this
+            ->shouldThrow(\InvalidArgumentException::class)
+            ->during('__invoke', [
+                new UpdatePaymentMethod('ORDERTOKEN', 0, 'CASH_ON_DELIVERY_METHOD'),
+            ])
+        ;
+    }
+
+    function it_throws_an_exception_if_order_is_cart(
+        OrderRepositoryInterface $orderRepository,
+        OrderInterface $order,
+        PaymentMethodRepositoryInterface $paymentMethodRepository,
+        PaymentInterface $payment
+    ): void {
+        $orderRepository->findOneBy(['tokenValue' => 'ORDERTOKEN'])->willReturn($order);
+        $order->getState()->willReturn(OrderInterface::STATE_CART);
+
+        $paymentMethodRepository->findOneBy(Argument::any())->shouldNotBeCalled();
+        $payment->setMethod(Argument::type(PaymentMethodInterface::class))->shouldNotBeCalled();
+
+        $this
+            ->shouldThrow(\InvalidArgumentException::class)
+            ->during('__invoke', [
+                new UpdatePaymentMethod('ORDERTOKEN', 0, 'CASH_ON_DELIVERY_METHOD'),
+            ])
+        ;
+    }
+
+    function it_throws_an_exception_if_order_cannot_have_payment_updated(
+        OrderRepositoryInterface $orderRepository,
+        OrderInterface $order,
+        PaymentMethodRepositoryInterface $paymentMethodRepository,
+        PaymentInterface $payment
+    ): void {
+        $orderRepository->findOneBy(['tokenValue' => 'ORDERTOKEN'])->willReturn($order);
+        $order->getState()->willReturn(OrderInterface::STATE_NEW);
+        $order->getPaymentState()->willReturn(OrderPaymentStates::STATE_PAID);
+
+        $paymentMethodRepository->findOneBy(Argument::any())->shouldNotBeCalled();
+        $payment->setMethod(Argument::type(PaymentMethodInterface::class))->shouldNotBeCalled();
+
+        $this
+            ->shouldThrow(\InvalidArgumentException::class)
+            ->during('__invoke', [
+                new UpdatePaymentMethod('ORDERTOKEN', 0, 'CASH_ON_DELIVERY_METHOD'),
+            ])
+        ;
+    }
+
+    function it_throws_an_exception_if_payment_method_with_given_code_has_not_been_found(
+        OrderRepositoryInterface $orderRepository,
+        OrderInterface $order,
+        PaymentMethodRepositoryInterface $paymentMethodRepository,
+        PaymentInterface $payment
+    ): void {
+        $orderRepository->findOneBy(['tokenValue' => 'ORDERTOKEN'])->willReturn($order);
+        $order->getState()->willReturn(OrderInterface::STATE_NEW);
+        $order->getPaymentState()->willReturn(OrderPaymentStates::STATE_AWAITING_PAYMENT);
+        $paymentMethodRepository->findOneBy(['code' => 'CASH_ON_DELIVERY_METHOD'])->willReturn(null);
+
+        $payment->setMethod(Argument::type(PaymentMethodInterface::class))->shouldNotBeCalled();
+
+        $this
+            ->shouldThrow(\InvalidArgumentException::class)
+            ->during('__invoke', [
+                new UpdatePaymentMethod('ORDERTOKEN', 0, 'CASH_ON_DELIVERY_METHOD'),
+            ])
+        ;
+    }
+
+    function it_throws_an_exception_if_ordered_payment_has_not_been_found(
+        OrderRepositoryInterface $orderRepository,
+        OrderInterface $order,
+        PaymentMethodRepositoryInterface $paymentMethodRepository,
+        PaymentMethodInterface $paymentMethod,
+        PaymentInterface $payment
+    ): void {
+        $orderRepository->findOneBy(['tokenValue' => 'ORDERTOKEN'])->willReturn($order);
+        $order->getState()->willReturn(OrderInterface::STATE_NEW);
+        $order->getPaymentState()->willReturn(OrderPaymentStates::STATE_AWAITING_PAYMENT);
+        $paymentMethodRepository->findOneBy(['code' => 'CASH_ON_DELIVERY_METHOD'])->willReturn($paymentMethod);
+        $order->getPayments()->willReturn(new ArrayCollection([]));
+
+        $payment->setMethod(Argument::type(PaymentMethodInterface::class))->shouldNotBeCalled();
+
+        $this
+            ->shouldThrow(\InvalidArgumentException::class)
+            ->during('__invoke', [
+                new UpdatePaymentMethod('ORDERTOKEN', 0, 'CASH_ON_DELIVERY_METHOD'),
+            ])
+        ;
+    }
+
+    function it_throws_an_exception_if_ordered_payment_is_not_new(
+        OrderRepositoryInterface $orderRepository,
+        OrderInterface $order,
+        PaymentMethodRepositoryInterface $paymentMethodRepository,
+        PaymentMethodInterface $paymentMethod,
+        PaymentInterface $payment
+    ): void {
+        $orderRepository->findOneBy(['tokenValue' => 'ORDERTOKEN'])->willReturn($order);
+        $order->getState()->willReturn(OrderInterface::STATE_NEW);
+        $order->getPaymentState()->willReturn(OrderPaymentStates::STATE_AWAITING_PAYMENT);
+        $paymentMethodRepository->findOneBy(['code' => 'CASH_ON_DELIVERY_METHOD'])->willReturn($paymentMethod);
+        $order->getPayments()->willReturn(new ArrayCollection([$payment->getWrappedObject()]));
+
+        $payment->getState()->willReturn(PaymentInterface::STATE_CART);
+        $payment->setMethod(Argument::type(PaymentMethodInterface::class))->shouldNotBeCalled();
+
+        $this
+            ->shouldThrow(\InvalidArgumentException::class)
+            ->during('__invoke', [
+                new UpdatePaymentMethod('ORDERTOKEN', 0, 'CASH_ON_DELIVERY_METHOD'),
+            ])
+        ;
+    }
+}

--- a/spec/Validator/Order/OrderExistsValidatorSpec.php
+++ b/spec/Validator/Order/OrderExistsValidatorSpec.php
@@ -50,7 +50,7 @@ class OrderExistsValidatorSpec extends ObjectBehavior
         ));
     }
 
-    function it_adds_constraint_if_order_does_not_exits_exists(
+    function it_adds_constraint_if_order_does_not_exists(
         OrderRepositoryInterface $orderRepository,
         ExecutionContextInterface $executionContext
     ): void {

--- a/spec/Validator/Order/OrderExistsValidatorSpec.php
+++ b/spec/Validator/Order/OrderExistsValidatorSpec.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\Sylius\ShopApiPlugin\Validator\Order;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Repository\OrderRepositoryInterface;
+use Sylius\ShopApiPlugin\Validator\Constraints\OrderExists;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+
+class OrderExistsValidatorSpec extends ObjectBehavior
+{
+    function let(ExecutionContextInterface $executionContext, OrderRepositoryInterface $orderRepository): void
+    {
+        $this->beConstructedWith($orderRepository);
+
+        $this->initialize($executionContext);
+    }
+
+    function it_does_not_add_constraint_if_order_exists(
+        OrderInterface $order,
+        OrderRepositoryInterface $orderRepository,
+        ExecutionContextInterface $executionContext
+    ): void {
+        $orderRepository->findOneBy(['tokenValue' => 'ORDERTOKEN', 'state' => OrderInterface::STATE_NEW])->willReturn($order);
+
+        $executionContext->addViolation(Argument::any())->shouldNotBeCalled();
+
+        $this->validate('ORDERTOKEN', new OrderExists(['state' => OrderInterface::STATE_NEW]));
+    }
+
+    function it_does_not_add_constraint_if_order_exists_multi_state(
+        OrderInterface $order,
+        OrderRepositoryInterface $orderRepository,
+        ExecutionContextInterface $executionContext
+    ): void {
+        $orderRepository->findOneBy(
+            [
+                'tokenValue' => 'ORDERTOKEN',
+                'state' => [OrderInterface::STATE_NEW, 'other_state'],
+            ])->willReturn($order);
+
+        $executionContext->addViolation(Argument::any())->shouldNotBeCalled();
+
+        $this->validate('ORDERTOKEN', new OrderExists(
+            ['state' => [OrderInterface::STATE_NEW, 'other_state']]
+        ));
+    }
+
+    function it_adds_constraint_if_order_does_not_exits_exists(
+        OrderRepositoryInterface $orderRepository,
+        ExecutionContextInterface $executionContext
+    ): void {
+        $orderRepository->findOneBy(['tokenValue' => 'ORDERTOKEN', 'state' => OrderInterface::STATE_NEW])->willReturn(null);
+
+        $executionContext->addViolation('sylius.shop_api.order.not_exists')->shouldBeCalled();
+
+        $this->validate('ORDERTOKEN', new OrderExists(['state' => OrderInterface::STATE_NEW]));
+    }
+}

--- a/src/Command/Order/UpdatePaymentMethod.php
+++ b/src/Command/Order/UpdatePaymentMethod.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\ShopApiPlugin\Command\Order;
+
+class UpdatePaymentMethod
+{
+    /** @var string */
+    protected $orderToken;
+
+    /** @var mixed */
+    protected $paymentIdentifier;
+
+    /** @var string */
+    protected $paymentMethod;
+
+    public function __construct(string $orderToken, $paymentIdentifier, string $paymentMethod)
+    {
+        $this->orderToken = $orderToken;
+        $this->paymentIdentifier = $paymentIdentifier;
+        $this->paymentMethod = $paymentMethod;
+    }
+
+    public function orderToken(): string
+    {
+        return $this->orderToken;
+    }
+
+    public function paymentIdentifier()
+    {
+        return $this->paymentIdentifier;
+    }
+
+    public function paymentMethod(): string
+    {
+        return $this->paymentMethod;
+    }
+}

--- a/src/Command/Order/UpdatePaymentMethod.php
+++ b/src/Command/Order/UpdatePaymentMethod.php
@@ -10,16 +10,16 @@ class UpdatePaymentMethod
     protected $orderToken;
 
     /** @var mixed */
-    protected $paymentIdentifier;
+    protected $paymentId;
 
     /** @var string */
-    protected $paymentMethod;
+    protected $paymentMethodCode;
 
-    public function __construct(string $orderToken, $paymentIdentifier, string $paymentMethod)
+    public function __construct(string $orderToken, $paymentId, string $paymentMethodCode)
     {
         $this->orderToken = $orderToken;
-        $this->paymentIdentifier = $paymentIdentifier;
-        $this->paymentMethod = $paymentMethod;
+        $this->paymentId = $paymentId;
+        $this->paymentMethodCode = $paymentMethodCode;
     }
 
     public function orderToken(): string
@@ -27,13 +27,13 @@ class UpdatePaymentMethod
         return $this->orderToken;
     }
 
-    public function paymentIdentifier()
+    public function paymentId()
     {
-        return $this->paymentIdentifier;
+        return $this->paymentId;
     }
 
-    public function paymentMethod(): string
+    public function paymentMethodCode(): string
     {
-        return $this->paymentMethod;
+        return $this->paymentMethodCode;
     }
 }

--- a/src/Command/Order/UpdatePaymentMethod.php
+++ b/src/Command/Order/UpdatePaymentMethod.php
@@ -28,6 +28,7 @@ class UpdatePaymentMethod
         return $this->orderToken;
     }
 
+    /** @return string|int */
     public function paymentId()
     {
         return $this->paymentId;

--- a/src/Command/Order/UpdatePaymentMethod.php
+++ b/src/Command/Order/UpdatePaymentMethod.php
@@ -15,6 +15,7 @@ class UpdatePaymentMethod
     /** @var string */
     protected $paymentMethodCode;
 
+    /** @param int|string $paymentId */
     public function __construct(string $orderToken, $paymentId, string $paymentMethodCode)
     {
         $this->orderToken = $orderToken;

--- a/src/Controller/Order/UpdatePaymentMethodAction.php
+++ b/src/Controller/Order/UpdatePaymentMethodAction.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\ShopApiPlugin\Controller\Order;
+
+use FOS\RestBundle\View\View;
+use FOS\RestBundle\View\ViewHandlerInterface;
+use Sylius\ShopApiPlugin\Factory\ValidationErrorViewFactoryInterface;
+use Sylius\ShopApiPlugin\Request\Order\UpdatePaymentMethodRequest;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+final class UpdatePaymentMethodAction
+{
+    /** @var ViewHandlerInterface */
+    private $viewHandler;
+
+    /** @var MessageBusInterface */
+    private $bus;
+
+    /** @var ValidatorInterface */
+    private $validator;
+
+    /** @var ValidationErrorViewFactoryInterface */
+    private $validationErrorViewFactory;
+
+    public function __construct(
+        ViewHandlerInterface $viewHandler,
+        MessageBusInterface $bus,
+        ValidatorInterface $validator,
+        ValidationErrorViewFactoryInterface $validationErrorViewFactory
+    ) {
+        $this->viewHandler = $viewHandler;
+        $this->bus = $bus;
+        $this->validator = $validator;
+        $this->validationErrorViewFactory = $validationErrorViewFactory;
+    }
+
+    public function __invoke(Request $request): Response
+    {
+        $updateRequest = new UpdatePaymentMethodRequest($request);
+
+        $validationResults = $this->validator->validate($updateRequest);
+        if (0 !== count($validationResults)) {
+            return $this->viewHandler->handle(
+                View::create($this->validationErrorViewFactory->create($validationResults),
+                    Response::HTTP_BAD_REQUEST
+                )
+            );
+        }
+
+        $this->bus->dispatch($updateRequest->getCommand());
+
+        return $this->viewHandler->handle(View::create(null, Response::HTTP_NO_CONTENT));
+    }
+}

--- a/src/Factory/Order/PlacedOrderViewFactory.php
+++ b/src/Factory/Order/PlacedOrderViewFactory.php
@@ -66,6 +66,7 @@ final class PlacedOrderViewFactory implements PlacedOrderViewFactoryInterface
         $placedOrderView->locale = $localeCode;
         $placedOrderView->checkoutState = $order->getCheckoutState();
         $placedOrderView->checkoutCompletedAt = $order->getCheckoutCompletedAt()->format('c');
+        $placedOrderView->paymentState = $order->getPaymentState();
         $placedOrderView->totals = $this->totalViewFactory->create($order);
         $placedOrderView->tokenValue = $order->getTokenValue();
         $placedOrderView->number = $order->getNumber();

--- a/src/Handler/Order/UpdatePaymentMethodHandler.php
+++ b/src/Handler/Order/UpdatePaymentMethodHandler.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\ShopApiPlugin\Handler\Order;
+
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\PaymentInterface;
+use Sylius\Component\Core\Model\PaymentMethodInterface;
+use Sylius\Component\Core\OrderPaymentStates;
+use Sylius\Component\Core\Repository\OrderRepositoryInterface;
+use Sylius\Component\Core\Repository\PaymentMethodRepositoryInterface;
+use Sylius\ShopApiPlugin\Command\Order\UpdatePaymentMethod;
+use Webmozart\Assert\Assert;
+
+final class UpdatePaymentMethodHandler
+{
+    /** @var OrderRepositoryInterface */
+    private $orderRepository;
+
+    /** @var PaymentMethodRepositoryInterface */
+    private $paymentMethodRepository;
+
+    public function __construct(
+        OrderRepositoryInterface $orderRepository,
+        PaymentMethodRepositoryInterface $paymentMethodRepository
+    ) {
+        $this->orderRepository = $orderRepository;
+        $this->paymentMethodRepository = $paymentMethodRepository;
+    }
+
+    public function __invoke(UpdatePaymentMethod $choosePaymentMethod): void
+    {
+        /** @var OrderInterface $order */
+        $order = $this->orderRepository->findOneBy(['tokenValue' => $choosePaymentMethod->orderToken()]);
+
+        Assert::notNull($order, 'Order has not been found.');
+        Assert::notSame(OrderInterface::STATE_CART, $order->getState(), 'Only orders can be updated.');
+        Assert::same(OrderPaymentStates::STATE_AWAITING_PAYMENT, $order->getPaymentState(), 'Only awaiting payment orders can be updated.');
+
+        /** @var PaymentMethodInterface $paymentMethod */
+        $paymentMethod = $this->paymentMethodRepository->findOneBy(['code' => $choosePaymentMethod->paymentMethod()]);
+
+        Assert::notNull($paymentMethod, 'Payment method has not been found');
+        Assert::true(isset($order->getPayments()[$choosePaymentMethod->paymentIdentifier()]), 'Can not find payment with given identifier.');
+
+        $payment = $order->getPayments()[$choosePaymentMethod->paymentIdentifier()];
+        Assert::same(PaymentInterface::STATE_NEW, $payment->getState(), 'Payment should have new state');
+
+        $payment->setMethod($paymentMethod);
+    }
+}

--- a/src/Handler/Order/UpdatePaymentMethodHandler.php
+++ b/src/Handler/Order/UpdatePaymentMethodHandler.php
@@ -39,12 +39,12 @@ final class UpdatePaymentMethodHandler
         Assert::same(OrderPaymentStates::STATE_AWAITING_PAYMENT, $order->getPaymentState(), 'Only awaiting payment orders can be updated.');
 
         /** @var PaymentMethodInterface $paymentMethod */
-        $paymentMethod = $this->paymentMethodRepository->findOneBy(['code' => $choosePaymentMethod->paymentMethod()]);
+        $paymentMethod = $this->paymentMethodRepository->findOneBy(['code' => $choosePaymentMethod->paymentMethodCode()]);
 
         Assert::notNull($paymentMethod, 'Payment method has not been found');
-        Assert::true(isset($order->getPayments()[$choosePaymentMethod->paymentIdentifier()]), 'Can not find payment with given identifier.');
+        Assert::true(isset($order->getPayments()[$choosePaymentMethod->paymentId()]), 'Can not find payment with given identifier.');
 
-        $payment = $order->getPayments()[$choosePaymentMethod->paymentIdentifier()];
+        $payment = $order->getPayments()[$choosePaymentMethod->paymentId()];
         Assert::same(PaymentInterface::STATE_NEW, $payment->getState(), 'Payment should have new state');
 
         $payment->setMethod($paymentMethod);

--- a/src/Request/Order/UpdatePaymentMethodRequest.php
+++ b/src/Request/Order/UpdatePaymentMethodRequest.php
@@ -35,6 +35,7 @@ class UpdatePaymentMethodRequest
         return $this->token;
     }
 
+    /** @return int|string */
     public function getPaymentId()
     {
         return $this->paymentIdentifier;

--- a/src/Request/Order/UpdatePaymentMethodRequest.php
+++ b/src/Request/Order/UpdatePaymentMethodRequest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\ShopApiPlugin\Request\Order;
+
+use Sylius\ShopApiPlugin\Command\Order\UpdatePaymentMethod;
+use Symfony\Component\HttpFoundation\Request;
+
+class UpdatePaymentMethodRequest
+{
+    /** @var string */
+    protected $token;
+
+    /** @var mixed */
+    protected $paymentIdentifier;
+
+    /** @var string */
+    protected $paymentMethod;
+
+    public function __construct(Request $request)
+    {
+        $this->token = $request->attributes->get('token');
+        $this->paymentIdentifier = $request->attributes->get('paymentId');
+        $this->paymentMethod = $request->request->get('method');
+    }
+
+    public function getCommand(): UpdatePaymentMethod
+    {
+        return new UpdatePaymentMethod($this->token, $this->paymentIdentifier, $this->paymentMethod);
+    }
+}

--- a/src/Request/Order/UpdatePaymentMethodRequest.php
+++ b/src/Request/Order/UpdatePaymentMethodRequest.php
@@ -30,7 +30,7 @@ class UpdatePaymentMethodRequest
         return new UpdatePaymentMethod($this->token, $this->paymentIdentifier, $this->paymentMethod);
     }
 
-    public function getOrderToken() : string
+    public function getOrderToken(): string
     {
         return $this->token;
     }

--- a/src/Request/Order/UpdatePaymentMethodRequest.php
+++ b/src/Request/Order/UpdatePaymentMethodRequest.php
@@ -29,4 +29,14 @@ class UpdatePaymentMethodRequest
     {
         return new UpdatePaymentMethod($this->token, $this->paymentIdentifier, $this->paymentMethod);
     }
+
+    public function getOrderToken() : string
+    {
+        return $this->token;
+    }
+
+    public function getPaymentId()
+    {
+        return $this->paymentIdentifier;
+    }
 }

--- a/src/Resources/config/routing/order.yml
+++ b/src/Resources/config/routing/order.yml
@@ -9,3 +9,15 @@ sylius_shop_api_order_details:
     methods: [GET]
     defaults:
         _controller: sylius.shop_api_plugin.controller.order.show_order_details_action
+
+sylius_shop_api_order_available_payment_methods:
+    path: /orders/{token}/payment
+    methods: [GET]
+    defaults:
+        _controller: sylius.shop_api_plugin.controller.checkout.show_available_payment_methods_action
+
+sylius_shop_api_order_update_payment_method:
+    path: /orders/{token}/payment/{paymentId}
+    methods: [PUT]
+    defaults:
+        _controller: sylius.shop_api_plugin.controller.order.update_payment_method_action

--- a/src/Resources/config/services/actions/order.xml
+++ b/src/Resources/config/services/actions/order.xml
@@ -19,5 +19,14 @@
             <argument type="service" id="sylius.shop_api_plugin.provider.current_user_provider" />
             <argument type="service" id="sylius.shop_api_plugin.view_repository.placed_order_view_repository" />
         </service>
+
+        <service id="sylius.shop_api_plugin.controller.order.update_payment_method_action"
+                 class="Sylius\ShopApiPlugin\Controller\Order\UpdatePaymentMethodAction"
+        >
+            <argument type="service" id="fos_rest.view_handler" />
+            <argument type="service" id="sylius_shop_api_plugin.command_bus" />
+            <argument type="service" id="validator" />
+            <argument type="service" id="sylius.shop_api_plugin.factory.validation_error_view_factory" />
+        </service>
     </services>
 </container>

--- a/src/Resources/config/services/handler/order.xml
+++ b/src/Resources/config/services/handler/order.xml
@@ -1,0 +1,13 @@
+<container xmlns="http://symfony.com/schema/dic/services">
+    <services>
+        <defaults public="true"/>
+
+        <service id="sylius.shop_api_plugin.handler.update_payment_method_handler"
+                 class="Sylius\ShopApiPlugin\Handler\Order\UpdatePaymentMethodHandler"
+        >
+            <argument type="service" id="sylius.repository.order"/>
+            <argument type="service" id="sylius.repository.payment_method"/>
+            <tag name="messenger.message_handler" />
+        </service>
+    </services>
+</container>

--- a/src/Resources/config/services/validators/order.xml
+++ b/src/Resources/config/services/validators/order.xml
@@ -7,5 +7,11 @@
             <argument type="service" id="sylius.repository.order" />
             <tag name="validator.constraint_validator" alias="sylius_shop_api_order_exists_validator" />
         </service>
+
+        <service id="sylius.shop_api_plugin.validator.payment_not_paid_validator"
+                 class="Sylius\ShopApiPlugin\Validator\Order\PaymentNotPaidValidator">
+            <argument type="service" id="sylius.repository.order" />
+            <tag name="validator.constraint_validator" alias="sylius_shop_api_payment_not_paid_validator" />
+        </service>
     </services>
 </container>

--- a/src/Resources/config/services/validators/order.xml
+++ b/src/Resources/config/services/validators/order.xml
@@ -1,0 +1,11 @@
+<container xmlns="http://symfony.com/schema/dic/services">
+    <services>
+        <defaults public="true" />
+
+        <service id="sylius.shop_api_plugin.validator.order_exists_validator"
+                 class="Sylius\ShopApiPlugin\Validator\Order\OrderExistsValidator">
+            <argument type="service" id="sylius.repository.order" />
+            <tag name="validator.constraint_validator" alias="sylius_shop_api_order_exists_validator" />
+        </service>
+    </services>
+</container>

--- a/src/Resources/config/validation/order/UpdatePaymentMethodRequest.xml
+++ b/src/Resources/config/validation/order/UpdatePaymentMethodRequest.xml
@@ -21,5 +21,7 @@
                 <option name="state">new</option>
             </constraint>
         </property>
+    
+        <constraint name="Sylius\ShopApiPlugin\Validator\Constraints\PaymentNotPaid" />
     </class>
 </constraint-mapping>

--- a/src/Resources/config/validation/order/UpdatePaymentMethodRequest.xml
+++ b/src/Resources/config/validation/order/UpdatePaymentMethodRequest.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+
+ This file is part of the Sylius package.
+
+ (c) Paweł Jędrzejewski
+
+ For the full copyright and license information, please view the LICENSE
+ file that was distributed with this source code.
+
+-->
+
+<constraint-mapping xmlns="http://symfony.com/schema/dic/constraint-mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/constraint-mapping http://symfony.com/schema/dic/services/constraint-mapping-1.0.xsd">
+    <class name="Sylius\ShopApiPlugin\Request\Order\UpdatePaymentMethodRequest">
+        <property name="token">
+            <constraint name="NotNull">
+                <option name="message">sylius.shop_api.token.not_null</option>
+            </constraint>
+            <constraint name="Sylius\ShopApiPlugin\Validator\Constraints\OrderExists">
+                <option name="state">new</option>
+            </constraint>
+        </property>
+    </class>
+</constraint-mapping>

--- a/src/Validator/Constraints/OrderExists.php
+++ b/src/Validator/Constraints/OrderExists.php
@@ -13,7 +13,7 @@ final class OrderExists extends Constraint
     /** @var string */
     public $message = 'sylius.shop_api.order.not_exists';
 
-    /** @var string|array<string> */
+    /** @var array|string[] */
     public $state = [OrderInterface::STATE_NEW, OrderInterface::STATE_FULFILLED, OrderInterface::STATE_CANCELLED];
 
     public function validatedBy(): string

--- a/src/Validator/Constraints/OrderExists.php
+++ b/src/Validator/Constraints/OrderExists.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\ShopApiPlugin\Validator\Constraints;
+
+use Sylius\Component\Order\Model\OrderInterface;
+use Sylius\ShopApiPlugin\Validator\Order\OrderExistsValidator;
+use Symfony\Component\Validator\Constraint;
+
+final class OrderExists extends Constraint
+{
+    /** @var string */
+    public $message = 'sylius.shop_api.order.not_exists';
+
+    /** @var string|array<string> */
+    public $state = [OrderInterface::STATE_NEW, OrderInterface::STATE_FULFILLED, OrderInterface::STATE_CANCELLED];
+
+    public function validatedBy(): string
+    {
+        return OrderExistsValidator::class;
+    }
+}

--- a/src/Validator/Constraints/PaymentNotPaid.php
+++ b/src/Validator/Constraints/PaymentNotPaid.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\ShopApiPlugin\Validator\Constraints;
+
+use Sylius\Component\Order\Model\OrderInterface;
+use Sylius\ShopApiPlugin\Validator\Order\PaymentNotPaidValidator;
+use Symfony\Component\Validator\Constraint;
+
+final class PaymentNotPaid extends Constraint
+{
+    /** @var string */
+    public $message = 'sylius.shop_api.payment.paid';
+
+    /** {@inheritdoc} */
+    public function getTargets()
+    {
+        return self::CLASS_CONSTRAINT;
+    }
+
+    public function validatedBy(): string
+    {
+        return PaymentNotPaidValidator::class;
+    }
+}

--- a/src/Validator/Constraints/PaymentNotPaid.php
+++ b/src/Validator/Constraints/PaymentNotPaid.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Validator\Constraints;
 
-use Sylius\Component\Order\Model\OrderInterface;
 use Sylius\ShopApiPlugin\Validator\Order\PaymentNotPaidValidator;
 use Symfony\Component\Validator\Constraint;
 

--- a/src/Validator/Order/OrderExistsValidator.php
+++ b/src/Validator/Order/OrderExistsValidator.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Sylius\ShopApiPlugin\Validator\Order;
 
 use Sylius\Component\Core\Repository\OrderRepositoryInterface;
+use Sylius\ShopApiPlugin\Validator\Constraints\OrderExists;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
+use Webmozart\Assert\Assert;
 
 final class OrderExistsValidator extends ConstraintValidator
 {
@@ -20,7 +22,8 @@ final class OrderExistsValidator extends ConstraintValidator
 
     public function validate($token, Constraint $constraint): void
     {
-        /** @var Sylius\ShopApiPlugin\Validator\Constraints\OrderExists $constraint */
+        Assert::isInstanceOf($constraint, OrderExists::class);
+
         if (null === $this->orderRepository->findOneBy(['tokenValue' => $token, 'state' => $constraint->state])) {
             $this->context->addViolation($constraint->message);
         }

--- a/src/Validator/Order/OrderExistsValidator.php
+++ b/src/Validator/Order/OrderExistsValidator.php
@@ -5,10 +5,8 @@ declare(strict_types=1);
 namespace Sylius\ShopApiPlugin\Validator\Order;
 
 use Sylius\Component\Core\Repository\OrderRepositoryInterface;
-use Sylius\ShopApiPlugin\Validator\Constraints\OrderExists;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
-use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 
 final class OrderExistsValidator extends ConstraintValidator
 {
@@ -22,10 +20,6 @@ final class OrderExistsValidator extends ConstraintValidator
 
     public function validate($token, Constraint $constraint): void
     {
-        if (!$constraint instanceof OrderExists) {
-            throw new UnexpectedTypeException($constraint, OrderExists::class);
-        }
-
         if (null === $this->orderRepository->findOneBy(['tokenValue' => $token, 'state' => $constraint->state])) {
             $this->context->addViolation($constraint->message);
         }

--- a/src/Validator/Order/OrderExistsValidator.php
+++ b/src/Validator/Order/OrderExistsValidator.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\ShopApiPlugin\Validator\Order;
+
+use Sylius\Component\Core\Repository\OrderRepositoryInterface;
+use Sylius\ShopApiPlugin\Validator\Constraints\OrderExists;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+
+final class OrderExistsValidator extends ConstraintValidator
+{
+    /** @var OrderRepositoryInterface */
+    private $orderRepository;
+
+    public function __construct(OrderRepositoryInterface $orderRepository)
+    {
+        $this->orderRepository = $orderRepository;
+    }
+
+    public function validate($token, Constraint $constraint): void
+    {
+        if (!$constraint instanceof OrderExists) {
+            throw new UnexpectedTypeException($constraint, OrderExists::class);
+        }
+
+        if (null === $this->orderRepository->findOneBy(['tokenValue' => $token, 'state' => $constraint->state])) {
+            $this->context->addViolation($constraint->message);
+        }
+    }
+}

--- a/src/Validator/Order/OrderExistsValidator.php
+++ b/src/Validator/Order/OrderExistsValidator.php
@@ -20,8 +20,8 @@ final class OrderExistsValidator extends ConstraintValidator
 
     public function validate($token, Constraint $constraint): void
     {
+        /** @var Sylius\ShopApiPlugin\Validator\Constraints\OrderExists $constraint */
         if (null === $this->orderRepository->findOneBy(['tokenValue' => $token, 'state' => $constraint->state])) {
-            /** @var Sylius\ShopApiPlugin\Validator\Constraints\OrderExists $constraint */
             $this->context->addViolation($constraint->message);
         }
     }

--- a/src/Validator/Order/OrderExistsValidator.php
+++ b/src/Validator/Order/OrderExistsValidator.php
@@ -21,6 +21,7 @@ final class OrderExistsValidator extends ConstraintValidator
     public function validate($token, Constraint $constraint): void
     {
         if (null === $this->orderRepository->findOneBy(['tokenValue' => $token, 'state' => $constraint->state])) {
+            /** @var Sylius\ShopApiPlugin\Validator\Constraints\OrderExists $constraint */
             $this->context->addViolation($constraint->message);
         }
     }

--- a/src/Validator/Order/PaymentNotPaidValidator.php
+++ b/src/Validator/Order/PaymentNotPaidValidator.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Validator\Order;
 
-use Sylius\Component\Core\Repository\OrderRepositoryInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\PaymentInterface;
+use Sylius\Component\Core\Repository\OrderRepositoryInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 
@@ -24,7 +24,7 @@ final class PaymentNotPaidValidator extends ConstraintValidator
     {
         /** @var OrderInterface|null $order */
         $order = $this->orderRepository->findOneBy(['tokenValue' => $updatePayment->getOrderToken()]);
-        if($order === null) {
+        if ($order === null) {
             return;
         }
 
@@ -33,9 +33,7 @@ final class PaymentNotPaidValidator extends ConstraintValidator
             return;
         }
 
-
-        if (!in_array($payment->getState(), [PaymentInterface::STATE_NEW, PaymentInterface::STATE_CANCELLED]))
-        {
+        if (!in_array($payment->getState(), [PaymentInterface::STATE_NEW, PaymentInterface::STATE_CANCELLED])) {
             $this->context->addViolation($constraint->message);
         }
     }

--- a/src/Validator/Order/PaymentNotPaidValidator.php
+++ b/src/Validator/Order/PaymentNotPaidValidator.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\ShopApiPlugin\Validator\Order;
+
+use Sylius\Component\Core\Repository\OrderRepositoryInterface;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\PaymentInterface;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+final class PaymentNotPaidValidator extends ConstraintValidator
+{
+    /** @var OrderRepositoryInterface */
+    private $orderRepository;
+
+    public function __construct(OrderRepositoryInterface $orderRepository)
+    {
+        $this->orderRepository = $orderRepository;
+    }
+
+    public function validate($updatePayment, Constraint $constraint): void
+    {
+        /** @var OrderInterface|null $order */
+        $order = $this->orderRepository->findOneBy(['tokenValue' => $updatePayment->getOrderToken()]);
+        if($order === null) {
+            return;
+        }
+
+        $payment = $order->getPayments()[$updatePayment->getPaymentId()] ?? null;
+        if ($payment === null) {
+            return;
+        }
+
+
+        if (!in_array($payment->getState(), [PaymentInterface::STATE_NEW, PaymentInterface::STATE_CANCELLED]))
+        {
+            $this->context->addViolation($constraint->message);
+        }
+    }
+}

--- a/src/View/Order/PlacedOrderView.php
+++ b/src/View/Order/PlacedOrderView.php
@@ -28,6 +28,9 @@ class PlacedOrderView
     /** @var string */
     public $checkoutCompletedAt;
 
+    /** @var string */
+    public $paymentState;
+
     /** @var array|ItemView[] */
     public $items = [];
 

--- a/tests/Controller/Order/OrderUpdatePaymentMethodApiTest.php
+++ b/tests/Controller/Order/OrderUpdatePaymentMethodApiTest.php
@@ -6,19 +6,26 @@ namespace Tests\Sylius\ShopApiPlugin\Controller\Order;
 
 use Symfony\Component\HttpFoundation\Response;
 use Tests\Sylius\ShopApiPlugin\Controller\JsonApiTestCase;
+use Tests\Sylius\ShopApiPlugin\Controller\Utils\OrderPlacerTrait;
 use Tests\Sylius\ShopApiPlugin\Controller\Utils\ShopUserLoginTrait;
 
 final class OrderUpdatePaymentMethodApiTest extends JsonApiTestCase
 {
     use ShopUserLoginTrait;
+    use OrderPlacerTrait;
 
     /**
      * @test
      */
     public function it_allows_to_update_payment_method(): void
     {
-        $fixtures = $this->loadFixturesFromFiles(['customer.yml', 'country.yml', 'address.yml', 'shop.yml', 'payment.yml', 'shipping.yml', 'order.yml']);
-        $this->logInUser('oliver@queen.com', '123password');
+        $this->loadFixturesFromFiles(['customer.yml', 'country.yml', 'address.yml', 'shop.yml', 'payment.yml', 'shipping.yml']);
+        $token = 'ORDERTOKENPLACED';
+        $email = 'oliver@queen.com';
+
+        $this->logInUser($email, '123password');
+
+        $this->placeOrderForCustomerWithEmail($email, $token);
 
         $data =
 <<<EOT
@@ -27,7 +34,7 @@ final class OrderUpdatePaymentMethodApiTest extends JsonApiTestCase
         }
 EOT;
 
-        $this->client->request('PUT', $this->getPaymentUrl('ORDERTOKENPLACED2') . '/0', [], [], self::CONTENT_TYPE_HEADER, $data);
+        $this->client->request('PUT', $this->getPaymentUrl('ORDERTOKENPLACED') . '/0', [], [], self::CONTENT_TYPE_HEADER, $data);
 
         $response = $this->client->getResponse();
         $this->assertResponseCode($response, Response::HTTP_NO_CONTENT);
@@ -38,8 +45,13 @@ EOT;
      */
     public function it_does_not_allow_to_update_payment_method_on_paid_order(): void
     {
-        $fixtures = $this->loadFixturesFromFiles(['customer.yml', 'country.yml', 'address.yml', 'shop.yml', 'payment.yml', 'shipping.yml', 'order.yml']);
-        $this->logInUser('oliver@queen.com', '123password');
+        $this->loadFixturesFromFiles(['customer.yml', 'country.yml', 'address.yml', 'shop.yml', 'payment.yml', 'shipping.yml']);
+        $token = 'ORDERTOKENPAID';
+        $email = 'oliver@queen.com';
+
+        $this->logInUser($email, '123password');
+
+        $this->placeOrderForCustomerWithEmail($email, $token);
 
         $data =
 <<<EOT

--- a/tests/Controller/Order/OrderUpdatePaymentMethodApiTest.php
+++ b/tests/Controller/Order/OrderUpdatePaymentMethodApiTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Sylius\ShopApiPlugin\Controller\Order;
+
+use Symfony\Component\HttpFoundation\Response;
+use Tests\Sylius\ShopApiPlugin\Controller\JsonApiTestCase;
+use Tests\Sylius\ShopApiPlugin\Controller\Utils\ShopUserLoginTrait;
+
+final class OrderUpdatePaymentMethodApiTest extends JsonApiTestCase
+{
+    use ShopUserLoginTrait;
+
+    /**
+     * @test
+     */
+    public function it_allows_to_update_payment_method(): void
+    {
+        $fixtures = $this->loadFixturesFromFiles(['customer.yml', 'country.yml', 'address.yml', 'shop.yml', 'payment.yml', 'shipping.yml', 'order.yml']);
+        $this->logInUser('oliver@queen.com', '123password');
+
+        $data =
+<<<EOT
+        {
+            "method": "PBC"
+        }
+EOT;
+
+        $this->client->request('PUT', $this->getPaymentUrl('ORDERTOKENPLACED2') . '/0', [], [], self::CONTENT_TYPE_HEADER, $data);
+
+        $response = $this->client->getResponse();
+        $this->assertResponseCode($response, Response::HTTP_NO_CONTENT);
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_allow_to_update_payment_method_on_paid_order(): void
+    {
+        $fixtures = $this->loadFixturesFromFiles(['customer.yml', 'country.yml', 'address.yml', 'shop.yml', 'payment.yml', 'shipping.yml', 'order.yml']);
+        $this->logInUser('oliver@queen.com', '123password');
+
+        $data =
+<<<EOT
+        {
+            "method": "PBC"
+        }
+EOT;
+
+        $this->client->request('PUT', $this->getPaymentUrl('ORDERTOKENPAID') . '/0', [], [], self::CONTENT_TYPE_HEADER, $data);
+
+        $response = $this->client->getResponse();
+        $this->assertResponseCode($response, Response::HTTP_BAD_REQUEST);
+    }
+
+    private function getPaymentUrl(string $token): string
+    {
+        return sprintf('/shop-api/WEB_GB/orders/%s/payment', $token);
+    }
+}

--- a/tests/Controller/Order/OrderUpdatePaymentMethodApiTest.php
+++ b/tests/Controller/Order/OrderUpdatePaymentMethodApiTest.php
@@ -70,10 +70,11 @@ EOT;
         $this->assertResponseCode($response, Response::HTTP_BAD_REQUEST);
     }
 
-    private function markOrderAsPayed() {
+    private function markOrderAsPayed()
+    {
         /** @var OrderInterface $order */
         $order = $this->get('sylius.repository.order')->findAll()[0];
-        foreach($order->getPayments() as $payment) {
+        foreach ($order->getPayments() as $payment) {
             $payment->setState(PaymentInterface::STATE_COMPLETED);
         }
         $order->setPaymentState(OrderPaymentStates::STATE_PAID);

--- a/tests/Responses/Expected/order/order_details_response.json
+++ b/tests/Responses/Expected/order/order_details_response.json
@@ -4,6 +4,7 @@
     "locale": "en_GB",
     "checkoutState": "completed",
     "checkoutCompletedAt": "@string@.isDateTime()",
+    "paymentState": "awaiting_payment",
     "items": [
         {
             "id": @integer@,

--- a/tests/Responses/Expected/order/order_details_response_guest.json
+++ b/tests/Responses/Expected/order/order_details_response_guest.json
@@ -4,6 +4,7 @@
     "locale": "en_GB",
     "checkoutState": "completed",
     "checkoutCompletedAt": "@string@.isDateTime()",
+    "paymentState": "awaiting_payment",
     "items": [
         {
             "id": @integer@,

--- a/tests/Responses/Expected/order/orders_list_response.json
+++ b/tests/Responses/Expected/order/orders_list_response.json
@@ -5,6 +5,7 @@
         "locale": "en_GB",
         "checkoutState": "completed",
         "checkoutCompletedAt": "@string@.isDateTime()",
+        "paymentState": "awaiting_payment",
         "items": [
             {
                 "id": @integer@,


### PR DESCRIPTION
Hi,

We have implemented two new actions to handle payment state on placed orders:

1. Get available payment methods: Same as /{channelCode}/checkout/{token}/payment but on order endpoint.
2. Update payment method on unpaid placed orders to implement the same behavior as in ShopBundle to allow a customer to change the payment method while order is unpaid.

1 is just reusing the same action from checkout, not sure if I should reimplement this as a different action.
2 adds validation as I've seen on other controllers, is this the preferred approach?

Tests are failing, there's something weird I couldn't figure out on loading the fixtures. I bet I'm doing something wrong. Am I missing something obvious there?

I've also added a new field to placedorder view: paymentState.

David.