### PR TITLE
Fix Symfony package constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "php": "^7.3",
         "sylius/sylius": "^1.8",
         "lexik/jwt-authentication-bundle": "^2.5",
-        "symfony/messenger": "^4.4|5.2",
+        "symfony/messenger": "^4.4|^5.2",
         "doctrine/doctrine-bundle": "^2.0",
         "friendsofsymfony/oauth-server-bundle": ">2.0.0-alpha.0 ^2.0@dev"
     },
@@ -20,9 +20,9 @@
         "phpstan/phpstan-webmozart-assert": "^0.12",
         "phpunit/phpunit": "^9.0",
         "sylius-labs/coding-standard": "^3.0",
-        "symfony/debug-bundle": "^4.4|5.2",
-        "symfony/dotenv": "^4.4|5.2",
-        "symfony/web-profiler-bundle": "^4.4|5.2",
+        "symfony/debug-bundle": "^4.4|^5.2",
+        "symfony/dotenv": "^4.4|^5.2",
+        "symfony/web-profiler-bundle": "^4.4|^5.2",
         "symfony/web-server-bundle": "^4.4",
         "mamazu/documentation-validator": "^1.0.1"
     },


### PR DESCRIPTION
With the current composer.json constraints regarding the Symfony packages we only are allowed to install version `5.2.0` of the packages. This PR fixes this and allows `^5.2` to be installed.