### PR TITLE
Fixing dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,9 @@
         "symfony/web-profiler-bundle": "^4.1",
         "symfony/web-server-bundle": "^4.1"
     },
+    "conflict": {
+        "phpstan/phpstan-webmozart-assert": "^0.11.3"
+    },
     "autoload": {
         "psr-4": {
             "Sylius\\ShopApiPlugin\\": "src/"

--- a/src/Mailer/Emails.php
+++ b/src/Mailer/Emails.php
@@ -7,6 +7,7 @@ namespace Sylius\ShopApiPlugin\Mailer;
 final class Emails
 {
     public const EMAIL_VERIFICATION_TOKEN = 'api_verification_token';
+
     public const EMAIL_RESET_PASSWORD_TOKEN = 'api_reset_password_token';
 
     private function __construct()


### PR DESCRIPTION
In the most recent version of phpstan's assert implementation the "implements" assertion has been added this howerver does not work with the current usage. I already made a pull request to fix it but other than that we need to exclude this version until it's fixed.