### PR TITLE
Fix CartBlamerListener case with empty token

### DIFF
--- a/src/EventListener/CartBlamerListener.php
+++ b/src/EventListener/CartBlamerListener.php
@@ -44,7 +44,9 @@ final class CartBlamerListener
             return;
         }
 
-        $token = $request->request->get('token');
+        if (null === $token = $request->request->get('token')) {
+            return;
+        }
 
         $cart = $this->cartRepository->findOneBy(['tokenValue' => $token]);
 


### PR DESCRIPTION
This PR solves false-positive CartBlamerListener execution.

> $cart = $this->cartRepository->findOneBy(['tokenValue' => $token]);

If database contains orders without `tokenValue`, then it will return non-null `$cart` result for null `$token`. [Order.orm.xml tokenValue is nullable](https://github.com/Sylius/Sylius/blob/master/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/Order.orm.xml#L76)