### PR TITLE
Addding assertions for product in current channel

### DIFF
--- a/doc/swagger.yml
+++ b/doc/swagger.yml
@@ -141,6 +141,8 @@ paths:
                     description: "Invalid input, validation failed."
                     schema:
                         $ref: "#/definitions/GeneralError"
+                500:
+                    description: "An error occurred - maybe the product is not in the channel of the cart"
 
     /carts/{token}/multiple-items:
         parameters:

--- a/doc/swagger.yml
+++ b/doc/swagger.yml
@@ -141,8 +141,6 @@ paths:
                     description: "Invalid input, validation failed."
                     schema:
                         $ref: "#/definitions/GeneralError"
-                500:
-                    description: "An error occurred - maybe the product is not in the channel of the cart"
 
     /carts/{token}/multiple-items:
         parameters:

--- a/spec/Checker/ProductInCartChannelCheckerSpec.php
+++ b/spec/Checker/ProductInCartChannelCheckerSpec.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\Sylius\ShopApiPlugin\Checker;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use PhpSpec\ObjectBehavior;
+use Sylius\Component\Core\Model\ChannelInterface;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\ProductInterface;
+use Sylius\ShopApiPlugin\Checker\ProductInCartChannelCheckerInterface;
+
+final class ProductInCartChannelCheckerSpec extends ObjectBehavior
+{
+    function it_implements_product_in_cart_channel_checker_interface(): void
+    {
+        $this->shouldImplement(ProductInCartChannelCheckerInterface::class);
+    }
+
+    function it_returns_true_if_the_channels_match(
+        ProductInterface $product,
+        OrderInterface $order,
+        ChannelInterface $channel
+    ): void {
+        $product->getChannels()->willReturn(new ArrayCollection([$channel->getWrappedObject()]));
+
+        $order->getChannel()->willReturn($channel);
+
+        $this->isProductInCartChannel($product, $order)->shouldReturn(true);
+    }
+
+    function it_returns_false_if_the_channels_do_not_match(
+        ProductInterface $product,
+        OrderInterface $order,
+        ChannelInterface $orderChannel,
+        ChannelInterface $productChannel1,
+        ChannelInterface $productChannel2
+    ): void {
+        $product->getChannels()->willReturn(new ArrayCollection([
+            $productChannel1->getWrappedObject(),
+            $productChannel2->getWrappedObject(),
+        ]));
+
+        $order->getChannel()->willReturn($orderChannel);
+
+        $this->isProductInCartChannel($product, $order)->shouldReturn(false);
+    }
+}

--- a/spec/Handler/Cart/PutVariantBasedConfigurableItemToCartHandlerSpec.php
+++ b/spec/Handler/Cart/PutVariantBasedConfigurableItemToCartHandlerSpec.php
@@ -6,9 +6,11 @@ namespace spec\Sylius\ShopApiPlugin\Handler\Cart;
 
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\ProductInterface;
 use Sylius\Component\Core\Model\ProductVariantInterface;
 use Sylius\Component\Core\Repository\OrderRepositoryInterface;
 use Sylius\Component\Core\Repository\ProductVariantRepositoryInterface;
+use Sylius\ShopApiPlugin\Checker\ProductInCartChannelCheckerInterface;
 use Sylius\ShopApiPlugin\Command\Cart\PutVariantBasedConfigurableItemToCart;
 use Sylius\ShopApiPlugin\Modifier\OrderModifierInterface;
 
@@ -17,19 +19,25 @@ final class PutVariantBasedConfigurableItemToCartHandlerSpec extends ObjectBehav
     function let(
         OrderRepositoryInterface $cartRepository,
         ProductVariantRepositoryInterface $productVariantRepository,
-        OrderModifierInterface $orderModifier
+        OrderModifierInterface $orderModifier,
+        ProductInCartChannelCheckerInterface $channelChecker
     ): void {
-        $this->beConstructedWith($cartRepository, $productVariantRepository, $orderModifier);
+        $this->beConstructedWith($cartRepository, $productVariantRepository, $orderModifier, $channelChecker);
     }
 
     function it_handles_putting_new_item_to_cart(
         OrderInterface $cart,
         OrderModifierInterface $orderModifier,
         OrderRepositoryInterface $cartRepository,
+        ProductInCartChannelCheckerInterface $channelChecker,
         ProductVariantInterface $productVariant,
+        ProductInterface $product,
         ProductVariantRepositoryInterface $productVariantRepository
     ): void {
         $productVariantRepository->findOneByCodeAndProductCode('RED_SMALL_T_SHIRT_CODE', 'T_SHIRT_CODE')->willReturn($productVariant);
+        $productVariant->getProduct()->willReturn($product);
+
+        $channelChecker->isProductInCartChannel($product, $cart)->willReturn(true);
 
         $cartRepository->findOneBy(['tokenValue' => 'ORDERTOKEN'])->willReturn($cart);
 
@@ -54,6 +62,26 @@ final class PutVariantBasedConfigurableItemToCartHandlerSpec extends ObjectBehav
     ): void {
         $cartRepository->findOneBy(['tokenValue' => 'ORDERTOKEN'])->willReturn($cart);
         $productVariantRepository->findOneByCodeAndProductCode('RED_SMALL_T_SHIRT_CODE', 'T_SHIRT_CODE')->willReturn(null);
+
+        $this->shouldThrow(\InvalidArgumentException::class)->during('__invoke', [
+            new PutVariantBasedConfigurableItemToCart('ORDERTOKEN', 'T_SHIRT_CODE', 'RED_SMALL_T_SHIRT_CODE', 5),
+        ]);
+    }
+
+    function it_throws_an_exception_if_product_has_different_channel_than_cart(
+        OrderInterface $cart,
+        OrderRepositoryInterface $cartRepository,
+        ProductInCartChannelCheckerInterface $channelChecker,
+        ProductVariantRepositoryInterface $productVariantRepository,
+        ProductVariantInterface $productVariant,
+        ProductInterface $product
+    ): void {
+        $productVariantRepository->findOneByCodeAndProductCode('RED_SMALL_T_SHIRT_CODE', 'T_SHIRT_CODE')->willReturn($productVariant);
+        $productVariant->getProduct()->willReturn($product);
+
+        $cartRepository->findOneBy(['tokenValue' => 'ORDERTOKEN'])->willReturn($cart);
+
+        $channelChecker->isProductInCartChannel($product, $cart)->willReturn(false);
 
         $this->shouldThrow(\InvalidArgumentException::class)->during('__invoke', [
             new PutVariantBasedConfigurableItemToCart('ORDERTOKEN', 'T_SHIRT_CODE', 'RED_SMALL_T_SHIRT_CODE', 5),

--- a/spec/Validator/Product/ProductInCartChannelValidatorSpec.php
+++ b/spec/Validator/Product/ProductInCartChannelValidatorSpec.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\Sylius\ShopApiPlugin\Validator\Product;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\ProductInterface;
+use Sylius\Component\Core\Repository\OrderRepositoryInterface;
+use Sylius\Component\Core\Repository\ProductRepositoryInterface;
+use Sylius\ShopApiPlugin\Checker\ProductInCartChannelCheckerInterface;
+use Sylius\ShopApiPlugin\Request\Cart\PutOptionBasedConfigurableItemToCartRequest;
+use Sylius\ShopApiPlugin\Validator\Constraints\ProductInCartChannel;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
+
+final class ProductInCartChannelValidatorSpec extends ObjectBehavior
+{
+    function let(
+        ExecutionContextInterface $executionContext,
+        ProductInCartChannelCheckerInterface $productInCartChannelChecker,
+        ProductRepositoryInterface $productRepository,
+        OrderRepositoryInterface $orderRepository
+    ): void {
+        $this->beConstructedWith($productInCartChannelChecker, $productRepository, $orderRepository);
+
+        $this->initialize($executionContext);
+    }
+
+    function it_is_constraint_validator(): void
+    {
+        $this->shouldHaveType(ConstraintValidator::class);
+    }
+
+    function it_skips_validation_if_the_product_is_null(
+        ProductInCartChannelCheckerInterface $productInCartChannelChecker,
+        OrderRepositoryInterface $orderRepository,
+        ProductRepositoryInterface $productRepository,
+        PutOptionBasedConfigurableItemToCartRequest $request
+    ): void {
+        $request->getProductCode()->willReturn('TEST');
+        $request->getToken()->willReturn('ORDER_TOKEN');
+
+        $productRepository->findOneByCode('TEST')->willReturn(null);
+        $orderRepository->findOneBy(['tokenValue' => 'ORDER_TOKEN'])->willReturn(null);
+
+        $productInCartChannelChecker->isProductInCartChannel(Argument::any())->shouldNotBeCalled();
+
+        $this->validate($request, new ProductInCartChannel());
+    }
+
+    function it_does_not_add_validation_if_product_and_cart_share_a_channel(
+        ProductInCartChannelCheckerInterface $productInCartChannelChecker,
+        ProductInterface $product,
+        OrderRepositoryInterface $orderRepository,
+        OrderInterface $order,
+        ProductRepositoryInterface $productRepository,
+        PutOptionBasedConfigurableItemToCartRequest $request,
+        ExecutionContextInterface $executionContext
+    ): void {
+        $request->getProductCode()->willReturn('TEST');
+        $request->getToken()->willReturn('ORDER_TOKEN');
+
+        $productRepository->findOneByCode('TEST')->willReturn($product);
+        $orderRepository->findOneBy(['tokenValue' => 'ORDER_TOKEN'])->willReturn($order);
+
+        $productInCartChannelChecker->isProductInCartChannel($product, $order)->willReturn(true);
+
+        $executionContext->buildViolation(Argument::any())->shouldNotBeCalled();
+
+        $this->validate($request, new ProductInCartChannel());
+    }
+
+    function it_adds_a_violation_if_the_product_does_not_have_the_same_channel_as_cart(
+        ProductInCartChannelCheckerInterface $productInCartChannelChecker,
+        ProductInterface $product,
+        OrderRepositoryInterface $orderRepository,
+        OrderInterface $order,
+        ProductRepositoryInterface $productRepository,
+        PutOptionBasedConfigurableItemToCartRequest $request,
+        ExecutionContextInterface $executionContext,
+        ConstraintViolationBuilderInterface $constraintViolationBuilder
+    ): void {
+        $request->getProductCode()->willReturn('TEST');
+        $request->getToken()->willReturn('ORDER_TOKEN');
+
+        $productRepository->findOneByCode('TEST')->willReturn($product);
+        $orderRepository->findOneBy(['tokenValue' => 'ORDER_TOKEN'])->willReturn($order);
+
+        $productInCartChannelChecker->isProductInCartChannel($product, $order)->willReturn(false);
+
+        $executionContext->buildViolation('sylius.shop_api.product.not_in_cart_channel')->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->atPath('productCode')->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->addViolation()->shouldBeCalled();
+
+        $this->validate($request, new ProductInCartChannel());
+    }
+}

--- a/src/Checker/ProductInCartChannelChecker.php
+++ b/src/Checker/ProductInCartChannelChecker.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\ShopApiPlugin\Checker;
+
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\ProductInterface;
+
+final class ProductInCartChannelChecker implements ProductInCartChannelCheckerInterface
+{
+    public function isProductInCartChannel(ProductInterface $product, OrderInterface $cart): bool
+    {
+        return in_array($cart->getChannel(), $product->getChannels()->toArray(), true);
+    }
+}

--- a/src/Checker/ProductInCartChannelCheckerInterface.php
+++ b/src/Checker/ProductInCartChannelCheckerInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\ShopApiPlugin\Checker;
+
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\ProductInterface;
+
+interface ProductInCartChannelCheckerInterface
+{
+    public function isProductInCartChannel(ProductInterface $product, OrderInterface $cart): bool;
+}

--- a/src/Handler/Cart/PutOptionBasedConfigurableItemToCartHandler.php
+++ b/src/Handler/Cart/PutOptionBasedConfigurableItemToCartHandler.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace Sylius\ShopApiPlugin\Handler\Cart;
 
 use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\ProductInterface;
 use Sylius\Component\Core\Model\ProductVariantInterface;
 use Sylius\Component\Core\Repository\OrderRepositoryInterface;
 use Sylius\Component\Core\Repository\ProductRepositoryInterface;
-use Sylius\Component\Product\Model\ProductInterface;
+use Sylius\ShopApiPlugin\Checker\ProductInCartChannelCheckerInterface;
 use Sylius\ShopApiPlugin\Command\Cart\PutOptionBasedConfigurableItemToCart;
 use Sylius\ShopApiPlugin\Modifier\OrderModifierInterface;
 use Webmozart\Assert\Assert;
@@ -24,14 +25,19 @@ final class PutOptionBasedConfigurableItemToCartHandler
     /** @var OrderModifierInterface */
     private $orderModifier;
 
+    /** @var ProductInCartChannelCheckerInterface */
+    private $channelChecker;
+
     public function __construct(
         OrderRepositoryInterface $cartRepository,
         ProductRepositoryInterface $productRepository,
-        OrderModifierInterface $orderModifier
+        OrderModifierInterface $orderModifier,
+        ProductInCartChannelCheckerInterface $channelChecker
     ) {
         $this->cartRepository = $cartRepository;
         $this->productRepository = $productRepository;
         $this->orderModifier = $orderModifier;
+        $this->channelChecker = $channelChecker;
     }
 
     public function __invoke(PutOptionBasedConfigurableItemToCart $putConfigurableItemToCart): void
@@ -43,8 +49,8 @@ final class PutOptionBasedConfigurableItemToCartHandler
 
         /** @var ProductInterface $product */
         $product = $this->productRepository->findOneByCode($putConfigurableItemToCart->product());
-
         Assert::notNull($product, 'Product has not been found');
+        Assert::true($this->channelChecker->isProductInCartChannel($product, $cart), 'Product is not in same channel as cart');
 
         $productVariant = $this->getVariant($putConfigurableItemToCart->options(), $product);
 

--- a/src/Handler/Cart/PutSimpleItemToCartHandler.php
+++ b/src/Handler/Cart/PutSimpleItemToCartHandler.php
@@ -8,6 +8,7 @@ use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\ProductInterface;
 use Sylius\Component\Core\Repository\OrderRepositoryInterface;
 use Sylius\Component\Core\Repository\ProductRepositoryInterface;
+use Sylius\ShopApiPlugin\Checker\ProductInCartChannelCheckerInterface;
 use Sylius\ShopApiPlugin\Command\Cart\PutSimpleItemToCart;
 use Sylius\ShopApiPlugin\Modifier\OrderModifierInterface;
 use Webmozart\Assert\Assert;
@@ -23,27 +24,32 @@ final class PutSimpleItemToCartHandler
     /** @var OrderModifierInterface */
     private $orderModifier;
 
+    /** @var ProductInCartChannelCheckerInterface */
+    private $channelChecker;
+
     public function __construct(
         OrderRepositoryInterface $cartRepository,
         ProductRepositoryInterface $productRepository,
-        OrderModifierInterface $orderModifier
+        OrderModifierInterface $orderModifier,
+        ProductInCartChannelCheckerInterface $channelChecker
     ) {
         $this->cartRepository = $cartRepository;
         $this->productRepository = $productRepository;
         $this->orderModifier = $orderModifier;
+        $this->channelChecker = $channelChecker;
     }
 
     public function __invoke(PutSimpleItemToCart $putSimpleItemToCart): void
     {
         /** @var OrderInterface $cart */
         $cart = $this->cartRepository->findOneBy(['tokenValue' => $putSimpleItemToCart->orderToken()]);
-
         Assert::notNull($cart, 'Cart has not been found');
 
         /** @var ProductInterface $product */
         $product = $this->productRepository->findOneBy(['code' => $putSimpleItemToCart->product()]);
-
         Assert::notNull($product, 'Product has not been found');
+
+        Assert::true($this->channelChecker->isProductInCartChannel($product, $cart), 'Product is not in same channel as cart');
         Assert::true($product->isSimple(), 'Product has to be simple');
 
         $productVariant = $product->getVariants()[0];

--- a/src/Request/Cart/PutOptionBasedConfigurableItemToCartRequest.php
+++ b/src/Request/Cart/PutOptionBasedConfigurableItemToCartRequest.php
@@ -31,6 +31,16 @@ class PutOptionBasedConfigurableItemToCartRequest implements RequestInterface
         $this->quantity = $quantity;
     }
 
+    public function getProductCode(): string
+    {
+        return $this->productCode ?? '';
+    }
+
+    public function getToken(): string
+    {
+        return $this->token;
+    }
+
     public static function fromArray(array $item): self
     {
         return new self(

--- a/src/Request/Cart/PutSimpleItemToCartRequest.php
+++ b/src/Request/Cart/PutSimpleItemToCartRequest.php
@@ -27,6 +27,16 @@ class PutSimpleItemToCartRequest implements RequestInterface
         $this->quantity = $quantity;
     }
 
+    public function getProductCode(): string
+    {
+        return $this->productCode ?? '';
+    }
+
+    public function getToken(): string
+    {
+        return $this->token;
+    }
+
     public static function fromArray(array $item): self
     {
         return new self(

--- a/src/Request/Cart/PutVariantBasedConfigurableItemToCartRequest.php
+++ b/src/Request/Cart/PutVariantBasedConfigurableItemToCartRequest.php
@@ -31,6 +31,16 @@ class PutVariantBasedConfigurableItemToCartRequest implements RequestInterface
         $this->quantity = $quantity;
     }
 
+    public function getProductCode(): string
+    {
+        return $this->productCode ?? '';
+    }
+
+    public function getToken(): string
+    {
+        return $this->token;
+    }
+
     public static function fromArray(array $item): self
     {
         return new self(

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -15,6 +15,7 @@
     <imports>
         <import resource="services/command_providers.xml"/>
         <import resource="services/controllers.xml"/>
+        <import resource="services/checker.xml"/>
         <import resource="services/factories.xml"/>
         <import resource="services/handlers.xml"/>
         <import resource="services/http.xml"/>
@@ -26,17 +27,6 @@
     </imports>
     <services>
         <defaults public="true" />
-
-        <service id="sylius.shop_api_plugin.checker.promotion_coupon_eligibility_checker"
-                 class="Sylius\ShopApiPlugin\Checker\PromotionCouponEligibilityChecker">
-            <argument type="service" id="sylius.promotion_eligibility_checker"/>
-            <argument type="service" id="sylius.promotion_coupon_eligibility_checker"/>
-        </service>
-
-        <service id="sylius.shop_api_plugin.checker.channel_existence"
-                 class="Sylius\ShopApiPlugin\Checker\ChannelExistenceChecker">
-            <argument type="service" id="sylius.repository.channel"/>
-        </service>
 
         <service id="sylius.shop_api_plugin.event_listener.user_registration_listener"
                  class="Sylius\ShopApiPlugin\EventListener\UserRegistrationListener">

--- a/src/Resources/config/services/checker.xml
+++ b/src/Resources/config/services/checker.xml
@@ -1,0 +1,13 @@
+<container xmlns="http://symfony.com/schema/dic/services">
+    <imports>
+        <import resource="checker/**/*"/>
+    </imports>
+
+    <services>
+        <service id="sylius.shop_api_plugin.checker.promotion_coupon_eligibility_checker"
+                 class="Sylius\ShopApiPlugin\Checker\PromotionCouponEligibilityChecker">
+            <argument type="service" id="sylius.promotion_eligibility_checker"/>
+            <argument type="service" id="sylius.promotion_coupon_eligibility_checker"/>
+        </service>
+    </services>
+</container>

--- a/src/Resources/config/services/checker/channel.xml
+++ b/src/Resources/config/services/checker/channel.xml
@@ -1,0 +1,11 @@
+<container xmlns="http://symfony.com/schema/dic/services">
+    <services>
+        <service id="sylius.shop_api_plugin.checker.channel_existence"
+                 class="Sylius\ShopApiPlugin\Checker\ChannelExistenceChecker">
+            <argument type="service" id="sylius.repository.channel"/>
+        </service>
+
+        <service id="sylius.shop_api_plugin.checker.product_in_cart_channel_checker"
+                 class="Sylius\ShopApiPlugin\Checker\ProductInCartChannelChecker" />
+    </services>
+</container>

--- a/src/Resources/config/services/handler/cart.xml
+++ b/src/Resources/config/services/handler/cart.xml
@@ -30,6 +30,7 @@
             <argument type="service" id="sylius.repository.order"/>
             <argument type="service" id="sylius.repository.product"/>
             <argument type="service" id="sylius.shop_api_plugin.modifier.order_modifier"/>
+            <argument type="service" id="sylius.shop_api_plugin.checker.product_in_cart_channel_checker" />
             <tag name="messenger.message_handler" />
         </service>
 
@@ -38,6 +39,7 @@
             <argument type="service" id="sylius.repository.order"/>
             <argument type="service" id="sylius.repository.product_variant"/>
             <argument type="service" id="sylius.shop_api_plugin.modifier.order_modifier"/>
+            <argument type="service" id="sylius.shop_api_plugin.checker.product_in_cart_channel_checker" />
             <tag name="messenger.message_handler" />
         </service>
 
@@ -46,6 +48,7 @@
             <argument type="service" id="sylius.repository.order"/>
             <argument type="service" id="sylius.repository.product"/>
             <argument type="service" id="sylius.shop_api_plugin.modifier.order_modifier"/>
+            <argument type="service" id="sylius.shop_api_plugin.checker.product_in_cart_channel_checker" />
             <tag name="messenger.message_handler" />
         </service>
 

--- a/src/Resources/config/services/validators/product.xml
+++ b/src/Resources/config/services/validators/product.xml
@@ -24,5 +24,13 @@
             <argument type="service" id="sylius.repository.product"/>
             <tag name="validator.constraint_validator" alias="sylius_shop_api_product_exists_validator"/>
         </service>
+
+        <service id="sylius.shop_api_plugin.validator.product_in_cart_channel_validator"
+                 class="Sylius\ShopApiPlugin\Validator\Product\ProductInCartChannelValidator">
+            <argument type="service" id="sylius.shop_api_plugin.checker.product_in_cart_channel_checker" />
+            <argument type="service" id="sylius.repository.product" />
+            <argument type="service" id="sylius.repository.order" />
+            <tag name="validator.constraint_validator" alias="sylius_shop_api_product_in_cart_channel_validator" />
+        </service>
     </services>
 </container>

--- a/src/Resources/config/validation/cart/PutOptionBasedConfigutableItemToCartRequest.xml
+++ b/src/Resources/config/validation/cart/PutOptionBasedConfigutableItemToCartRequest.xml
@@ -13,6 +13,8 @@
 
 <constraint-mapping xmlns="http://symfony.com/schema/dic/constraint-mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/constraint-mapping http://symfony.com/schema/dic/services/constraint-mapping-1.0.xsd">
     <class name="Sylius\ShopApiPlugin\Request\Cart\PutOptionBasedConfigurableItemToCartRequest">
+        <constraint name="Sylius\ShopApiPlugin\Validator\Constraints\ProductInCartChannel" />
+
         <property name="token">
             <constraint name="NotNull">
                 <option name="message">sylius.shop_api.token.not_null</option>

--- a/src/Resources/config/validation/cart/PutSimpleItemToCartRequest.xml
+++ b/src/Resources/config/validation/cart/PutSimpleItemToCartRequest.xml
@@ -13,6 +13,8 @@
 
 <constraint-mapping xmlns="http://symfony.com/schema/dic/constraint-mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/constraint-mapping http://symfony.com/schema/dic/services/constraint-mapping-1.0.xsd">
     <class name="Sylius\ShopApiPlugin\Request\Cart\PutSimpleItemToCartRequest">
+        <constraint name="Sylius\ShopApiPlugin\Validator\Constraints\ProductInCartChannel" />
+
         <property name="token">
             <constraint name="NotNull">
                 <option name="message">sylius.shop_api.token.not_null</option>

--- a/src/Resources/config/validation/cart/PutVariantBasedConfigutableItemToCartRequest.xml
+++ b/src/Resources/config/validation/cart/PutVariantBasedConfigutableItemToCartRequest.xml
@@ -13,6 +13,8 @@
 
 <constraint-mapping xmlns="http://symfony.com/schema/dic/constraint-mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/constraint-mapping http://symfony.com/schema/dic/services/constraint-mapping-1.0.xsd">
     <class name="Sylius\ShopApiPlugin\Request\Cart\PutVariantBasedConfigurableItemToCartRequest">
+        <constraint name="Sylius\ShopApiPlugin\Validator\Constraints\ProductInCartChannel" />
+
         <property name="token">
             <constraint name="NotNull">
                 <option name="message">sylius.shop_api.token.not_null</option>

--- a/src/Validator/Constraints/ProductInCartChannel.php
+++ b/src/Validator/Constraints/ProductInCartChannel.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\ShopApiPlugin\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+
+final class ProductInCartChannel extends Constraint
+{
+    /** @var string */
+    public $message = 'sylius.shop_api.product.not_in_cart_channel';
+
+    /** {@inheritdoc} */
+    public function getTargets()
+    {
+        return self::CLASS_CONSTRAINT;
+    }
+
+    /** {@inheritdoc} */
+    public function validatedBy()
+    {
+        return 'sylius_shop_api_product_in_cart_channel_validator';
+    }
+}

--- a/src/Validator/Product/ProductInCartChannelValidator.php
+++ b/src/Validator/Product/ProductInCartChannelValidator.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\ShopApiPlugin\Validator\Product;
+
+use Sylius\Component\Core\Repository\OrderRepositoryInterface;
+use Sylius\Component\Core\Repository\ProductRepositoryInterface;
+use Sylius\ShopApiPlugin\Checker\ProductInCartChannelCheckerInterface;
+use Sylius\ShopApiPlugin\Request\Cart\PutOptionBasedConfigurableItemToCartRequest;
+use Sylius\ShopApiPlugin\Request\Cart\PutSimpleItemToCartRequest;
+use Sylius\ShopApiPlugin\Request\Cart\PutVariantBasedConfigurableItemToCartRequest;
+use Sylius\ShopApiPlugin\Validator\Constraints\ProductInCartChannel;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+final class ProductInCartChannelValidator extends ConstraintValidator
+{
+    /** @var ProductInCartChannelCheckerInterface */
+    private $productInCartChannelChecker;
+
+    /** @var ProductRepositoryInterface */
+    private $productRepository;
+
+    /** @var OrderRepositoryInterface */
+    private $cartRepository;
+
+    public function __construct(
+        ProductInCartChannelCheckerInterface $productInCartChannelChecker,
+        ProductRepositoryInterface $productRepository,
+        OrderRepositoryInterface $cartRepository
+    ) {
+        $this->productInCartChannelChecker = $productInCartChannelChecker;
+        $this->productRepository = $productRepository;
+        $this->cartRepository = $cartRepository;
+    }
+
+    /** {@inheritdoc} */
+    public function validate($value, Constraint $constraint): void
+    {
+        /** @var PutOptionBasedConfigurableItemToCartRequest|PutVariantBasedConfigurableItemToCartRequest|PutSimpleItemToCartRequest $value */
+        $product = $this->productRepository->findOneByCode($value->getProductCode());
+        $cart = $this->cartRepository->findOneBy(['tokenValue' => $value->getToken()]);
+
+        if ($product === null || $cart === null) {
+            // Handled by other validators
+            return;
+        }
+
+        if (!$this->productInCartChannelChecker->isProductInCartChannel($product, $cart)) {
+            /** @var ProductInCartChannel $constraint */
+            $this->context->buildViolation($constraint->message)
+                ->atPath('productCode')
+                ->addViolation();
+        }
+    }
+}

--- a/tests/Controller/Cart/PutItemToCartApiTest.php
+++ b/tests/Controller/Cart/PutItemToCartApiTest.php
@@ -229,6 +229,32 @@ JSON;
     /**
      * @test
      */
+    public function it_validates_if_simple_product_is_in_same_channel_as_cart(): void
+    {
+        $this->loadFixturesFromFiles(['shop.yml', 'channel.yml']);
+
+        $token = 'SDAOSLEFNWU35H3QLI5325';
+
+        /** @var MessageBusInterface $bus */
+        $bus = $this->get('sylius_shop_api_plugin.command_bus');
+        $bus->dispatch(new PickupCart($token, 'unused_channel'));
+
+        $data =
+            <<<JSON
+        {
+            "productCode": "LOGAN_MUG_CODE",
+            "quantity": 3
+        }
+JSON;
+        $this->client->request('POST', sprintf('/shop-api/carts/%s/items', $token), [], [], self::CONTENT_TYPE_HEADER, $data);
+        $response = $this->client->getResponse();
+
+        $this->assertResponse($response, 'cart/product_not_in_cart_channel', Response::HTTP_INTERNAL_SERVER_ERROR);
+    }
+
+    /**
+     * @test
+     */
     public function it_does_not_allow_to_add_product_if_cart_does_not_exists_during_add_simple_product(): void
     {
         $this->loadFixturesFromFiles(['shop.yml']);
@@ -468,6 +494,33 @@ JSON;
     /**
      * @test
      */
+    public function it_validates_if_variant_based_product_is_in_cart_channel(): void
+    {
+        $this->loadFixturesFromFiles(['shop.yml', 'channel.yml']);
+
+        $token = 'SDAOSLEFNWU35H3QLI5325';
+
+        /** @var MessageBusInterface $bus */
+        $bus = $this->get('sylius_shop_api_plugin.command_bus');
+        $bus->dispatch(new PickupCart($token, 'unused_channel'));
+
+        $data =
+            <<<JSON
+        {
+            "productCode": "LOGAN_T_SHIRT_CODE",
+            "variantCode": "SMALL_LOGAN_T_SHIRT_CODE",
+            "quantity": 3
+        }
+JSON;
+        $this->client->request('POST', sprintf('/shop-api/carts/%s/items', $token), [], [], self::CONTENT_TYPE_HEADER, $data);
+        $response = $this->client->getResponse();
+
+        $this->assertResponse($response, 'cart/product_not_in_cart_channel', Response::HTTP_INTERNAL_SERVER_ERROR);
+    }
+
+    /**
+     * @test
+     */
     public function it_validates_if_product_is_configurable_during_add_variant_based_configurable_product(): void
     {
         $this->loadFixturesFromFiles(['shop.yml']);
@@ -604,6 +657,36 @@ JSON;
         $response = $this->client->getResponse();
 
         $this->assertResponse($response, 'cart/add_product_variant_based_on_options_multiple_times_to_cart_response', Response::HTTP_CREATED);
+    }
+
+    /**
+     * @test
+     */
+    public function it_validates_product_channel_when_adding_a_product_variant_based_on_option_to_the_cart(): void
+    {
+        $this->loadFixturesFromFiles(['shop.yml', 'channel.yml']);
+
+        $token = 'SDAOSLEFNWU35H3QLI5325';
+
+        /** @var MessageBusInterface $bus */
+        $bus = $this->get('sylius_shop_api_plugin.command_bus');
+        $bus->dispatch(new PickupCart($token, 'unused_channel'));
+
+        $data =
+            <<<JSON
+        {
+            "productCode": "LOGAN_HAT_CODE",
+            "options": {
+                "HAT_SIZE": "HAT_SIZE_S",
+                "HAT_COLOR": "HAT_COLOR_RED"
+            },
+            "quantity": 3
+        }
+JSON;
+        $this->client->request('POST', sprintf('/shop-api/carts/%s/items', $token), [], [], self::CONTENT_TYPE_HEADER, $data);
+        $response = $this->client->getResponse();
+
+        $this->assertResponse($response, 'cart/product_not_in_cart_channel', Response::HTTP_INTERNAL_SERVER_ERROR);
     }
 
     /**

--- a/tests/Controller/Cart/PutItemToCartApiTest.php
+++ b/tests/Controller/Cart/PutItemToCartApiTest.php
@@ -249,7 +249,7 @@ JSON;
         $this->client->request('POST', sprintf('/shop-api/carts/%s/items', $token), [], [], self::CONTENT_TYPE_HEADER, $data);
         $response = $this->client->getResponse();
 
-        $this->assertResponse($response, 'cart/product_not_in_cart_channel', Response::HTTP_INTERNAL_SERVER_ERROR);
+        $this->assertResponse($response, 'cart/product_not_in_cart_channel', Response::HTTP_BAD_REQUEST);
     }
 
     /**
@@ -515,7 +515,7 @@ JSON;
         $this->client->request('POST', sprintf('/shop-api/carts/%s/items', $token), [], [], self::CONTENT_TYPE_HEADER, $data);
         $response = $this->client->getResponse();
 
-        $this->assertResponse($response, 'cart/product_not_in_cart_channel', Response::HTTP_INTERNAL_SERVER_ERROR);
+        $this->assertResponse($response, 'cart/product_not_in_cart_channel', Response::HTTP_BAD_REQUEST);
     }
 
     /**
@@ -686,7 +686,7 @@ JSON;
         $this->client->request('POST', sprintf('/shop-api/carts/%s/items', $token), [], [], self::CONTENT_TYPE_HEADER, $data);
         $response = $this->client->getResponse();
 
-        $this->assertResponse($response, 'cart/product_not_in_cart_channel', Response::HTTP_INTERNAL_SERVER_ERROR);
+        $this->assertResponse($response, 'cart/product_not_in_cart_channel', Response::HTTP_BAD_REQUEST);
     }
 
     /**

--- a/tests/DataFixtures/ORM/channel.yml
+++ b/tests/DataFixtures/ORM/channel.yml
@@ -23,6 +23,17 @@ Sylius\Component\Core\Model\Channel:
         enabled: true
         taxCalculationStrategy: "order_items_based"
         accountVerificationRequired: false
+    unused_channel:
+        code: "unused_channel"
+        name: "Channel that is not used in a product"
+        hostname: "localhost"
+        description: "Lorem ipsum"
+        baseCurrency: "@euro"
+        defaultLocale: "@locale_de_de"
+        locales: ["@locale_de_de"]
+        color: "red"
+        enabled: true
+        taxCalculationStrategy: "order_items_based"
 
 Sylius\Component\Currency\Model\Currency:
     pound:

--- a/tests/DataFixtures/ORM/shop.yml
+++ b/tests/DataFixtures/ORM/shop.yml
@@ -38,7 +38,7 @@ Sylius\Component\Core\Model\Product:
     mug:
         code: "LOGAN_MUG_CODE"
         createdAt: "<date_create('2019-02-01 03:00:00')>"
-        channels: ["@gb_web_channel"]
+        channels: ["@gb_web_channel", "@de_web_channel"]
         currentLocale: "en_GB"
         translations: ["@en_gb_mug_product_translation", "@de_de_mug_product_translation"]
         images: ["@mug_thumbnail"]
@@ -60,7 +60,7 @@ Sylius\Component\Core\Model\Product:
     hat:
         code: "LOGAN_HAT_CODE"
         createdAt: "<date_create('2019-02-01 04:00:00')>"
-        channels: ["@gb_web_channel"]
+        channels: ["@gb_web_channel", "@de_web_channel"]
         options: ["@hat_size"]
         currentLocale: "en_GB"
         translations: ["@en_gb_hat_product_translation", "@de_de_hat_product_translation"]

--- a/tests/Responses/Expected/cart/product_not_in_cart_channel.json
+++ b/tests/Responses/Expected/cart/product_not_in_cart_channel.json
@@ -1,4 +1,9 @@
 {
-    "code": 500,
-    "message": "Product is not in same channel as cart"
+    "code": 400,
+    "message": "Validation failed",
+    "errors": {
+        "productCode": [
+            "sylius.shop_api.product.not_in_cart_channel"
+        ]
+    }
 }

--- a/tests/Responses/Expected/cart/product_not_in_cart_channel.json
+++ b/tests/Responses/Expected/cart/product_not_in_cart_channel.json
@@ -1,0 +1,4 @@
+{
+    "code": 500,
+    "message": "Product is not in same channel as cart"
+}


### PR DESCRIPTION
Fixes #59 

## What does it do?
Currently you can add any product to any cart. After this pull request the product needs to be available in the cart's channel. So that if a product is in channel A and the cart is picked up in channel B then the product-add endpoint will now throw an error (500).

## Why a 500 and not a 400 with validation errors?
The problem is that the Validation would need to take two properties of the request into consideration: the current cart token, the product code. Which means that it has to be a "Class Constraint" and needs to access properties of the request object. This is currently not possible as the current request objects don't have getter and the properties are private. So there is no way of validating them. Therefore this pull request only adds an assertion that it is true. (validation may follow if it will be possible to do so in the future)

PS: @JakobTolkemit you might be interested.