### PR TITLE
Allow customizing picked up cart's locale

### DIFF
--- a/src/Command/Cart/PickupCart.php
+++ b/src/Command/Cart/PickupCart.php
@@ -34,7 +34,7 @@ class PickupCart implements CommandInterface, LocaleAwareCommandInterface
         return $this->channelCode;
     }
 
-    public function setLocaleCode(string $localeCode)
+    public function setLocaleCode(string $localeCode): void
     {
         $this->localeCode = $localeCode;
     }

--- a/src/Command/Cart/PickupCart.php
+++ b/src/Command/Cart/PickupCart.php
@@ -5,14 +5,18 @@ declare(strict_types=1);
 namespace Sylius\ShopApiPlugin\Command\Cart;
 
 use Sylius\ShopApiPlugin\Command\CommandInterface;
+use Sylius\ShopApiPlugin\Command\LocaleAwareCommandInterface;
 
-class PickupCart implements CommandInterface
+class PickupCart implements CommandInterface, LocaleAwareCommandInterface
 {
     /** @var string */
     protected $orderToken;
 
     /** @var string */
     protected $channelCode;
+
+    /** @var string|null */
+    protected $localeCode;
 
     public function __construct(string $orderToken, string $channelCode)
     {
@@ -28,5 +32,15 @@ class PickupCart implements CommandInterface
     public function channelCode(): string
     {
         return $this->channelCode;
+    }
+
+    public function setLocaleCode(string $localeCode)
+    {
+        $this->localeCode = $localeCode;
+    }
+
+    public function getLocaleCode(): ?string
+    {
+        return $this->localeCode;
     }
 }

--- a/src/Command/LocaleAwareCommandInterface.php
+++ b/src/Command/LocaleAwareCommandInterface.php
@@ -6,7 +6,7 @@ namespace Sylius\ShopApiPlugin\Command;
 
 interface LocaleAwareCommandInterface
 {
-    public function setLocaleCode(string $localeCode);
+    public function setLocaleCode(string $localeCode): void;
 
     public function getLocaleCode(): ?string;
 }

--- a/src/Command/LocaleAwareCommandInterface.php
+++ b/src/Command/LocaleAwareCommandInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\ShopApiPlugin\Command;
+
+interface LocaleAwareCommandInterface
+{
+    public function setLocaleCode(string $localeCode);
+
+    public function getLocaleCode(): ?string;
+}

--- a/src/Handler/Cart/PickupCartHandler.php
+++ b/src/Handler/Cart/PickupCartHandler.php
@@ -52,7 +52,7 @@ final class PickupCartHandler
         $cart = $this->cartFactory->createNew();
         $cart->setChannel($channel);
         $cart->setCurrencyCode($channel->getBaseCurrency()->getCode());
-        $cart->setLocaleCode($channel->getDefaultLocale()->getCode());
+        $cart->setLocaleCode($pickupCart->getLocaleCode() ?? $channel->getDefaultLocale()->getCode());
         $cart->setTokenValue($pickupCart->orderToken());
 
         $this->cartRepository->add($cart);

--- a/src/Resources/config/services/command_providers/cart.xml
+++ b/src/Resources/config/services/command_providers/cart.xml
@@ -42,6 +42,7 @@
         >
             <argument>%sylius.shop_api.request.pickup_cart.class%</argument>
             <argument type="service" id="validator" />
+            <argument type="service" id="sylius.context.locale" />
         </service>
 
         <service

--- a/tests/Controller/Cart/PickupApiTest.php
+++ b/tests/Controller/Cart/PickupApiTest.php
@@ -38,6 +38,25 @@ final class PickupApiTest extends JsonApiTestCase
     /**
      * @test
      */
+    public function it_creates_a_new_cart_with_locale(): void
+    {
+        $this->loadFixturesFromFiles(['shop.yml']);
+
+        $this->client->request('POST', '/shop-api/carts?locale=de_DE', [], [], self::CONTENT_TYPE_HEADER);
+
+        $response = $this->client->getResponse();
+
+        $this->assertResponse($response, 'cart/empty_response_de_DE', Response::HTTP_CREATED);
+
+        $orderRepository = $this->get('sylius.repository.order');
+        $count = $orderRepository->count([]);
+
+        $this->assertSame(1, $count, 'Only one cart should be created');
+    }
+
+    /**
+     * @test
+     */
     public function it_only_creates_one_cart_if_user_is_logged_in(): void
     {
         $this->loadFixturesFromFiles(['shop.yml', 'customer.yml']);

--- a/tests/Responses/Expected/cart/empty_response_de_DE.json
+++ b/tests/Responses/Expected/cart/empty_response_de_DE.json
@@ -1,0 +1,18 @@
+{
+    "tokenValue": "@string@",
+    "channel": "WEB_GB",
+    "currency": "GBP",
+    "locale": "de_DE",
+    "checkoutState": "cart",
+    "items": [],
+    "totals": {
+        "total": 0,
+        "items": 0,
+        "taxes": 0,
+        "shipping": 0,
+        "promotion": 0
+    },
+    "payments": [],
+    "shipments": [],
+    "cartDiscounts": []
+}


### PR DESCRIPTION
Currently when picking up a new cart, the default channel locale is always used.

This PR fixes this by enabling the use of an optional ?locale URL parameter to customize the cart's locale.