### PR TITLE
Check order integrity on checkout complete

### DIFF
--- a/spec/Command/Cart/CompleteOrderWithCustomerSpec.php
+++ b/spec/Command/Cart/CompleteOrderWithCustomerSpec.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\Sylius\ShopApiPlugin\Command\Cart;
+
+use PhpSpec\ObjectBehavior;
+
+final class CompleteOrderWithCustomerSpec extends ObjectBehavior
+{
+    function let(): void
+    {
+        $this->beConstructedWith('ORDERTOKEN', 'test@example.com');
+    }
+
+    function it_has_order_token(): void
+    {
+        $this->orderToken()->shouldReturn('ORDERTOKEN');
+    }
+
+    function it_has_email(): void
+    {
+        $this->email()->shouldReturn('test@example.com');
+    }
+
+    function it_can_have_a_note(): void
+    {
+        $this->beConstructedWith('ORDERTOKEN', 'test@example.com', 'Some order notes');
+
+        $this->notes()->shouldReturn('Some order notes');
+    }
+}

--- a/spec/Handler/Cart/CompleteOrderWithCustomerHandlerSpec.php
+++ b/spec/Handler/Cart/CompleteOrderWithCustomerHandlerSpec.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\Sylius\ShopApiPlugin\Handler\Cart;
+
+use PhpSpec\ObjectBehavior;
+use SM\Factory\FactoryInterface as StateMachineFactoryInterface;
+use SM\StateMachine\StateMachineInterface;
+use Sylius\Component\Core\Model\CustomerInterface;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\OrderCheckoutTransitions;
+use Sylius\Component\Core\Repository\OrderRepositoryInterface;
+use Sylius\Component\Order\Processor\OrderProcessorInterface;
+use Sylius\ShopApiPlugin\Command\Cart\CompleteOrderWithCustomer;
+use Sylius\ShopApiPlugin\Provider\CustomerProviderInterface;
+
+final class CompleteOrderWithCustomerHandlerSpec extends ObjectBehavior
+{
+    function let(
+        OrderRepositoryInterface $orderRepository,
+        StateMachineFactoryInterface $stateMachineFactory,
+        OrderProcessorInterface $orderProcessor,
+        CustomerProviderInterface $customerProvider
+    ): void {
+        $this->beConstructedWith(
+            $orderRepository,
+            $stateMachineFactory,
+            $orderProcessor,
+            $customerProvider
+        );
+    }
+
+    function it_handles_order_completion_with_customer_assignment(
+        OrderInterface $order,
+        CustomerProviderInterface $customerProvider,
+        CustomerInterface $customer,
+        OrderRepositoryInterface $orderRepository,
+        StateMachineFactoryInterface $stateMachineFactory,
+        StateMachineInterface $stateMachine
+    ): void {
+        $orderRepository->findOneBy(['tokenValue' => 'ORDERTOKEN'])->willReturn($order);
+        $customerProvider->provide('john@doe.com')->willReturn($customer);
+
+        $order->setCustomer($customer)->shouldBeCalled();
+
+        $stateMachineFactory->get($order, OrderCheckoutTransitions::GRAPH)->willReturn($stateMachine);
+        $stateMachine->can('complete')->willReturn(true);
+
+        $order->setNotes(null)->shouldBeCalled();
+        $stateMachine->apply('complete')->shouldBeCalled();
+
+        $this(new CompleteOrderWithCustomer('ORDERTOKEN', 'john@doe.com'));
+    }
+
+    function it_handles_order_completion_with_notes(
+        OrderInterface $order,
+        CustomerProviderInterface $customerProvider,
+        CustomerInterface $customer,
+        OrderRepositoryInterface $orderRepository,
+        StateMachineFactoryInterface $stateMachineFactory,
+        StateMachineInterface $stateMachine
+    ): void {
+        $orderRepository->findOneBy(['tokenValue' => 'ORDERTOKEN'])->willReturn($order);
+        $customerProvider->provide('john@doe.com')->willReturn($customer);
+
+        $order->setCustomer($customer)->shouldBeCalled();
+
+        $stateMachineFactory->get($order, OrderCheckoutTransitions::GRAPH)->willReturn($stateMachine);
+        $stateMachine->can('complete')->willReturn(true);
+
+        $order->setNotes('Some notes')->shouldBeCalled();
+        $stateMachine->apply('complete')->shouldBeCalled();
+
+        $this(new CompleteOrderWithCustomer('ORDERTOKEN', 'john@doe.com', 'Some notes'));
+    }
+
+    function it_throws_an_exception_if_order_does_not_exist(
+        OrderRepositoryInterface $orderRepository
+    ): void {
+        $orderRepository->findOneBy(['tokenValue' => 'ORDERTOKEN'])->willReturn(null);
+
+        $this
+            ->shouldThrow(\InvalidArgumentException::class)
+            ->during('__invoke', [new CompleteOrderWithCustomer('ORDERTOKEN', 'john@doe.com')])
+        ;
+    }
+
+    function it_throws_an_exception_if_order_cannot_be_completed(
+        StateMachineFactoryInterface $stateMachineFactory,
+        CustomerProviderInterface $customerProvider,
+        CustomerInterface $customer,
+        OrderInterface $order,
+        OrderRepositoryInterface $orderRepository,
+        StateMachineInterface $stateMachine
+    ): void {
+        $orderRepository->findOneBy(['tokenValue' => 'ORDERTOKEN'])->willReturn($order);
+        $customerProvider->provide('john@doe.com')->willReturn($customer);
+
+        $order->setCustomer($customer)->shouldBeCalled();
+
+        $stateMachineFactory->get($order, OrderCheckoutTransitions::GRAPH)->willReturn($stateMachine);
+        $stateMachine->can(OrderCheckoutTransitions::TRANSITION_COMPLETE)->willReturn(false);
+
+        $this
+            ->shouldThrow(\InvalidArgumentException::class)
+            ->during('__invoke', [new CompleteOrderWithCustomer('ORDERTOKEN', 'john@doe.com')])
+        ;
+    }
+}

--- a/spec/Handler/Cart/CompleteOrderWithCustomerHandlerSpec.php
+++ b/spec/Handler/Cart/CompleteOrderWithCustomerHandlerSpec.php
@@ -36,6 +36,7 @@ final class CompleteOrderWithCustomerHandlerSpec extends ObjectBehavior
         CustomerProviderInterface $customerProvider,
         CustomerInterface $customer,
         OrderRepositoryInterface $orderRepository,
+        OrderProcessorInterface $orderProcessor,
         StateMachineFactoryInterface $stateMachineFactory,
         StateMachineInterface $stateMachine
     ): void {
@@ -43,6 +44,7 @@ final class CompleteOrderWithCustomerHandlerSpec extends ObjectBehavior
         $customerProvider->provide('john@doe.com')->willReturn($customer);
 
         $order->setCustomer($customer)->shouldBeCalled();
+        $orderProcessor->process($order)->shouldBeCalled();
 
         $stateMachineFactory->get($order, OrderCheckoutTransitions::GRAPH)->willReturn($stateMachine);
         $stateMachine->can('complete')->willReturn(true);
@@ -58,6 +60,7 @@ final class CompleteOrderWithCustomerHandlerSpec extends ObjectBehavior
         CustomerProviderInterface $customerProvider,
         CustomerInterface $customer,
         OrderRepositoryInterface $orderRepository,
+        OrderProcessorInterface $orderProcessor,
         StateMachineFactoryInterface $stateMachineFactory,
         StateMachineInterface $stateMachine
     ): void {
@@ -65,6 +68,7 @@ final class CompleteOrderWithCustomerHandlerSpec extends ObjectBehavior
         $customerProvider->provide('john@doe.com')->willReturn($customer);
 
         $order->setCustomer($customer)->shouldBeCalled();
+        $orderProcessor->process($order)->shouldBeCalled();
 
         $stateMachineFactory->get($order, OrderCheckoutTransitions::GRAPH)->willReturn($stateMachine);
         $stateMachine->can('complete')->willReturn(true);
@@ -92,12 +96,14 @@ final class CompleteOrderWithCustomerHandlerSpec extends ObjectBehavior
         CustomerInterface $customer,
         OrderInterface $order,
         OrderRepositoryInterface $orderRepository,
+        OrderProcessorInterface $orderProcessor,
         StateMachineInterface $stateMachine
     ): void {
         $orderRepository->findOneBy(['tokenValue' => 'ORDERTOKEN'])->willReturn($order);
         $customerProvider->provide('john@doe.com')->willReturn($customer);
 
         $order->setCustomer($customer)->shouldBeCalled();
+        $orderProcessor->process($order)->shouldBeCalled();
 
         $stateMachineFactory->get($order, OrderCheckoutTransitions::GRAPH)->willReturn($stateMachine);
         $stateMachine->can(OrderCheckoutTransitions::TRANSITION_COMPLETE)->willReturn(false);

--- a/spec/Processor/SafeOrderProcessorSpec.php
+++ b/spec/Processor/SafeOrderProcessorSpec.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\Sylius\ShopApiPlugin\Processor;
+
+use Doctrine\Common\Persistence\ObjectManager;
+use PhpSpec\ObjectBehavior;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Order\Processor\OrderProcessorInterface;
+use Sylius\ShopApiPlugin\Exception\OrderTotalIntegrityException;
+
+final class SafeOrderProcessorSpec extends ObjectBehavior
+{
+    function let(OrderProcessorInterface $orderProcessor, ObjectManager $orderManager): void
+    {
+        $this->beConstructedWith($orderProcessor, $orderManager);
+    }
+
+    function it_implements_order_processor_interface(): void
+    {
+        $this->shouldImplement(OrderProcessorInterface::class);
+    }
+
+    function it_throws_exception_if_processed_order_total_has_been_changed(
+        OrderProcessorInterface $orderProcessor,
+        OrderInterface $order
+    ): void {
+        $order->getTotal()->willReturn(1000, 2000);
+
+        $orderProcessor->process($order)->shouldBeCalled();
+
+        $this->shouldThrow(OrderTotalIntegrityException::class)->during('process', [$order]);
+    }
+
+    function it_does_nothing_if_processed_order_total_has_not_been_changed(
+        OrderProcessorInterface $orderProcessor,
+        ObjectManager $orderManager,
+        OrderInterface $order
+    ): void {
+        $order->getTotal()->willReturn(1000, 1000);
+
+        $orderProcessor->process($order)->shouldBeCalled();
+        $orderManager->flush()->shouldBeCalled();
+
+        $this->shouldNotThrow(OrderTotalIntegrityException::class)->during('process', [$order]);
+    }
+}

--- a/src/Command/Cart/CompleteOrderWithCustomer.php
+++ b/src/Command/Cart/CompleteOrderWithCustomer.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\ShopApiPlugin\Command\Cart;
+
+use Sylius\ShopApiPlugin\Command\CommandInterface;
+
+class CompleteOrderWithCustomer implements CommandInterface
+{
+    /** @var string */
+    protected $orderToken;
+
+    /** @var string */
+    protected $email;
+
+    /** @var string|null */
+    protected $notes;
+
+    public function __construct(string $orderToken, string $email, ?string $notes = null)
+    {
+        $this->orderToken = $orderToken;
+        $this->email = $email;
+        $this->notes = $notes;
+    }
+
+    public function orderToken(): string
+    {
+        return $this->orderToken;
+    }
+
+    public function email(): string
+    {
+        return $this->email;
+    }
+
+    public function notes(): ?string
+    {
+        return $this->notes;
+    }
+}

--- a/src/Controller/Checkout/CompleteOrderAction.php
+++ b/src/Controller/Checkout/CompleteOrderAction.php
@@ -8,6 +8,7 @@ use FOS\RestBundle\View\View;
 use FOS\RestBundle\View\ViewHandlerInterface;
 use Sylius\ShopApiPlugin\Command\CommandInterface;
 use Sylius\ShopApiPlugin\CommandProvider\CommandProviderInterface;
+use Sylius\ShopApiPlugin\Exception\OrderTotalIntegrityException;
 use Sylius\ShopApiPlugin\Exception\WrongUserException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -57,6 +58,15 @@ final class CompleteOrderAction
                     View::create(
                         'You need to be logged in with the same user that wants to complete the order',
                         Response::HTTP_UNAUTHORIZED
+                    )
+                );
+            }
+
+            if ($previousException instanceof OrderTotalIntegrityException) {
+                return $this->viewHandler->handle(
+                    View::create(
+                        ['code' => Response::HTTP_BAD_REQUEST, 'message' => $exception->getMessage()],
+                        Response::HTTP_BAD_REQUEST
                     )
                 );
             }

--- a/src/Controller/Checkout/CompleteOrderAction.php
+++ b/src/Controller/Checkout/CompleteOrderAction.php
@@ -6,6 +6,7 @@ namespace Sylius\ShopApiPlugin\Controller\Checkout;
 
 use FOS\RestBundle\View\View;
 use FOS\RestBundle\View\ViewHandlerInterface;
+use Sylius\ShopApiPlugin\Command\CommandInterface;
 use Sylius\ShopApiPlugin\CommandProvider\CommandProviderInterface;
 use Sylius\ShopApiPlugin\Exception\WrongUserException;
 use Symfony\Component\HttpFoundation\Request;
@@ -27,26 +28,27 @@ final class CompleteOrderAction
     /** @var CommandProviderInterface */
     private $completeOrderCommandProvider;
 
+    /** @var CommandProviderInterface */
+    private $completeOrderWithCustomerCommandProvider;
+
     public function __construct(
         ViewHandlerInterface $viewHandler,
         MessageBusInterface $bus,
         CommandProviderInterface $assignCustomerToCartCommandProvider,
-        CommandProviderInterface $completeOrderCommandProvider
+        CommandProviderInterface $completeOrderCommandProvider,
+        CommandProviderInterface $completeOrderWithCustomerCommandProvider
     ) {
         $this->viewHandler = $viewHandler;
         $this->bus = $bus;
         $this->assignCustomerToCartCommandProvider = $assignCustomerToCartCommandProvider;
         $this->completeOrderCommandProvider = $completeOrderCommandProvider;
+        $this->completeOrderWithCustomerCommandProvider = $completeOrderWithCustomerCommandProvider;
     }
 
     public function __invoke(Request $request): Response
     {
         try {
-            if (null !== $request->request->get('email')) {
-                $this->bus->dispatch($this->assignCustomerToCartCommandProvider->getCommand($request));
-            }
-
-            $this->bus->dispatch($this->completeOrderCommandProvider->getCommand($request));
+            $this->bus->dispatch($this->provideCorrectCompleteOrderCommand($request));
         } catch (HandlerFailedException $exception) {
             $previousException = $exception->getPrevious();
 
@@ -63,5 +65,14 @@ final class CompleteOrderAction
         }
 
         return $this->viewHandler->handle(View::create(null, Response::HTTP_NO_CONTENT));
+    }
+
+    private function provideCorrectCompleteOrderCommand(Request $request): CommandInterface
+    {
+        if (null !== $request->request->get('email')) {
+            return $this->completeOrderWithCustomerCommandProvider->getCommand($request);
+        }
+
+        return $this->completeOrderCommandProvider->getCommand($request);
     }
 }

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -16,6 +16,7 @@ use Sylius\ShopApiPlugin\Request\Checkout\AddressOrderRequest;
 use Sylius\ShopApiPlugin\Request\Checkout\ChoosePaymentMethodRequest;
 use Sylius\ShopApiPlugin\Request\Checkout\ChooseShippingMethodRequest;
 use Sylius\ShopApiPlugin\Request\Checkout\CompleteOrderRequest;
+use Sylius\ShopApiPlugin\Request\Checkout\CompleteOrderWithCustomerRequest;
 use Sylius\ShopApiPlugin\Request\Customer\GenerateResetPasswordTokenRequest;
 use Sylius\ShopApiPlugin\Request\Customer\RegisterCustomerRequest;
 use Sylius\ShopApiPlugin\Request\Customer\ResendVerificationTokenRequest;
@@ -111,6 +112,7 @@ final class Configuration implements ConfigurationInterface
                         ->scalarNode('choose_payment_method')->defaultValue(ChoosePaymentMethodRequest::class)->end()
                         ->scalarNode('choose_shipping_method')->defaultValue(ChooseShippingMethodRequest::class)->end()
                         ->scalarNode('complete_order')->defaultValue(CompleteOrderRequest::class)->end()
+                        ->scalarNode('complete_order_with_customer')->defaultValue(CompleteOrderWithCustomerRequest::class)->end()
                         ->scalarNode('drop_cart')->defaultValue(DropCartRequest::class)->end()
                         ->scalarNode('generate_reset_password_token')->defaultValue(GenerateResetPasswordTokenRequest::class)->end()
                         ->scalarNode('pickup_cart')->defaultValue(PickupCartRequest::class)->end()

--- a/src/Exception/OrderTotalIntegrityException.php
+++ b/src/Exception/OrderTotalIntegrityException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\ShopApiPlugin\Exception;
+
+use Throwable;
+
+final class OrderTotalIntegrityException extends \RuntimeException
+{
+    public function __construct()
+    {
+        parent::__construct('Your order total has been changed, check your order information and confirm it again.');
+    }
+}

--- a/src/Handler/Cart/CompleteOrderWithCustomerHandler.php
+++ b/src/Handler/Cart/CompleteOrderWithCustomerHandler.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\ShopApiPlugin\Handler\Cart;
+
+use SM\Factory\FactoryInterface as StateMachineFactory;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\OrderCheckoutTransitions;
+use Sylius\Component\Core\Repository\OrderRepositoryInterface;
+use Sylius\Component\Order\Processor\OrderProcessorInterface;
+use Sylius\ShopApiPlugin\Command\Cart\CompleteOrderWithCustomer;
+use Sylius\ShopApiPlugin\Provider\CustomerProviderInterface;
+use Webmozart\Assert\Assert;
+
+final class CompleteOrderWithCustomerHandler
+{
+    /** @var OrderRepositoryInterface */
+    private $orderRepository;
+
+    /** @var StateMachineFactory */
+    private $stateMachineFactory;
+
+    /** @var OrderProcessorInterface */
+    private $orderProcessor;
+
+    /** @var CustomerProviderInterface */
+    private $customerProvider;
+
+    public function __construct(
+        OrderRepositoryInterface $orderRepository,
+        StateMachineFactory $stateMachineFactory,
+        OrderProcessorInterface $orderProcessor,
+        CustomerProviderInterface $customerProvider
+    ) {
+        $this->orderRepository = $orderRepository;
+        $this->stateMachineFactory = $stateMachineFactory;
+        $this->orderProcessor = $orderProcessor;
+        $this->customerProvider = $customerProvider;
+    }
+
+    public function __invoke(CompleteOrderWithCustomer $completeOrderWithCustomer): void
+    {
+        /** @var OrderInterface $order */
+        $order = $this->orderRepository->findOneBy(['tokenValue' => $completeOrderWithCustomer->orderToken()]);
+        Assert::notNull($order, sprintf('Order with %s token has not been found.', $completeOrderWithCustomer->orderToken()));
+
+        $this->assignCustomer($order, $completeOrderWithCustomer->email());
+
+        $stateMachine = $this->stateMachineFactory->get($order, OrderCheckoutTransitions::GRAPH);
+        Assert::true($stateMachine->can(OrderCheckoutTransitions::TRANSITION_COMPLETE), sprintf('Order with %s token cannot be completed.', $completeOrderWithCustomer->orderToken()));
+
+        $order->setNotes($completeOrderWithCustomer->notes());
+
+        $stateMachine->apply(OrderCheckoutTransitions::TRANSITION_COMPLETE);
+    }
+
+    private function assignCustomer(OrderInterface $order, string $email): void
+    {
+        $customer = $this->customerProvider->provide($email);
+
+        $order->setCustomer($customer);
+
+        $this->orderProcessor->process($order);
+    }
+}

--- a/src/Processor/SafeOrderProcessor.php
+++ b/src/Processor/SafeOrderProcessor.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\ShopApiPlugin\Processor;
+
+use Doctrine\Common\Persistence\ObjectManager;
+use Sylius\Component\Order\Model\OrderInterface;
+use Sylius\Component\Order\Processor\OrderProcessorInterface;
+use Sylius\ShopApiPlugin\Exception\OrderTotalIntegrityException;
+
+final class SafeOrderProcessor implements OrderProcessorInterface
+{
+    /** @var OrderProcessorInterface */
+    private $orderProcessor;
+
+    /** @var ObjectManager */
+    private $orderManager;
+
+    public function __construct(OrderProcessorInterface $orderProcessor, ObjectManager $orderManager)
+    {
+        $this->orderProcessor = $orderProcessor;
+        $this->orderManager = $orderManager;
+    }
+
+    /** @throws OrderTotalIntegrityException */
+    public function process(OrderInterface $order): void
+    {
+        $oldTotal = $order->getTotal();
+
+        $this->orderProcessor->process($order);
+
+        if ($order->getTotal() !== $oldTotal) {
+            throw new OrderTotalIntegrityException();
+        }
+
+        $this->orderManager->flush();
+    }
+}

--- a/src/Request/Checkout/CompleteOrderWithCustomerRequest.php
+++ b/src/Request/Checkout/CompleteOrderWithCustomerRequest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\ShopApiPlugin\Request\Checkout;
+
+use Sylius\ShopApiPlugin\Command\Cart\CompleteOrderWithCustomer;
+use Sylius\ShopApiPlugin\Command\CommandInterface;
+use Sylius\ShopApiPlugin\Request\RequestInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+class CompleteOrderWithCustomerRequest implements RequestInterface
+{
+    /** @var string|null */
+    protected $token;
+
+    /** @var string|null */
+    protected $email;
+
+    /** @var string|null */
+    protected $notes;
+
+    protected function __construct(Request $request)
+    {
+        $this->token = $request->attributes->get('token');
+        $this->email = $request->request->get('email');
+        $this->notes = $request->request->get('notes');
+    }
+
+    public static function fromHttpRequest(Request $request): RequestInterface
+    {
+        return new self($request);
+    }
+
+    public function getCommand(): CommandInterface
+    {
+        return new CompleteOrderWithCustomer($this->token, $this->email, $this->notes);
+    }
+}

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -81,5 +81,13 @@
             <argument type="service" id="sylius_shop_api_plugin.command_bus" />
             <tag name="messenger.message_handler" />
         </service>
+
+        <service
+            id="sylius.shop_api_plugin.processor.safe_order_processor"
+            class="Sylius\ShopApiPlugin\Processor\SafeOrderProcessor"
+        >
+            <argument type="service" id="sylius.order_processing.order_processor" />
+            <argument type="service" id="sylius.manager.order" />
+        </service>
     </services>
 </container>

--- a/src/Resources/config/services/actions/checkout.xml
+++ b/src/Resources/config/services/actions/checkout.xml
@@ -57,6 +57,7 @@
             <argument type="service" id="sylius_shop_api_plugin.command_bus" />
             <argument type="service" id="sylius.shop_api_plugin.command_provider.assign_customer_to_cart" />
             <argument type="service" id="sylius.shop_api_plugin.command_provider.complete_order" />
+            <argument type="service" id="sylius.shop_api_plugin.command_provider.complete_order_with_customer" />
         </service>
     </services>
 </container>

--- a/src/Resources/config/services/command_providers/checkout.xml
+++ b/src/Resources/config/services/command_providers/checkout.xml
@@ -35,5 +35,13 @@
             <argument>%sylius.shop_api.request.complete_order.class%</argument>
             <argument type="service" id="validator" />
         </service>
+
+        <service
+            id="sylius.shop_api_plugin.command_provider.complete_order_with_customer"
+            class="Sylius\ShopApiPlugin\CommandProvider\DefaultCommandProvider"
+        >
+            <argument>%sylius.shop_api.request.complete_order_with_customer.class%</argument>
+            <argument type="service" id="validator" />
+        </service>
     </services>
 </container>

--- a/src/Resources/config/services/handler/cart.xml
+++ b/src/Resources/config/services/handler/cart.xml
@@ -116,5 +116,14 @@
             <argument type="service" id="sm.factory"/>
             <tag name="messenger.message_handler" />
         </service>
+
+        <service id="sylius.shop_api_plugin.handler.complete_order_with_customer_handler"
+                 class="Sylius\ShopApiPlugin\Handler\Cart\CompleteOrderWithCustomerHandler">
+            <argument type="service" id="sylius.repository.order"/>
+            <argument type="service" id="sm.factory"/>
+            <argument type="service" id="sylius.order_processing.order_processor" />
+            <argument type="service" id="sylius.shop_api_plugin.provider.customer_provider" />
+            <tag name="messenger.message_handler" />
+        </service>
     </services>
 </container>

--- a/src/Resources/config/services/handler/cart.xml
+++ b/src/Resources/config/services/handler/cart.xml
@@ -121,7 +121,7 @@
                  class="Sylius\ShopApiPlugin\Handler\Cart\CompleteOrderWithCustomerHandler">
             <argument type="service" id="sylius.repository.order"/>
             <argument type="service" id="sm.factory"/>
-            <argument type="service" id="sylius.order_processing.order_processor" />
+            <argument type="service" id="sylius.shop_api_plugin.processor.safe_order_processor" />
             <argument type="service" id="sylius.shop_api_plugin.provider.customer_provider" />
             <tag name="messenger.message_handler" />
         </service>

--- a/tests/Controller/Checkout/CompleteOrderApiTest.php
+++ b/tests/Controller/Checkout/CompleteOrderApiTest.php
@@ -298,11 +298,7 @@ JSON;
             "email": "oliver@queen.com"
         }
 JSON;
-
-        /** @var ProductVariantInterface $productVariant */
-        $productVariant = $this->get('sylius.repository.product_variant')->findOneBy(['code' => 'LOGAN_MUG_CODE']);
-        $productVariant->getChannelPricings()->first()->setPrice(4000);
-        $this->get('sylius.manager.product_variant')->flush();
+        $this->modifyVariantPrice();
 
         $response = $this->complete($token, $data);
         $this->assertResponse($response, 'cart/total_integrity_error', Response::HTTP_BAD_REQUEST);
@@ -320,5 +316,15 @@ JSON;
         );
 
         return $this->client->getResponse();
+    }
+
+    private function modifyVariantPrice(): void
+    {
+        /** @var ProductVariantInterface $productVariant */
+        $productVariant = $this->get('sylius.repository.product_variant')->findOneBy(['code' => 'LOGAN_MUG_CODE']);
+        foreach ($productVariant->getChannelPricings() as $channelPricing) {
+            $channelPricing->setPrice(4000);
+        }
+        $this->get('sylius.manager.product_variant')->flush();
     }
 }

--- a/tests/Responses/Expected/cart/total_integrity_error.json
+++ b/tests/Responses/Expected/cart/total_integrity_error.json
@@ -1,0 +1,4 @@
+{
+    "code": 400,
+    "message": "Your order total has been changed, check your order information and confirm it again."
+}


### PR DESCRIPTION
Fixes https://github.com/Sylius/ShopApiPlugin/issues/589

The main idea right now is to check the total of the order before and after customer assignment (and therefore - cart recalculation). This is the same thing as we do in [Sylius itself](https://github.com/Sylius/Sylius/blob/27c5b4970ccc086393ce0d643b0065e87cab065c/src/Sylius/Bundle/ShopBundle/EventListener/OrderIntegrityChecker.php#L78). The next step would be also to check the promotion integrity 🐎 

#SymfonyHackday