### PR TITLE
Loosen dep constraint for Symfony messenger component

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
 
         "sylius/sylius": "^1.4",
         "lexik/jwt-authentication-bundle": "^2.5",
-        "symfony/messenger": "~4.3.0"
+        "symfony/messenger": "^4.3"
     },
     "require-dev": {
         "lchrusciel/api-test-case": "^4.0",


### PR DESCRIPTION
This pull request aligns the constraint of the Symfony messenger component required by ShopApiPlugin with the other Symfony constraints from Sylius main package. (And therefor allows to upgrade to v4.4 of Symfony's messenger component.)