### PR TITLE
Fixing the documentation parser

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,4 +49,4 @@ script:
 
     - vendor/bin/phpspec run --format dot -vvv --no-interaction
     - vendor/bin/phpunit
-    - vendor/bin/doc-parser.php doc/Cookbook.md
+    - vendor/bin/doc-parser doc/Cookbook.md


### PR DESCRIPTION
After the update of the documentation parser the executable is renamed.