### PR TITLE
Extending customer details tests

### DIFF
--- a/src/Command/Customer/UpdateCustomer.php
+++ b/src/Command/Customer/UpdateCustomer.php
@@ -45,7 +45,7 @@ class UpdateCustomer implements CommandInterface
         $this->birthday = $birthday;
         $this->gender = $gender;
         $this->phoneNumber = $phoneNumber;
-        $this->subscribedToNewsletter = $subscribedToNewsletter;
+        $this->subscribedToNewsletter = $subscribedToNewsletter ?? false;
     }
 
     public function firstName(): string

--- a/tests/Controller/Customer/LoggedInCustomerDetailsActionTest.php
+++ b/tests/Controller/Customer/LoggedInCustomerDetailsActionTest.php
@@ -6,9 +6,12 @@ namespace Tests\Sylius\ShopApiPlugin\Controller\Customer;
 
 use Symfony\Component\HttpFoundation\Response;
 use Tests\Sylius\ShopApiPlugin\Controller\JsonApiTestCase;
+use Tests\Sylius\ShopApiPlugin\Controller\Utils\ShopUserLoginTrait;
 
 final class LoggedInCustomerDetailsActionTest extends JsonApiTestCase
 {
+    use ShopUserLoginTrait;
+
     /**
      * @test
      */
@@ -16,25 +19,9 @@ final class LoggedInCustomerDetailsActionTest extends JsonApiTestCase
     {
         $this->loadFixturesFromFiles(['channel.yml', 'customer.yml']);
 
-        $data =
-            <<<JSON
-        {
-            "email": "oliver@queen.com",
-            "password": "123password"
-        }
-JSON;
+        $this->logInUser('oliver@queen.com', '123password');
 
-        $this->client->request('POST', '/shop-api/login', [], [], self::CONTENT_TYPE_HEADER, $data);
-
-        $response = json_decode($this->client->getResponse()->getContent(), true);
-        $this->client->setServerParameter('HTTP_Authorization', sprintf('Bearer %s', $response['token']));
-
-        $this->client->request('GET', '/shop-api/me', [], [], [
-            'CONTENT_TYPE' => 'application/json',
-            'ACCEPT' => 'application/json',
-        ]);
-
-        $response = $this->client->getResponse();
+        $response = $this->getCustomerDetails();
         $this->assertResponse($response, 'customer/logged_in_customer_details_response', Response::HTTP_OK);
     }
 
@@ -45,20 +32,14 @@ JSON;
     {
         $this->loadFixturesFromFiles(['channel.yml', 'customer.yml']);
 
-        $data =
-            <<<JSON
-        {
-            "email": "oliver@queen.com",
-            "password": "123password"
-        }
-JSON;
-
-        $this->client->request('GET', '/shop-api/me', [], [], [
-            'CONTENT_TYPE' => 'application/json',
-            'ACCEPT' => 'application/json',
-        ]);
-
-        $response = $this->client->getResponse();
+        $response = $this->getCustomerDetails();
         $this->assertResponseCode($response, Response::HTTP_UNAUTHORIZED);
+    }
+
+    private function getCustomerDetails(): Response
+    {
+        $this->client->request('GET', '/shop-api/me', [], [], self::CONTENT_TYPE_HEADER);
+
+        return $this->client->getResponse();
     }
 }

--- a/tests/Controller/Customer/UpdateCustomerApiTest.php
+++ b/tests/Controller/Customer/UpdateCustomerApiTest.php
@@ -53,6 +53,40 @@ JSON;
         Assert::assertEquals($customer->isSubscribedToNewsletter(), true);
     }
 
+    public function it_updates_customer_when_newsletter_is_not_set(): void
+    {
+        $this->loadFixturesFromFiles(['channel.yml', 'customer.yml']);
+        $this->logInUser('oliver@queen.com', '123password');
+
+        /** @var CustomerRepositoryInterface $customerRepository */
+        $customerRepository = $this->get('sylius.repository.customer');
+
+        $data =
+<<<JSON
+        {
+            "firstName": "New name",
+            "lastName": "New lastName",
+            "birthday": "2017-11-01",
+            "gender": "m",
+            "phoneNumber": "0918972132",
+        }
+JSON;
+        $this->client->request('PUT', '/shop-api/me', [], [], self::CONTENT_TYPE_HEADER, $data);
+        $response = $this->client->getResponse();
+        $this->assertResponse($response, 'customer/update_customer', Response::HTTP_OK);
+
+        /** @var CustomerInterface $customer */
+        $customer = $customerRepository->findOneByEmail('oliver@queen.com');
+
+        Assert::assertEquals($customer->getFirstName(), 'New name');
+        Assert::assertEquals($customer->getLastName(), 'New lastName');
+        Assert::assertEquals($customer->getEmail(), 'oliver@queen.com');
+        Assert::assertEquals($customer->getBirthday(), new \DateTimeImmutable('2017-11-01'));
+        Assert::assertEquals($customer->getGender(), 'm');
+        Assert::assertEquals($customer->getPhoneNumber(), '0918972132');
+        Assert::assertEquals($customer->isSubscribedToNewsletter(), false);
+    }
+
     /**
      * @test
      */

--- a/tests/DataFixtures/ORM/customer.yml
+++ b/tests/DataFixtures/ORM/customer.yml
@@ -24,6 +24,7 @@ Sylius\Component\Core\Model\Customer:
         gender: "m"
         group: "@retail"
         phoneNumber: "0212115512"
+        birthday: <dateTimeBetween("-200 days", "now")>
 
     hater:
         firstName: "Slade"

--- a/tests/Responses/Expected/address_book/add_address_response.json
+++ b/tests/Responses/Expected/address_book/add_address_response.json
@@ -15,6 +15,7 @@
         "firstName": "Oliver",
         "lastName": "Queen",
         "gender": "m",
+        "birthday": "@string@.isDateTime()",
         "group": {
             "id": @integer@,
             "code": "retail",

--- a/tests/Responses/Expected/address_book/show_address_book_response.json
+++ b/tests/Responses/Expected/address_book/show_address_book_response.json
@@ -17,6 +17,7 @@
             "firstName": "Oliver",
             "lastName": "Queen",
             "gender": "m",
+            "birthday": "@string@.isDateTime()",
             "group": {
                 "id": @integer@,
                 "code": "retail",
@@ -56,6 +57,7 @@
             "firstName": "Oliver",
             "lastName": "Queen",
             "gender": "m",
+            "birthday": "@string@.isDateTime()",
             "group": {
                 "id": @integer@,
                 "code": "retail",
@@ -95,6 +97,7 @@
             "firstName": "Oliver",
             "lastName": "Queen",
             "gender": "m",
+            "birthday": "@string@.isDateTime()",
             "group": {
                 "id": @integer@,
                 "code": "retail",

--- a/tests/Responses/Expected/customer/logged_in_customer_details_response.json
+++ b/tests/Responses/Expected/customer/logged_in_customer_details_response.json
@@ -4,6 +4,7 @@
     "lastName": "Queen",
     "email": "oliver@queen.com",
     "gender": "m",
+    "birthday": "@string@.isDateTime()",
     "phoneNumber": "0212115512",
     "subscribedToNewsletter": false
 }

--- a/tests/Responses/Expected/customer/update_customer.json
+++ b/tests/Responses/Expected/customer/update_customer.json
@@ -1,9 +1,9 @@
 {
-    "id": @integer@,
+    "id": "@integer@",
     "firstName": "New name",
     "lastName": "New lastName",
     "email": "oliver@queen.com",
-    "birthday": "@string@",
+    "birthday": "@string@.isDateTime()",
     "gender": "m",
     "phoneNumber": "0918972132",
     "subscribedToNewsletter": true


### PR DESCRIPTION
This PR fixes/changes the folloing things:
* (DX) In the tests the customer details test the login request is replaced with the trait that does the request
* (DX) Removed credentials from "customer is not logged in" test.
* (DX) Extracted requesting the endpoint into a function (and now with globally defined `CONTENT_TYPE_HEADER`)
* Fixing type bug. If you instanciate the `UpdateCustomer` with null for `subscribedToNewsletter` then the getter for it will crash as null is not part of the return type.