### PR TITLE
Handle registration for exist customer

### DIFF
--- a/src/Handler/Customer/RegisterCustomerHandler.php
+++ b/src/Handler/Customer/RegisterCustomerHandler.php
@@ -5,13 +5,12 @@ declare(strict_types=1);
 namespace Sylius\ShopApiPlugin\Handler\Customer;
 
 use Sylius\Component\Channel\Repository\ChannelRepositoryInterface;
-use Sylius\Component\Core\Model\CustomerInterface;
 use Sylius\Component\Core\Model\ShopUserInterface;
-use Sylius\Component\Core\Repository\CustomerRepositoryInterface;
 use Sylius\Component\Resource\Factory\FactoryInterface;
 use Sylius\Component\User\Repository\UserRepositoryInterface;
 use Sylius\ShopApiPlugin\Command\Customer\RegisterCustomer;
 use Sylius\ShopApiPlugin\Event\CustomerRegistered;
+use Sylius\ShopApiPlugin\Provider\CustomerProviderInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Webmozart\Assert\Assert;
 
@@ -23,32 +22,27 @@ final class RegisterCustomerHandler
     /** @var ChannelRepositoryInterface */
     private $channelRepository;
 
-    /** @var CustomerRepositoryInterface */
-    private $customerRepository;
-
     /** @var FactoryInterface */
     private $userFactory;
-
-    /** @var FactoryInterface */
-    private $customerFactory;
 
     /** @var EventDispatcherInterface */
     private $eventDispatcher;
 
+    /** @var CustomerProviderInterface */
+    private $customerProvider;
+
     public function __construct(
         UserRepositoryInterface $userRepository,
         ChannelRepositoryInterface $channelRepository,
-        CustomerRepositoryInterface $customerRepository,
         FactoryInterface $userFactory,
-        FactoryInterface $customerFactory,
-        EventDispatcherInterface $eventDispatcher
+        EventDispatcherInterface $eventDispatcher,
+        CustomerProviderInterface $customerProvider
     ) {
         $this->userRepository = $userRepository;
         $this->channelRepository = $channelRepository;
-        $this->customerRepository = $customerRepository;
         $this->userFactory = $userFactory;
-        $this->customerFactory = $customerFactory;
         $this->eventDispatcher = $eventDispatcher;
+        $this->customerProvider = $customerProvider;
     }
 
     public function __invoke(RegisterCustomer $command): void
@@ -56,12 +50,7 @@ final class RegisterCustomerHandler
         $this->assertEmailIsNotTaken($command->email());
         $this->assertChannelExists($command->channelCode());
 
-        /** @var CustomerInterface|null $customer */
-        $customer = $this->customerRepository->findOneBy(['email' => $command->email()]);
-        if (!$customer) {
-            /** @var CustomerInterface $customer */
-            $customer = $this->customerFactory->createNew();
-        }
+        $customer = $this->customerProvider->provide($command->email());
 
         $customer->setFirstName($command->firstName());
         $customer->setLastName($command->lastName());

--- a/src/Provider/ShopUserAwareCustomerProvider.php
+++ b/src/Provider/ShopUserAwareCustomerProvider.php
@@ -59,7 +59,7 @@ final class ShopUserAwareCustomerProvider implements CustomerProviderInterface
         }
 
         if ($customer->getUser() !== null) {
-            throw new WrongUserException('Customer already registered. Please log in to finish checkout.');
+            throw new WrongUserException('Customer already registered.');
         }
 
         return $customer;

--- a/src/Resources/config/services/handler/customer.xml
+++ b/src/Resources/config/services/handler/customer.xml
@@ -6,6 +6,7 @@
                  class="Sylius\ShopApiPlugin\Handler\Customer\RegisterCustomerHandler">
             <argument type="service" id="sylius.repository.shop_user"/>
             <argument type="service" id="sylius.repository.channel"/>
+            <argument type="service" id="sylius.repository.customer"/>
             <argument type="service" id="sylius.factory.shop_user"/>
             <argument type="service" id="sylius.factory.customer"/>
             <argument type="service" id="event_dispatcher"/>

--- a/src/Resources/config/services/handler/customer.xml
+++ b/src/Resources/config/services/handler/customer.xml
@@ -6,10 +6,9 @@
                  class="Sylius\ShopApiPlugin\Handler\Customer\RegisterCustomerHandler">
             <argument type="service" id="sylius.repository.shop_user"/>
             <argument type="service" id="sylius.repository.channel"/>
-            <argument type="service" id="sylius.repository.customer"/>
             <argument type="service" id="sylius.factory.shop_user"/>
-            <argument type="service" id="sylius.factory.customer"/>
             <argument type="service" id="event_dispatcher"/>
+            <argument type="service" id="sylius.shop_api_plugin.provider.customer_provider"/>
             <tag name="messenger.message_handler" />
         </service>
 


### PR DESCRIPTION
Closes #533

This would handle the registration process like Standard Sylius that a Customer is set to the User if the E-Mail Address exist as a customer. Currently you are not able to register if you did an anonymous order over the shop api.