### PR TITLE
Fix CartBlamerListener without token

### DIFF
--- a/doc/swagger.yml
+++ b/doc/swagger.yml
@@ -1592,6 +1592,11 @@ definitions:
             password:
                 type: "string"
                 example: "test12334verysecure"
+            token:
+                type: "string"
+                description: "The token of the current cart which should be assign to the customer"
+                example: "SDAOSLEFNWU35H3QLI5325"
+                required: false
     UpdateUserRequest:
         type: "object"
         properties:

--- a/doc/swagger.yml
+++ b/doc/swagger.yml
@@ -1585,6 +1585,9 @@ definitions:
                 example: "WEB_GB"
     LoginRequest:
         type: "object"
+        required:
+            - email
+            - password
         properties:
             email:
                 type: "string"
@@ -1596,7 +1599,6 @@ definitions:
                 type: "string"
                 description: "The token of the current cart which should be assign to the customer"
                 example: "SDAOSLEFNWU35H3QLI5325"
-                required: false
     UpdateUserRequest:
         type: "object"
         properties:

--- a/src/EventListener/CartBlamerListener.php
+++ b/src/EventListener/CartBlamerListener.php
@@ -46,6 +46,10 @@ final class CartBlamerListener
 
         $token = $request->request->get('token');
 
+        if (!$token) {
+            return;
+        }
+
         $cart = $this->cartRepository->findOneBy(['tokenValue' => $token]);
 
         if (null === $cart) {

--- a/tests/Controller/Customer/LoginApiTest.php
+++ b/tests/Controller/Customer/LoginApiTest.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Tests\Sylius\ShopApiPlugin\Controller\Customer;
 
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Repository\OrderRepositoryInterface;
+use Sylius\Component\Resource\Factory\FactoryInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Tests\Sylius\ShopApiPlugin\Controller\JsonApiTestCase;
@@ -68,6 +71,43 @@ JSON;
 
         $response = $this->client->getResponse();
         $this->assertResponse($response, 'customer/bad_credentials_response', Response::HTTP_UNAUTHORIZED);
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_blow_up_if_empty_carts_exists_in_database(): void
+    {
+        $this->loadFixturesFromFiles(['shop.yml', 'customer.yml']);
+
+        /** @var OrderRepositoryInterface $orderRepository */
+        $orderRepository = $this->get('sylius.repository.order');
+        /** @var FactoryInterface $orderFactory */
+        $orderFactory = $this->get('sylius.factory.order');
+
+        /** @var OrderInterface $resource */
+        $resource = $orderFactory->createNew();
+        $resource->setCurrencyCode('EUR');
+        $resource->setLocaleCode('en_US');
+        $orderRepository->add($resource);
+        /** @var OrderInterface $resource */
+        $resource = $orderFactory->createNew();
+        $resource->setCurrencyCode('EUR');
+        $resource->setLocaleCode('en_US');
+        $orderRepository->add($resource);
+
+        $data =
+<<<JSON
+        {
+            "email": "oliver@queen.com",
+            "password": "123password"
+        }
+JSON;
+
+        $this->client->request('POST', '/shop-api/login', [], [], self::CONTENT_TYPE_HEADER, $data);
+
+        $response = $this->client->getResponse();
+        $this->assertResponse($response, 'customer/customer_log_in_response', Response::HTTP_OK);
     }
 
     protected function getContainer(): ContainerInterface


### PR DESCRIPTION
Carts which are not created over the ShopApi have no tokenValue so if you try to login it will accidently try to assign a Cart which is not the one of the current value.

So a cart should only tried to be loaded when the $token is given to the api.