### PR TITLE
Define release cycle for Shop API

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,3 +183,20 @@ Instead, all security issues must be sent to `security@sylius.com`.
 
 This library is officially maintained by [Sylius](https://sylius.com) together with the following contributors outside of the organization:
  * [Maximilian Pesch](https://github.com/mamazu)
+
+## Release cycle
+
+This projects follows [Semantic Versioning](https://semver.org/). Shop API release cycle is independent from Sylius release cycle.
+
+Next major releases are not planned yet. Minor and patch releases will be published as needed.
+
+We provide bug fixes only for the most recent minor release.
+We provide security fixes for one year since the release of subsequent minor release.
+
+#### Example (with arbitrary dates):
+
+ - `v1.0.0` is released on _23.11.2019_
+ - `v1.0.1` with a bugfix is provided on _03.02.2020_
+ - `v1.1.0` is released on _15.02.2020_:
+   - `1.0` branch will not get bugfixes anymore
+   - `1.0` security support will end on _15.02.2021_


### PR DESCRIPTION
Since this plugin is stable, it should define a release cycle for both bugfixes and security fixes.