### PR TITLE
[Doc] fix `checkoutState` parameter in `PlacedOrder` swagger definition

### DIFF
--- a/doc/swagger.yml
+++ b/doc/swagger.yml
@@ -1758,15 +1758,16 @@ definitions:
             checkoutState:
                 description: "Current state of a checkout."
                 type: "string"
-                default: "cart"
+                default: "checkout"
                 externalDocs:
                     description: "Find out more about checkout states in the Sylius documentation."
                     url: "http://docs.sylius.com/en/latest/book/orders/checkout.html#checkout-state-machine"
                 enum:
                     - "cart"
-                    - "new"
-                    - "fulfilled"
-                    - "cancelled"
+                    - "addressed"
+                    - "shipping_selected"
+                    - "payment_selected"
+                    - "completed"
             checkoutCompletedAt:
                 description: "Date the order was completed in ISO 8601 format."
                 type: "string"


### PR DESCRIPTION
I think the intention here was to display order's state (then the enum would be correct), but in fact checkout state is returned as in `Cart` definition.

Note that the checkout state will always be `completed` for placed orders.