### PR TITLE
fix product not assigned to channel error message

### DIFF
--- a/src/ViewRepository/Product/ProductDetailsViewRepository.php
+++ b/src/ViewRepository/Product/ProductDetailsViewRepository.php
@@ -58,7 +58,7 @@ final class ProductDetailsViewRepository implements ProductDetailsViewRepository
         $product = $this->productRepository->findOneByCode($productCode);
 
         Assert::notNull($product, sprintf('Product with code %s has not been found.', $productCode));
-        Assert::true($product->hasChannel($channel), sprintf('Channel with code %s has not been found.', $channelCode));
+        Assert::true($product->hasChannel($channel), sprintf('Product with code %s has not been found for channel %s.', $productCode, $channelCode));
 
         return $this->productViewFactory->create($product, $channel, $localeCode);
     }


### PR DESCRIPTION
I was wondering why querying an existing product results into a channel not found error.

(Could be possible that there will be some test failures, I will fix them soon).