### PR TITLE
Display message about decoupling from ShopBundle

### DIFF
--- a/src/DependencyInjection/SyliusShopApiExtension.php
+++ b/src/DependencyInjection/SyliusShopApiExtension.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\DependencyInjection;
 
+use Psr\Log\LoggerInterface;
+use Sylius\Bundle\ShopBundle\SyliusShopBundle;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\Extension;
@@ -28,5 +30,11 @@ final class SyliusShopApiExtension extends Extension
         $container->setParameter('sylius.shop_api.included_attributes', $config['included_attributes']);
 
         $loader->load('services.xml');
+
+        if (in_array(SyliusShopBundle::class, $container->getParameter('kernel.bundles'))) {
+            /** @var LoggerInterface $logger */
+            $logger = $container->get('sylius.shop_api_plugin.logger.console');
+            $logger->notice('Beware! SyliusShopApi is not built to work with SyliusShopBundle.');
+        }
     }
 }

--- a/src/Resources/config/app/config.yml
+++ b/src/Resources/config/app/config.yml
@@ -23,3 +23,9 @@ sylius_customer:
         customer:
             classes:
                 controller: Sylius\ShopApiPlugin\Controller\Customer\CustomerController
+
+monolog:
+    handlers:
+        console:
+            type: console
+            channels: ['console']

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -95,5 +95,9 @@
         <service id="sylius.context.cart.new" class="Sylius\Component\Order\Context\CartContext">
             <argument type="service" id="sylius.factory.order" />
         </service>
+
+        <service id="sylius.shop_api_plugin.logger.console" class="Monolog\Logger" >
+            <argument>console</argument>
+        </service>
     </services>
 </container>

--- a/tests/DependencyInjection/ShopApiExtensionTest.php
+++ b/tests/DependencyInjection/ShopApiExtensionTest.php
@@ -15,6 +15,7 @@ final class ShopApiExtensionTest extends AbstractExtensionTestCase
      */
     public function it_sets_up_parameter_with_attributes_to_serialize(): void
     {
+        $this->setParameter('kernel.bundles', []);
         $this->load([
             'included_attributes' => [
                 'ATTRIBUTE_CODE',
@@ -29,6 +30,7 @@ final class ShopApiExtensionTest extends AbstractExtensionTestCase
      */
     public function it_defines_view_classes_parameters(): void
     {
+        $this->setParameter('kernel.bundles', []);
         $this->load([]);
 
         $nameToClass = [


### PR DESCRIPTION
<img width="775" alt="Zrzut ekranu 2019-07-25 o 09 56 32" src="https://user-images.githubusercontent.com/6212718/61857186-e841e880-aec3-11e9-8254-fc9fa8d6cee1.png">

The message is not-so-pretty, but it could be improved later. cc @lchrusciel @mamazu do you think such a message makes sense, as an addition to [this line](https://github.com/Sylius/ShopApiPlugin/blob/master/README.md#L21) in README 🚀 🐎 