### PR TITLE
[Address] Handle adress exists validation in case when address does not belong to any customer

### DIFF
--- a/spec/Validator/Address/AddressExistsValidatorSpec.php
+++ b/spec/Validator/Address/AddressExistsValidatorSpec.php
@@ -79,4 +79,26 @@ final class AddressExistsValidatorSpec extends ObjectBehavior
 
         $this->validate('ADDRESS_ID', new AddressExists());
     }
+
+    function it_adds_constraint_if_the_address_is_not_owned_by_anyone(
+        AddressInterface $address,
+        AddressRepositoryInterface $addressRepository,
+        LoggedInShopUserProviderInterface $currentUserProvider,
+        ShopUserInterface $shopUser,
+        CustomerInterface $customerOwner,
+        ExecutionContextInterface $executionContext
+    ): void {
+        $addressRepository->findOneBy(['id' => 'ADDRESS_ID'])->willReturn($address);
+
+        $customerOwner->getEmail()->willReturn('oliver@queen.com');
+        $address->getCustomer()->willReturn(null);
+
+        $currentUserProvider->provide()->willReturn($shopUser);
+
+        $shopUser->getEmail()->willReturn('shop@example.com');
+
+        $executionContext->addViolation('sylius.shop_api.address.not_exists')->shouldBeCalled();
+
+        $this->validate('ADDRESS_ID', new AddressExists());
+    }
 }

--- a/src/Validator/Address/AddressExistsValidator.php
+++ b/src/Validator/Address/AddressExistsValidator.php
@@ -42,8 +42,9 @@ final class AddressExistsValidator extends ConstraintValidator
         }
 
         $user = $this->loggedInUserProvider->provide();
+        $customer = $address->getCustomer();
 
-        if ($address->getCustomer()->getEmail() !== $user->getEmail()) {
+        if (null === $customer || $customer->getEmail() !== $user->getEmail()) {
             $this->context->addViolation($constraint->message);
 
             return;


### PR DESCRIPTION
Hi there, 
I've got an error during validation of address existence in case when it does not belong to any customer:
see `AddressExistsValidator`
```php
if ($address->getCustomer()->getEmail() !== $user->getEmail()) {
    return $this->context->addViolation($constraint->message);
}
```