### PR TITLE
Use sylius_shop_password_reset route in passwordReset email template

### DIFF
--- a/src/Resources/views/Email/passwordReset.html.twig
+++ b/src/Resources/views/Email/passwordReset.html.twig
@@ -3,7 +3,7 @@
 {% endblock %}
 
 {% block body %}
-    {% set url = url('sylius_shop_api_password_reset', {'channelCode': channelCode, 'token': user.passwordResetToken}) %}
+    {% set url = url('sylius_shop_password_reset', {'channelCode': channelCode, 'token': user.passwordResetToken}) %}
     {% autoescape %}
         <h3>Hello {{ user.username }}</h3>
 


### PR DESCRIPTION
This PR updates the `passwordReset.html.twig` template to use the `sylius_shop_password_reset` route of Sylius for generating the password-reset link.

Right now, the `sylius_shop_api_password_reset` route is used. This route is defined to allow only `PUT` requests in the `register.yml` file. This means that every user that clicks on the link in the email will cause a `405 Method Not Allowed` exception.

See `Resources/config/routing/register.yml`
```
sylius_shop_api_password_reset:
    path: /password-reset/{token}
    methods: [PUT]
    defaults:
        _controller: sylius.controller.shop_user:resetPasswordAction
```