### PR TITLE
Fixing double carts

### DIFF
--- a/src/DependencyInjection/Compiler/CartContextPass.php
+++ b/src/DependencyInjection/Compiler/CartContextPass.php
@@ -9,25 +9,24 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
 
-class CartContextPass implements CompilerPassInterface
+final class CartContextPass implements CompilerPassInterface
 {
     public const CART_CONTEXT_SERVICE_TAG = 'sylius.context.cart';
-
-    private $compositeId = 'sylius.shop_api_plugin.context.cart';
-    private $tagName = self::CART_CONTEXT_SERVICE_TAG;
+    private const COMPOSITE_ID = 'sylius.shop_api_plugin.context.cart';
+    private const EXCLUDED_SERVICE = 'sylius.context.cart.new';
 
     /**
      * {@inheritdoc}
      */
     public function process(ContainerBuilder $container): void
     {
-        if (!$container->has($this->compositeId)) {
+        if (!$container->has(self::COMPOSITE_ID)) {
             return;
         }
 
-        $contextDefinition = $container->findDefinition($this->compositeId);
+        $contextDefinition = $container->findDefinition(self::COMPOSITE_ID);
 
-        $taggedServices = $container->findTaggedServiceIds($this->tagName);
+        $taggedServices = $container->findTaggedServiceIds(self::CART_CONTEXT_SERVICE_TAG);
         foreach ($taggedServices as $id => $tags) {
             $this->addMethodCalls($contextDefinition, $id, $tags);
         }
@@ -35,7 +34,7 @@ class CartContextPass implements CompilerPassInterface
 
     private function addMethodCalls(Definition $contextDefinition, string $id, array $tags): void
     {
-        if ($id === 'sylius.context.cart.new') {
+        if ($id === self::EXCLUDED_SERVICE) {
             return;
         }
 

--- a/src/DependencyInjection/Compiler/CartContextPass.php
+++ b/src/DependencyInjection/Compiler/CartContextPass.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\DependencyInjection\Compiler;

--- a/src/DependencyInjection/Compiler/CartContextPass.php
+++ b/src/DependencyInjection/Compiler/CartContextPass.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types=1);
+
+namespace Sylius\ShopApiPlugin\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+class CartContextPass implements CompilerPassInterface
+{
+    public const CART_CONTEXT_SERVICE_TAG = 'sylius.context.cart';
+
+    private $compositeId = 'sylius.shop_api_plugin.context.cart';
+    private $tagName = self::CART_CONTEXT_SERVICE_TAG;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container): void
+    {
+        if (!$container->has($this->compositeId)) {
+            return;
+        }
+
+        $contextDefinition = $container->findDefinition($this->compositeId);
+
+        $taggedServices = $container->findTaggedServiceIds($this->tagName);
+        foreach ($taggedServices as $id => $tags) {
+            $this->addMethodCalls($contextDefinition, $id, $tags);
+        }
+    }
+
+    private function addMethodCalls(Definition $contextDefinition, string $id, array $tags): void
+    {
+        if ($id === 'sylius.context.cart.new') {
+            return;
+        }
+
+        foreach ($tags as $attributes) {
+            $contextDefinition->addMethodCall('addContext', [new Reference($id), $attributes['priority'] ?? 0]);
+        }
+    }
+}

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -63,15 +63,12 @@
             <argument type="service" id="sylius.manager.order" />
         </service>
 
-        <service
-                id="sylius.shop_api_plugin.normalizer.request_cart_token_normalizer"
-                class="Sylius\ShopApiPlugin\Normalizer\RequestCartTokenNormalizer"
-        >
+        <service id="sylius.shop_api_plugin.normalizer.request_cart_token_normalizer"
+                 class="Sylius\ShopApiPlugin\Normalizer\RequestCartTokenNormalizer">
             <argument type="service" id="validator" />
             <argument type="service" id="sylius_shop_api_plugin.command_bus" />
         </service>
 
-        <!-- Removing the create cart context from composite context (see: https://github.com/Sylius/Sylius/issues/10192) -->
         <service id="sylius.shop_api_plugin.context.cart" class="Sylius\Component\Order\Context\CompositeCartContext" />
 
         <service id="sylius.listener.cart_blamer" class="Sylius\Bundle\CoreBundle\EventListener\CartBlamerListener">

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -72,8 +72,13 @@
         </service>
 
         <!-- Removing the create cart context from composite context (see: https://github.com/Sylius/Sylius/issues/10192) -->
-        <service id="sylius.context.cart.new" class="Sylius\Component\Order\Context\CartContext">
-            <argument type="service" id="sylius.factory.order" />
+        <service id="sylius.shop_api_plugin.context.cart" class="Sylius\Component\Order\Context\CompositeCartContext" />
+
+        <service id="sylius.listener.cart_blamer" class="Sylius\Bundle\CoreBundle\EventListener\CartBlamerListener">
+            <argument type="service" id="sylius.manager.order" />
+            <argument type="service" id="sylius.shop_api_plugin.context.cart" />
+            <tag name="kernel.event_listener" event="sylius.user.security.implicit_login" method="onImplicitLogin" />
+            <tag name="kernel.event_listener" event="security.interactive_login" method="onInteractiveLogin" />
         </service>
     </services>
 </container>

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -72,6 +72,8 @@
         </service>
 
         <!-- Removing the create cart context from composite context (see: https://github.com/Sylius/Sylius/issues/10192) -->
+        <service id="sylius.shop_api_plugin.context.cart" class="Sylius\Component\Order\Context\CompositeCartContext" />
+
         <service id="sylius.listener.cart_blamer" class="Sylius\Bundle\CoreBundle\EventListener\CartBlamerListener">
             <argument type="service" id="sylius.manager.order" />
             <argument type="service" id="sylius.shop_api_plugin.context.cart" />

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -72,8 +72,6 @@
         </service>
 
         <!-- Removing the create cart context from composite context (see: https://github.com/Sylius/Sylius/issues/10192) -->
-        <service id="sylius.shop_api_plugin.context.cart" class="Sylius\Component\Order\Context\CompositeCartContext" />
-
         <service id="sylius.listener.cart_blamer" class="Sylius\Bundle\CoreBundle\EventListener\CartBlamerListener">
             <argument type="service" id="sylius.manager.order" />
             <argument type="service" id="sylius.shop_api_plugin.context.cart" />

--- a/src/ShopApiPlugin.php
+++ b/src/ShopApiPlugin.php
@@ -5,9 +5,18 @@ declare(strict_types=1);
 namespace Sylius\ShopApiPlugin;
 
 use Sylius\Bundle\CoreBundle\Application\SyliusPluginTrait;
+use Sylius\ShopApiPlugin\DependencyInjection\Compiler\CartContextPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 final class ShopApiPlugin extends Bundle
 {
     use SyliusPluginTrait;
+
+    public function build(ContainerBuilder $container)
+    {
+        parent::build($container);
+
+        $container->addCompilerPass(new CartContextPass());
+    }
 }


### PR DESCRIPTION
In the last pull request #401 the cart provider was overridden however this fix is much more specific in that it replaces the cart context only in a specific point (the cart blamer) The cart blamer is used on login so it is also the point where the cart creation shouldn't occur. For a more indepth view on if this is the right part of where the override should happen, the Sylius Core team would need to give feedback. This however should prevent the Sylius frontend from crashing when using the ShopApi