### PR TITLE
fix: do not try to filter svg images

### DIFF
--- a/src/Factory/ImageViewFactory.php
+++ b/src/Factory/ImageViewFactory.php
@@ -37,8 +37,17 @@ final class ImageViewFactory implements ImageViewFactoryInterface
         $imageView->code = $image->getType();
         $imageView->path = $image->getPath();
 
-        $imageView->cachedPath = $this->filterService->getUrlOfFilteredImage($image->getPath(), $this->filter);
+        if ($this->canImageBeFiltered($image->getPath())) {
+            $imageView->cachedPath = $this->filterService->getUrlOfFilteredImage($image->getPath(), $this->filter);
+        } else {
+            $imageView->cachedPath = $image->getPath();
+        }
 
         return $imageView;
+    }
+    
+    private function canImageBeFiltered(string $path): bool
+    {
+        return substr($path, -4) !== '.svg';
     }
 }


### PR DESCRIPTION
Fixes #695 
Liip Imagine cannot handle svg files so we keep original svg path