### PR TITLE
Add route for changing password of current user

### DIFF
--- a/doc/swagger.yml
+++ b/doc/swagger.yml
@@ -866,6 +866,26 @@ paths:
             security:
                 -   bearerAuth: []
 
+    /me/change-password:
+        put:
+            tags:
+                - "users"
+            summary: "Updates the password of the user that is currently logged in."
+            operationId: "changePassword"
+            parameters:
+                -   name: "content"
+                    in: "body"
+                    required: true
+                    schema:
+                        $ref: "#/definitions/ChangePasswordRequest"
+            responses:
+                204:
+                    description: "Update password request success"
+                400:
+                    description: "There were validation errors"
+                401:
+                    description: "User token invalid"
+
     /address-book:
         get:
             tags:
@@ -1627,6 +1647,14 @@ definitions:
             subscribedToNewsletter:
                 type: "integer"
                 example: 0
+    ChangePasswordRequest:
+        type: "object"
+        properties:
+            currentPassword:
+                type: "string"
+                example: "current-user-password"
+            newPassword:
+                $ref: "#/definitions/PasswordReset"
     LoggedInCustomerDetails:
         type: "object"
         properties:

--- a/spec/Handler/Cart/PickupCartHandlerSpec.php
+++ b/spec/Handler/Cart/PickupCartHandlerSpec.php
@@ -41,7 +41,7 @@ final class PickupCartHandlerSpec extends ObjectBehavior
 
     function it_handles_cart_pickup_for_not_logged_in_user(
         ChannelInterface $channel,
-        CurrencyInterface  $currency,
+        CurrencyInterface $currency,
         ChannelRepositoryInterface $channelRepository,
         FactoryInterface $cartFactory,
         LocaleInterface $locale,

--- a/src/Resources/config/routing/customer.yml
+++ b/src/Resources/config/routing/customer.yml
@@ -9,3 +9,9 @@ sylius_shop_api_update_customer:
      methods: [PUT]
      defaults:
         _controller: sylius.shop_api_plugin.controller.customer.update_customer_action
+
+sylius_shop_api_change_password:
+    path: /me/change-password
+    methods: [PUT]
+    defaults:
+        _controller: sylius.controller.shop_user:changePasswordAction

--- a/tests/Controller/Customer/ChangePasswordApiTest.php
+++ b/tests/Controller/Customer/ChangePasswordApiTest.php
@@ -35,6 +35,19 @@ JSON;
 
         $response = $this->client->getResponse();
         $this->assertResponseCode($response, Response::HTTP_NO_CONTENT);
+
+        // test login with new password
+        $newLoginData =
+<<<JSON
+        {
+            "email": "oliver@queen.com",
+            "password": "new-pass"
+        }
+JSON;
+        $this->client->request('POST', '/shop-api/login', [], [], ['CONTENT_TYPE' => 'application/json', 'ACCEPT' => 'application/json'], $newLoginData);
+
+        $response = $this->client->getResponse();
+        $this->assertResponseCode($response, Response::HTTP_OK);
     }
 
     /**

--- a/tests/Controller/Customer/ChangePasswordApiTest.php
+++ b/tests/Controller/Customer/ChangePasswordApiTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Sylius\ShopApiPlugin\Controller\Customer;
+
+use Symfony\Component\HttpFoundation\Response;
+use Tests\Sylius\ShopApiPlugin\Controller\JsonApiTestCase;
+use Tests\Sylius\ShopApiPlugin\Controller\Utils\ShopUserLoginTrait;
+
+final class ChangePasswordApiTest extends JsonApiTestCase
+{
+    use ShopUserLoginTrait;
+
+    /**
+     * @test
+     */
+    public function it_allows_to_update_customer_password(): void
+    {
+        $this->loadFixturesFromFiles(['channel.yml', 'customer.yml']);
+        $this->logInUser('oliver@queen.com', '123password');
+
+        $changePasswordData =
+<<<JSON
+        {
+            "currentPassword": "123password",
+            "newPassword": {
+                "first": "new-pass",
+                "second": "new-pass"
+            }
+        }
+JSON;
+
+        $this->client->request('PUT', '/shop-api/me/change-password', [], [], self::CONTENT_TYPE_HEADER, $changePasswordData);
+
+        $response = $this->client->getResponse();
+        $this->assertResponseCode($response, Response::HTTP_NO_CONTENT);
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_allow_to_update_customer_password_without_being_logged_in(): void
+    {
+        $this->loadFixturesFromFiles(['channel.yml', 'customer.yml']);
+
+        $changePasswordData =
+<<<JSON
+        {
+            "currentPassword": "123password",
+            "newPassword": {
+                "first": "new-pass",
+                "second": "new-pass"
+            }
+        }
+JSON;
+
+        $this->client->request('PUT', '/shop-api/me/change-password', [], [], self::CONTENT_TYPE_HEADER, $changePasswordData);
+
+        $response = $this->client->getResponse();
+        $this->assertResponseCode($response, Response::HTTP_UNAUTHORIZED);
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_allow_to_update_customer_password_with_invalid_current_password(): void
+    {
+        $this->loadFixturesFromFiles(['channel.yml', 'customer.yml']);
+        $this->logInUser('oliver@queen.com', '123password');
+
+        $changePasswordData =
+<<<JSON
+        {
+            "currentPassword": "wrong-pass",
+            "newPassword": {
+                "first": "new-pass",
+                "second": "new-pass"
+            }
+        }
+JSON;
+
+        $this->client->request('PUT', '/shop-api/me/change-password', [], [], self::CONTENT_TYPE_HEADER, $changePasswordData);
+
+        $response = $this->client->getResponse();
+        $this->assertResponseCode($response, Response::HTTP_BAD_REQUEST);
+    }
+}


### PR DESCRIPTION
Closes #28

This PR adds a `sylius_shop_api_change_password` route with the path `/me/change-password`.
The route allows to change the password of the user that is currently logged in.

The PR does not implement any new action, but rather uses the existing `changePasswordAction` of the `UserController` of Sylius. This is the same strategy that is already used for the `sylius_shop_api_password_reset` route.