### PR TITLE
[Maintanance] Remove redundant specs

### DIFF
--- a/spec/Command/Cart/AddCouponSpec.php
+++ b/spec/Command/Cart/AddCouponSpec.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace spec\Sylius\ShopApiPlugin\Command\Cart;
 
 use PhpSpec\ObjectBehavior;
-use TypeError;
 
 final class AddCouponSpec extends ObjectBehavior
 {
@@ -22,19 +21,5 @@ final class AddCouponSpec extends ObjectBehavior
     public function it_has_coupon_code(): void
     {
         $this->couponCode()->shouldReturn('COUPON_CODE');
-    }
-
-    public function it_throws_an_exception_if_order_token_is_not_a_string(): void
-    {
-        $this->beConstructedWith(new \stdClass(), 'COUPON_CODE');
-
-        $this->shouldThrow(TypeError::class)->duringInstantiation();
-    }
-
-    public function it_throws_an_exception_if_coupon_code_is_not_a_string(): void
-    {
-        $this->beConstructedWith('ORDERTOKEN', new \stdClass());
-
-        $this->shouldThrow(TypeError::class)->duringInstantiation();
     }
 }

--- a/spec/Command/Cart/AddressOrderSpec.php
+++ b/spec/Command/Cart/AddressOrderSpec.php
@@ -6,7 +6,6 @@ namespace spec\Sylius\ShopApiPlugin\Command\Cart;
 
 use PhpSpec\ObjectBehavior;
 use Sylius\ShopApiPlugin\Model\Address;
-use TypeError;
 
 final class AddressOrderSpec extends ObjectBehavior
 {
@@ -64,32 +63,5 @@ final class AddressOrderSpec extends ObjectBehavior
             'postcode' => 'NWB',
             'provinceName' => 'Greater London',
         ]));
-    }
-
-    function it_throws_an_exception_if_order_token_is_not_a_string(): void
-    {
-        $this->beConstructedWith(
-            new \stdClass(),
-            Address::createFromArray([
-                'firstName' => 'Sherlock',
-                'lastName' => 'Holmes',
-                'city' => 'London',
-                'street' => 'Baker Street 221b',
-                'countryCode' => 'GB',
-                'postcode' => 'NWB',
-                'provinceName' => 'Greater London',
-            ]),
-            Address::createFromArray([
-                'firstName' => 'John',
-                'lastName' => 'Watson',
-                'city' => 'London',
-                'street' => 'Baker Street 221b',
-                'countryCode' => 'GB',
-                'postcode' => 'NWB',
-                'provinceName' => 'Greater London',
-            ])
-        );
-
-        $this->shouldThrow(TypeError::class)->duringInstantiation();
     }
 }

--- a/spec/Command/Cart/ChangeItemQuantitySpec.php
+++ b/spec/Command/Cart/ChangeItemQuantitySpec.php
@@ -6,7 +6,6 @@ namespace spec\Sylius\ShopApiPlugin\Command\Cart;
 
 use InvalidArgumentException;
 use PhpSpec\ObjectBehavior;
-use TypeError;
 
 final class ChangeItemQuantitySpec extends ObjectBehavior
 {
@@ -28,13 +27,6 @@ final class ChangeItemQuantitySpec extends ObjectBehavior
     function it_has_quantity(): void
     {
         $this->quantity()->shouldReturn(5);
-    }
-
-    function it_throws_an_exception_if_order_token_is_not_a_string(): void
-    {
-        $this->beConstructedWith(new \stdClass(), 'T_SHIRT_CODE', 1);
-
-        $this->shouldThrow(TypeError::class)->duringInstantiation();
     }
 
     function it_throws_an_exception_if_quantity_is_not_less_then_1(): void

--- a/spec/Command/Cart/ChoosePaymentMethodSpec.php
+++ b/spec/Command/Cart/ChoosePaymentMethodSpec.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace spec\Sylius\ShopApiPlugin\Command\Cart;
 
 use PhpSpec\ObjectBehavior;
-use TypeError;
 
 final class ChoosePaymentMethodSpec extends ObjectBehavior
 {
@@ -27,19 +26,5 @@ final class ChoosePaymentMethodSpec extends ObjectBehavior
     function it_has_payment_method_defined(): void
     {
         $this->paymentMethod()->shouldReturn('CASH_ON_DELIVERY_METHOD');
-    }
-
-    function it_throws_an_exception_if_order_token_is_not_a_string(): void
-    {
-        $this->beConstructedWith(new \stdClass(), 1, 'COD_METHOD');
-
-        $this->shouldThrow(TypeError::class)->duringInstantiation();
-    }
-
-    function it_throws_an_exception_if_payment_method_code_is_not_a_string(): void
-    {
-        $this->beConstructedWith('ORDERTOKEN', 1, new \stdClass());
-
-        $this->shouldThrow(TypeError::class)->duringInstantiation();
     }
 }

--- a/spec/Command/Cart/ChooseShippingMethodSpec.php
+++ b/spec/Command/Cart/ChooseShippingMethodSpec.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace spec\Sylius\ShopApiPlugin\Command\Cart;
 
 use PhpSpec\ObjectBehavior;
-use TypeError;
 
 final class ChooseShippingMethodSpec extends ObjectBehavior
 {
@@ -27,19 +26,5 @@ final class ChooseShippingMethodSpec extends ObjectBehavior
     function it_has_shipping_method_defined(): void
     {
         $this->shippingMethod()->shouldReturn('DHL_SHIPPING_METHOD');
-    }
-
-    function it_throws_an_exception_if_order_token_is_not_a_string(): void
-    {
-        $this->beConstructedWith(new \stdClass(), 1, 'DHL_METHOD');
-
-        $this->shouldThrow(TypeError::class)->duringInstantiation();
-    }
-
-    function it_throws_an_exception_if_shipping_method_code_is_not_a_string(): void
-    {
-        $this->beConstructedWith('ORDERTOKEN', 1, new \stdClass());
-
-        $this->shouldThrow(TypeError::class)->duringInstantiation();
     }
 }

--- a/spec/Command/Cart/CompleteOrderSpec.php
+++ b/spec/Command/Cart/CompleteOrderSpec.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace spec\Sylius\ShopApiPlugin\Command\Cart;
 
 use PhpSpec\ObjectBehavior;
-use TypeError;
 
 final class CompleteOrderSpec extends ObjectBehavior
 {
@@ -29,26 +28,5 @@ final class CompleteOrderSpec extends ObjectBehavior
         $this->beConstructedWith('ORDERTOKEN', 'example@customer.com', 'Some order notes');
 
         $this->notes()->shouldReturn('Some order notes');
-    }
-
-    function it_throws_an_exception_if_notes_are_not_a_string(): void
-    {
-        $this->beConstructedWith('ORDERTOKEN', 'example@customer.com', new \stdClass());
-
-        $this->shouldThrow(TypeError::class)->duringInstantiation();
-    }
-
-    function it_throws_an_exception_if_order_token_is_not_a_string(): void
-    {
-        $this->beConstructedWith(new \stdClass(), 'example@customer.com');
-
-        $this->shouldThrow(TypeError::class)->duringInstantiation();
-    }
-
-    function it_throws_an_exception_if_email_is_not_a_string(): void
-    {
-        $this->beConstructedWith('ORDERTOKEN', new \stdClass());
-
-        $this->shouldThrow(TypeError::class)->duringInstantiation();
     }
 }

--- a/spec/Command/Cart/DropCartSpec.php
+++ b/spec/Command/Cart/DropCartSpec.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace spec\Sylius\ShopApiPlugin\Command\Cart;
 
 use PhpSpec\ObjectBehavior;
-use TypeError;
 
 final class DropCartSpec extends ObjectBehavior
 {
@@ -17,12 +16,5 @@ final class DropCartSpec extends ObjectBehavior
     function it_has_order_token(): void
     {
         $this->orderToken()->shouldReturn('ORDERTOKEN');
-    }
-
-    function it_throws_an_exception_if_order_token_is_not_a_string(): void
-    {
-        $this->beConstructedWith(new \stdClass());
-
-        $this->shouldThrow(TypeError::class)->duringInstantiation();
     }
 }

--- a/spec/Command/Cart/PickupCartSpec.php
+++ b/spec/Command/Cart/PickupCartSpec.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace spec\Sylius\ShopApiPlugin\Command\Cart;
 
 use PhpSpec\ObjectBehavior;
-use TypeError;
 
 final class PickupCartSpec extends ObjectBehavior
 {
@@ -22,19 +21,5 @@ final class PickupCartSpec extends ObjectBehavior
     function it_has_channel_code(): void
     {
         $this->channelCode()->shouldReturn('CHANNEL_CODE');
-    }
-
-    function it_throws_an_exception_if_order_token_is_not_a_string(): void
-    {
-        $this->beConstructedWith(new \stdClass(), 'CHANNEL_CODE');
-
-        $this->shouldThrow(TypeError::class)->duringInstantiation();
-    }
-
-    function it_throws_an_exception_if_channel_code_is_not_a_string(): void
-    {
-        $this->beConstructedWith('ORDERTOKEN', new \stdClass());
-
-        $this->shouldThrow(TypeError::class)->duringInstantiation();
     }
 }

--- a/spec/Command/Cart/PutOptionBasedConfigurableItemToCartSpec.php
+++ b/spec/Command/Cart/PutOptionBasedConfigurableItemToCartSpec.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace spec\Sylius\ShopApiPlugin\Command\Cart;
 
 use PhpSpec\ObjectBehavior;
-use TypeError;
 
 final class PutOptionBasedConfigurableItemToCartSpec extends ObjectBehavior
 {
@@ -32,20 +31,6 @@ final class PutOptionBasedConfigurableItemToCartSpec extends ObjectBehavior
     function it_has_quantity(): void
     {
         $this->quantity()->shouldReturn(5);
-    }
-
-    function it_throws_an_exception_if_order_token_is_not_a_string(): void
-    {
-        $this->beConstructedWith(new \stdClass(), 'T_SHIRT_CODE', ['RED_OPTION_CODE'], 1);
-
-        $this->shouldThrow(TypeError::class)->duringInstantiation();
-    }
-
-    function it_throws_an_exception_if_product_code_is_not_a_string(): void
-    {
-        $this->beConstructedWith('ORDERTOKEN', new \stdClass(), ['RED_OPTION_CODE'], 1);
-
-        $this->shouldThrow(TypeError::class)->duringInstantiation();
     }
 
     function it_throws_an_exception_if_options_are_empty(): void

--- a/spec/Command/Cart/PutSimpleItemToCartSpec.php
+++ b/spec/Command/Cart/PutSimpleItemToCartSpec.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace spec\Sylius\ShopApiPlugin\Command\Cart;
 
 use PhpSpec\ObjectBehavior;
-use TypeError;
 
 final class PutSimpleItemToCartSpec extends ObjectBehavior
 {
@@ -27,20 +26,6 @@ final class PutSimpleItemToCartSpec extends ObjectBehavior
     function it_has_quantity(): void
     {
         $this->quantity()->shouldReturn(5);
-    }
-
-    function it_throws_an_exception_if_order_token_is_not_a_string(): void
-    {
-        $this->beConstructedWith(new \stdClass(), 'T_SHIRT_CODE', 1);
-
-        $this->shouldThrow(TypeError::class)->duringInstantiation();
-    }
-
-    function it_throws_an_exception_if_product_code_is_not_a_string(): void
-    {
-        $this->beConstructedWith('ORDERTOKEN', new \stdClass(), 1);
-
-        $this->shouldThrow(TypeError::class)->duringInstantiation();
     }
 
     function it_throws_an_exception_if_quantity_is_not_less_then_0(): void

--- a/spec/Command/Cart/PutVariantBasedConfigurableItemToCartSpec.php
+++ b/spec/Command/Cart/PutVariantBasedConfigurableItemToCartSpec.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace spec\Sylius\ShopApiPlugin\Command\Cart;
 
 use PhpSpec\ObjectBehavior;
-use TypeError;
 
 final class PutVariantBasedConfigurableItemToCartSpec extends ObjectBehavior
 {
@@ -32,27 +31,6 @@ final class PutVariantBasedConfigurableItemToCartSpec extends ObjectBehavior
     function it_has_quantity(): void
     {
         $this->quantity()->shouldReturn(5);
-    }
-
-    function it_throws_an_exception_if_order_token_is_not_a_string(): void
-    {
-        $this->beConstructedWith(new \stdClass(), 'T_SHIRT_CODE', 'RED_SMALL_T_SHIRT_CODE', 1);
-
-        $this->shouldThrow(TypeError::class)->duringInstantiation();
-    }
-
-    function it_throws_an_exception_if_product_code_is_not_a_string(): void
-    {
-        $this->beConstructedWith('ORDERTOKEN', new \stdClass(), 'RED_SMALL_T_SHIRT_CODE', 1);
-
-        $this->shouldThrow(TypeError::class)->duringInstantiation();
-    }
-
-    function it_throws_an_exception_if_product_variant_code_is_not_a_string(): void
-    {
-        $this->beConstructedWith('ORDERTOKEN', 'T_SHIRT_CODE', new \stdClass(), 1);
-
-        $this->shouldThrow(TypeError::class)->duringInstantiation();
     }
 
     function it_throws_an_exception_if_quantity_is_not_less_then_0(): void


### PR DESCRIPTION
TypeError tests don't provide any value, we are just testing that PHP itself is working correctly