### PR TITLE
Remove trailing slashes from route paths

### DIFF
--- a/src/Resources/config/routing/address_book.yml
+++ b/src/Resources/config/routing/address_book.yml
@@ -1,5 +1,5 @@
 sylius_shop_api_address_book_create:
-    path: /address-book/
+    path: /address-book
     controller: sylius.controller.address:createAction
     methods: [POST]
     defaults:
@@ -10,7 +10,7 @@ sylius_shop_api_address_book_create:
                     - "expr:service('sylius.context.customer').getCustomer()"
 
 sylius_shop_api_address_book_index:
-    path: /address-book/
+    path: /address-book
     controller: sylius.controller.address:indexAction
     methods: [GET]
     defaults:

--- a/src/Resources/config/routing/productList.yml
+++ b/src/Resources/config/routing/productList.yml
@@ -1,5 +1,5 @@
 sylius_shop_api_product_show_latest:
-    path: /product-latest/
+    path: /product-latest
     methods: [GET]
     defaults:
         _controller: sylius.shop_api_plugin.controller.product.show_latest_product_action

--- a/src/Resources/config/routing/taxon.yml
+++ b/src/Resources/config/routing/taxon.yml
@@ -5,7 +5,7 @@ sylius_shop_api_taxon_show_details:
         _controller: sylius.shop_api_plugin.controller.taxon.show_taxon_details_action
 
 sylius_shop_api_taxon_show_tree:
-    path: /taxons/
+    path: /taxons
     methods: [GET]
     defaults:
         _controller: sylius.shop_api_plugin.controller.taxon.show_taxon_tree_action

--- a/tests/Controller/AddressBook/CreateAddressApiTest.php
+++ b/tests/Controller/AddressBook/CreateAddressApiTest.php
@@ -133,7 +133,7 @@ JSON;
 
     private function createAddress(string $data): Response
     {
-        $this->client->request('POST', '/shop-api/address-book/', [], [], self::CONTENT_TYPE_HEADER, $data);
+        $this->client->request('POST', '/shop-api/address-book', [], [], self::CONTENT_TYPE_HEADER, $data);
 
         return $this->client->getResponse();
     }

--- a/tests/Controller/AddressBook/ShowApiTest.php
+++ b/tests/Controller/AddressBook/ShowApiTest.php
@@ -37,7 +37,7 @@ final class ShowApiTest extends JsonApiTestCase
 
     private function showAddressBook(): Response
     {
-        $this->client->request('GET', '/shop-api/address-book/', [], [], self::CONTENT_TYPE_HEADER);
+        $this->client->request('GET', '/shop-api/address-book', [], [], self::CONTENT_TYPE_HEADER);
 
         return $this->client->getResponse();
     }

--- a/tests/Controller/Product/ShowLatestApiTest.php
+++ b/tests/Controller/Product/ShowLatestApiTest.php
@@ -16,7 +16,7 @@ final class ShowLatestApiTest extends JsonApiTestCase
     {
         $this->loadFixturesFromFiles(['shop.yml']);
 
-        $this->client->request('GET', '/shop-api/product-latest/', [], [], self::CONTENT_TYPE_HEADER);
+        $this->client->request('GET', '/shop-api/product-latest', [], [], self::CONTENT_TYPE_HEADER);
 
         $response = $this->client->getResponse();
 
@@ -30,7 +30,7 @@ final class ShowLatestApiTest extends JsonApiTestCase
     {
         $this->loadFixturesFromFiles(['shop.yml']);
 
-        $this->client->request('GET', '/shop-api/product-latest/', ['limit' => 2], [], self::CONTENT_TYPE_HEADER);
+        $this->client->request('GET', '/shop-api/product-latest', ['limit' => 2], [], self::CONTENT_TYPE_HEADER);
 
         $response = $this->client->getResponse();
 

--- a/tests/Controller/Taxon/ShowTreeApiTest.php
+++ b/tests/Controller/Taxon/ShowTreeApiTest.php
@@ -16,7 +16,7 @@ final class ShowTreeApiTest extends JsonApiTestCase
     {
         $this->loadFixturesFromFiles(['shop.yml']);
 
-        $this->client->request('GET', '/shop-api/taxons/', [], [], self::CONTENT_TYPE_HEADER);
+        $this->client->request('GET', '/shop-api/taxons', [], [], self::CONTENT_TYPE_HEADER);
 
         $response = $this->client->getResponse();
 
@@ -30,7 +30,7 @@ final class ShowTreeApiTest extends JsonApiTestCase
     {
         $this->loadFixturesFromFiles(['shop.yml']);
 
-        $this->client->request('GET', '/shop-api/taxons/?locale=de_DE', [], [], self::CONTENT_TYPE_HEADER);
+        $this->client->request('GET', '/shop-api/taxons?locale=de_DE', [], [], self::CONTENT_TYPE_HEADER);
 
         $response = $this->client->getResponse();
 


### PR DESCRIPTION
This PR removes all remaining trailing slashes from the paths of the API routes. 

This is mainly a consistency thing as these routes are documented without trailing slashes in the `doc/swagger.yml` file.
Furthermore, symfony should redirect these paths anyway 🙂 (see https://symfony.com/doc/4.1/routing.html#redirecting-urls-with-trailing-slashes).