### PR TITLE
Returning 401 on customer details/update actions when not logged in

### DIFF
--- a/doc/swagger.yml
+++ b/doc/swagger.yml
@@ -841,8 +841,8 @@ paths:
                     description: "Provides currently logged in user details."
                     schema:
                         $ref: "#/definitions/LoggedInCustomerDetails"
-                500:
-                    description: "There is no currently logged in user."
+                401:
+                    description: "User token invalid"
             security:
                 -   bearerAuth: []
         put:
@@ -862,9 +862,7 @@ paths:
                     schema:
                         $ref: "#/definitions/LoggedInCustomerDetails"
                 401:
-                    description: "User token is invalid."
-                500:
-                    description: "There is no currently logged in user."
+                    description: "User token invalid"
             security:
                 -   bearerAuth: []
 

--- a/src/Controller/Customer/LoggedInCustomerDetailsAction.php
+++ b/src/Controller/Customer/LoggedInCustomerDetailsAction.php
@@ -35,6 +35,10 @@ final class LoggedInCustomerDetailsAction
 
     public function __invoke(Request $request): Response
     {
+        if (!$this->loggedInShopUserProvider->isUserLoggedIn()) {
+            return $this->viewHandler->handle(View::create(null, Response::HTTP_UNAUTHORIZED));
+        }
+
         $customer = $this->loggedInShopUserProvider->provide()->getCustomer();
         Assert::notNull($customer);
 

--- a/src/Controller/Customer/UpdateCustomerAction.php
+++ b/src/Controller/Customer/UpdateCustomerAction.php
@@ -54,6 +54,10 @@ final class UpdateCustomerAction
 
     public function __invoke(Request $request): Response
     {
+        if (!$this->loggedInUserProvider->isUserLoggedIn()) {
+            return $this->viewHandler->handle(View::create(null, Response::HTTP_UNAUTHORIZED));
+        }
+
         $validationResults = $this->updateCustomerCommandProvider->validate($request, null, ['sylius_customer_profile_update']);
         if (0 !== count($validationResults)) {
             return $this->viewHandler->handle(View::create(

--- a/tests/Controller/Customer/LoggedInCustomerDetailsActionTest.php
+++ b/tests/Controller/Customer/LoggedInCustomerDetailsActionTest.php
@@ -17,7 +17,7 @@ final class LoggedInCustomerDetailsActionTest extends JsonApiTestCase
         $this->loadFixturesFromFiles(['channel.yml', 'customer.yml']);
 
         $data =
-<<<JSON
+            <<<JSON
         {
             "email": "oliver@queen.com",
             "password": "123password"
@@ -36,5 +36,29 @@ JSON;
 
         $response = $this->client->getResponse();
         $this->assertResponse($response, 'customer/logged_in_customer_details_response', Response::HTTP_OK);
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_allow_to_show_customer_details_without_being_logged_in(): void
+    {
+        $this->loadFixturesFromFiles(['channel.yml', 'customer.yml']);
+
+        $data =
+            <<<JSON
+        {
+            "email": "oliver@queen.com",
+            "password": "123password"
+        }
+JSON;
+
+        $this->client->request('GET', '/shop-api/me', [], [], [
+            'CONTENT_TYPE' => 'application/json',
+            'ACCEPT' => 'application/json',
+        ]);
+
+        $response = $this->client->getResponse();
+        $this->assertResponseCode($response, Response::HTTP_UNAUTHORIZED);
     }
 }

--- a/tests/Controller/Customer/UpdateCustomerApiTest.php
+++ b/tests/Controller/Customer/UpdateCustomerApiTest.php
@@ -75,7 +75,7 @@ JSON;
 JSON;
         $this->client->request('PUT', '/shop-api/me', [], [], self::CONTENT_TYPE_HEADER, $data);
         $response = $this->client->getResponse();
-        $this->assertResponseCode($response, Response::HTTP_INTERNAL_SERVER_ERROR);
+        $this->assertResponseCode($response, Response::HTTP_UNAUTHORIZED);
     }
 
     /**


### PR DESCRIPTION
The `LoggedInCustomerDetailsAction` and the `UpdateCustomerAction` now return an unauthorized response instead of throwing `TokenNotFoundException` if the user is not logged in.