### PR TITLE
Adding the license block to the coding standard

### DIFF
--- a/easy-coding-standard.yml
+++ b/easy-coding-standard.yml
@@ -1,6 +1,12 @@
 imports:
     - { resource: 'vendor/sylius-labs/coding-standard/easy-coding-standard.yml' }
 
+services:
+    PhpCsFixer\Fixer\Comment\HeaderCommentFixer:
+      comment_type: "PHPDoc"
+      location: "after_open"
+      header: "This file is part of the Sylius package.\n\n (c) Paweł Jędrzejewski\n\nFor the full copyright and license information, please view the LICENSE\nfile that was distributed with this source code."
+
 parameters:
     skip:
         SlevomatCodingStandard\Sniffs\Commenting\InlineDocCommentDeclarationSniff.MissingVariable: ~

--- a/src/Checker/ChannelExistenceChecker.php
+++ b/src/Checker/ChannelExistenceChecker.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Checker;

--- a/src/Checker/ChannelExistenceCheckerInterface.php
+++ b/src/Checker/ChannelExistenceCheckerInterface.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Checker;

--- a/src/Checker/ProductInCartChannelChecker.php
+++ b/src/Checker/ProductInCartChannelChecker.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Checker;

--- a/src/Checker/ProductInCartChannelCheckerInterface.php
+++ b/src/Checker/ProductInCartChannelCheckerInterface.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Checker;

--- a/src/Checker/PromotionCouponEligibilityChecker.php
+++ b/src/Checker/PromotionCouponEligibilityChecker.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Checker;

--- a/src/Command/AddressBook/SetDefaultAddress.php
+++ b/src/Command/AddressBook/SetDefaultAddress.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Command\AddressBook;

--- a/src/Command/Cart/AddCoupon.php
+++ b/src/Command/Cart/AddCoupon.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Command\Cart;

--- a/src/Command/Cart/AddressOrder.php
+++ b/src/Command/Cart/AddressOrder.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Command\Cart;

--- a/src/Command/Cart/AssignCustomerToCart.php
+++ b/src/Command/Cart/AssignCustomerToCart.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Command\Cart;

--- a/src/Command/Cart/ChangeItemQuantity.php
+++ b/src/Command/Cart/ChangeItemQuantity.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Command\Cart;

--- a/src/Command/Cart/ChoosePaymentMethod.php
+++ b/src/Command/Cart/ChoosePaymentMethod.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Command\Cart;

--- a/src/Command/Cart/ChooseShippingMethod.php
+++ b/src/Command/Cart/ChooseShippingMethod.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Command\Cart;

--- a/src/Command/Cart/CompleteOrder.php
+++ b/src/Command/Cart/CompleteOrder.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Command\Cart;

--- a/src/Command/Cart/DropCart.php
+++ b/src/Command/Cart/DropCart.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Command\Cart;

--- a/src/Command/Cart/PickupCart.php
+++ b/src/Command/Cart/PickupCart.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Command\Cart;

--- a/src/Command/Cart/PutOptionBasedConfigurableItemToCart.php
+++ b/src/Command/Cart/PutOptionBasedConfigurableItemToCart.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Command\Cart;

--- a/src/Command/Cart/PutSimpleItemToCart.php
+++ b/src/Command/Cart/PutSimpleItemToCart.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Command\Cart;

--- a/src/Command/Cart/PutVariantBasedConfigurableItemToCart.php
+++ b/src/Command/Cart/PutVariantBasedConfigurableItemToCart.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Command\Cart;

--- a/src/Command/Cart/RemoveCoupon.php
+++ b/src/Command/Cart/RemoveCoupon.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Command\Cart;

--- a/src/Command/Cart/RemoveItemFromCart.php
+++ b/src/Command/Cart/RemoveItemFromCart.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Command\Cart;

--- a/src/Command/CommandInterface.php
+++ b/src/Command/CommandInterface.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Command;

--- a/src/Command/Customer/EnableCustomer.php
+++ b/src/Command/Customer/EnableCustomer.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Command\Customer;

--- a/src/Command/Customer/GenerateResetPasswordToken.php
+++ b/src/Command/Customer/GenerateResetPasswordToken.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Command\Customer;

--- a/src/Command/Customer/GenerateVerificationToken.php
+++ b/src/Command/Customer/GenerateVerificationToken.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Command\Customer;

--- a/src/Command/Customer/RegisterCustomer.php
+++ b/src/Command/Customer/RegisterCustomer.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Command\Customer;

--- a/src/Command/Customer/SendOrderConfirmation.php
+++ b/src/Command/Customer/SendOrderConfirmation.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Command\Customer;

--- a/src/Command/Customer/SendResetPasswordToken.php
+++ b/src/Command/Customer/SendResetPasswordToken.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Command\Customer;

--- a/src/Command/Customer/SendVerificationToken.php
+++ b/src/Command/Customer/SendVerificationToken.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Command\Customer;

--- a/src/Command/Customer/UpdateCustomer.php
+++ b/src/Command/Customer/UpdateCustomer.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Command\Customer;

--- a/src/Command/Customer/VerifyAccount.php
+++ b/src/Command/Customer/VerifyAccount.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Command\Customer;

--- a/src/Command/LocaleAwareCommandInterface.php
+++ b/src/Command/LocaleAwareCommandInterface.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Command;

--- a/src/Command/Order/UpdatePaymentMethod.php
+++ b/src/Command/Order/UpdatePaymentMethod.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Command\Order;

--- a/src/Command/Product/AddProductReviewByCode.php
+++ b/src/Command/Product/AddProductReviewByCode.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Command\Product;

--- a/src/Command/Product/AddProductReviewBySlug.php
+++ b/src/Command/Product/AddProductReviewBySlug.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Command\Product;

--- a/src/CommandProvider/ChannelBasedCommandProvider.php
+++ b/src/CommandProvider/ChannelBasedCommandProvider.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\CommandProvider;

--- a/src/CommandProvider/ChannelBasedCommandProviderInterface.php
+++ b/src/CommandProvider/ChannelBasedCommandProviderInterface.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\CommandProvider;

--- a/src/CommandProvider/CommandProviderInterface.php
+++ b/src/CommandProvider/CommandProviderInterface.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\CommandProvider;

--- a/src/CommandProvider/DefaultCommandProvider.php
+++ b/src/CommandProvider/DefaultCommandProvider.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\CommandProvider;

--- a/src/CommandProvider/PutItemToCartCommandProvider.php
+++ b/src/CommandProvider/PutItemToCartCommandProvider.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\CommandProvider;

--- a/src/CommandProvider/ShopUserBasedCommandProvider.php
+++ b/src/CommandProvider/ShopUserBasedCommandProvider.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\CommandProvider;

--- a/src/CommandProvider/ShopUserBasedCommandProviderInterface.php
+++ b/src/CommandProvider/ShopUserBasedCommandProviderInterface.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\CommandProvider;

--- a/src/CompilerPass/RemoveUserCartRecalculationListenerPass.php
+++ b/src/CompilerPass/RemoveUserCartRecalculationListenerPass.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\CompilerPass;

--- a/src/Controller/AddressBook/SetDefaultAddressAction.php
+++ b/src/Controller/AddressBook/SetDefaultAddressAction.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Controller\AddressBook;

--- a/src/Controller/Cart/AddCouponAction.php
+++ b/src/Controller/Cart/AddCouponAction.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Controller\Cart;

--- a/src/Controller/Cart/ChangeItemQuantityAction.php
+++ b/src/Controller/Cart/ChangeItemQuantityAction.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Controller\Cart;

--- a/src/Controller/Cart/DropCartAction.php
+++ b/src/Controller/Cart/DropCartAction.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Controller\Cart;

--- a/src/Controller/Cart/EstimateShippingCostAction.php
+++ b/src/Controller/Cart/EstimateShippingCostAction.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Controller\Cart;

--- a/src/Controller/Cart/PickupCartAction.php
+++ b/src/Controller/Cart/PickupCartAction.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Controller\Cart;

--- a/src/Controller/Cart/PutItemToCartAction.php
+++ b/src/Controller/Cart/PutItemToCartAction.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Controller\Cart;

--- a/src/Controller/Cart/PutItemsToCartAction.php
+++ b/src/Controller/Cart/PutItemsToCartAction.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Controller\Cart;

--- a/src/Controller/Cart/RemoveCouponAction.php
+++ b/src/Controller/Cart/RemoveCouponAction.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Controller\Cart;

--- a/src/Controller/Cart/RemoveItemFromCartAction.php
+++ b/src/Controller/Cart/RemoveItemFromCartAction.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Controller\Cart;

--- a/src/Controller/Cart/SummarizeAction.php
+++ b/src/Controller/Cart/SummarizeAction.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Controller\Cart;

--- a/src/Controller/Checkout/AddressAction.php
+++ b/src/Controller/Checkout/AddressAction.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Controller\Checkout;

--- a/src/Controller/Checkout/ChoosePaymentMethodAction.php
+++ b/src/Controller/Checkout/ChoosePaymentMethodAction.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Controller\Checkout;

--- a/src/Controller/Checkout/ChooseShippingMethodAction.php
+++ b/src/Controller/Checkout/ChooseShippingMethodAction.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Controller\Checkout;

--- a/src/Controller/Checkout/CompleteOrderAction.php
+++ b/src/Controller/Checkout/CompleteOrderAction.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Controller\Checkout;

--- a/src/Controller/Checkout/ShowAvailablePaymentMethodsAction.php
+++ b/src/Controller/Checkout/ShowAvailablePaymentMethodsAction.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Controller\Checkout;

--- a/src/Controller/Checkout/ShowAvailableShippingMethodsAction.php
+++ b/src/Controller/Checkout/ShowAvailableShippingMethodsAction.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Controller\Checkout;

--- a/src/Controller/Customer/CustomerController.php
+++ b/src/Controller/Customer/CustomerController.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Controller\Customer;

--- a/src/Controller/Customer/LoggedInCustomerDetailsAction.php
+++ b/src/Controller/Customer/LoggedInCustomerDetailsAction.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Controller\Customer;

--- a/src/Controller/Customer/RegisterCustomerAction.php
+++ b/src/Controller/Customer/RegisterCustomerAction.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Controller\Customer;

--- a/src/Controller/Customer/RequestPasswordResettingAction.php
+++ b/src/Controller/Customer/RequestPasswordResettingAction.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Controller\Customer;

--- a/src/Controller/Customer/ResendVerificationTokenAction.php
+++ b/src/Controller/Customer/ResendVerificationTokenAction.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Controller\Customer;

--- a/src/Controller/Customer/UpdateCustomerAction.php
+++ b/src/Controller/Customer/UpdateCustomerAction.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Controller\Customer;

--- a/src/Controller/Customer/VerifyAccountAction.php
+++ b/src/Controller/Customer/VerifyAccountAction.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Controller\Customer;

--- a/src/Controller/Order/ShowOrderDetailsAction.php
+++ b/src/Controller/Order/ShowOrderDetailsAction.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Controller\Order;

--- a/src/Controller/Order/ShowOrdersListAction.php
+++ b/src/Controller/Order/ShowOrdersListAction.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Controller\Order;

--- a/src/Controller/Order/UpdatePaymentMethodAction.php
+++ b/src/Controller/Order/UpdatePaymentMethodAction.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Controller\Order;

--- a/src/Controller/Product/AddReviewByCodeAction.php
+++ b/src/Controller/Product/AddReviewByCodeAction.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Controller\Product;

--- a/src/Controller/Product/AddReviewBySlugAction.php
+++ b/src/Controller/Product/AddReviewBySlugAction.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Controller\Product;

--- a/src/Controller/Product/ShowLatestProductAction.php
+++ b/src/Controller/Product/ShowLatestProductAction.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Controller\Product;

--- a/src/Controller/Product/ShowProductCatalogByTaxonCodeAction.php
+++ b/src/Controller/Product/ShowProductCatalogByTaxonCodeAction.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Controller\Product;

--- a/src/Controller/Product/ShowProductCatalogByTaxonSlugAction.php
+++ b/src/Controller/Product/ShowProductCatalogByTaxonSlugAction.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Controller\Product;

--- a/src/Controller/Product/ShowProductDetailsByCodeAction.php
+++ b/src/Controller/Product/ShowProductDetailsByCodeAction.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Controller\Product;

--- a/src/Controller/Product/ShowProductDetailsBySlugAction.php
+++ b/src/Controller/Product/ShowProductDetailsBySlugAction.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Controller\Product;

--- a/src/Controller/Product/ShowProductReviewsByCodeAction.php
+++ b/src/Controller/Product/ShowProductReviewsByCodeAction.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Controller\Product;

--- a/src/Controller/Product/ShowProductReviewsBySlugAction.php
+++ b/src/Controller/Product/ShowProductReviewsBySlugAction.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Controller\Product;

--- a/src/Controller/Taxon/ShowTaxonDetailsAction.php
+++ b/src/Controller/Taxon/ShowTaxonDetailsAction.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Controller\Taxon;

--- a/src/Controller/Taxon/ShowTaxonTreeAction.php
+++ b/src/Controller/Taxon/ShowTaxonTreeAction.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Controller\Taxon;

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\DependencyInjection;

--- a/src/DependencyInjection/SyliusShopApiExtension.php
+++ b/src/DependencyInjection/SyliusShopApiExtension.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\DependencyInjection;

--- a/src/Event/CartPickedUp.php
+++ b/src/Event/CartPickedUp.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Event;

--- a/src/Event/CustomerRegistered.php
+++ b/src/Event/CustomerRegistered.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Event;

--- a/src/Event/OrderCompleted.php
+++ b/src/Event/OrderCompleted.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Event;

--- a/src/EventListener/CartBlamerListener.php
+++ b/src/EventListener/CartBlamerListener.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\EventListener;

--- a/src/EventListener/Messenger/CartPickedUpListener.php
+++ b/src/EventListener/Messenger/CartPickedUpListener.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\EventListener\Messenger;

--- a/src/EventListener/Messenger/OrderCompletedListener.php
+++ b/src/EventListener/Messenger/OrderCompletedListener.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\EventListener\Messenger;

--- a/src/EventListener/UserCartRecalculationListener.php
+++ b/src/EventListener/UserCartRecalculationListener.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\EventListener;

--- a/src/EventListener/UserRegistrationListener.php
+++ b/src/EventListener/UserRegistrationListener.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\EventListener;

--- a/src/Exception/ChannelNotFoundException.php
+++ b/src/Exception/ChannelNotFoundException.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Exception;

--- a/src/Exception/UserNotFoundException.php
+++ b/src/Exception/UserNotFoundException.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Exception;

--- a/src/Exception/ViewCreationException.php
+++ b/src/Exception/ViewCreationException.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Exception;

--- a/src/Exception/WrongUserException.php
+++ b/src/Exception/WrongUserException.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Exception;

--- a/src/Factory/AddressBook/AddressViewFactory.php
+++ b/src/Factory/AddressBook/AddressViewFactory.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Factory\AddressBook;

--- a/src/Factory/AddressBook/AddressViewFactoryInterface.php
+++ b/src/Factory/AddressBook/AddressViewFactoryInterface.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Factory\AddressBook;

--- a/src/Factory/Cart/AdjustmentViewFactory.php
+++ b/src/Factory/Cart/AdjustmentViewFactory.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Factory\Cart;

--- a/src/Factory/Cart/AdjustmentViewFactoryInterface.php
+++ b/src/Factory/Cart/AdjustmentViewFactoryInterface.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Factory\Cart;

--- a/src/Factory/Cart/CartItemViewFactory.php
+++ b/src/Factory/Cart/CartItemViewFactory.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Factory\Cart;

--- a/src/Factory/Cart/CartItemViewFactoryInterface.php
+++ b/src/Factory/Cart/CartItemViewFactoryInterface.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Factory\Cart;

--- a/src/Factory/Cart/CartViewFactory.php
+++ b/src/Factory/Cart/CartViewFactory.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Factory\Cart;

--- a/src/Factory/Cart/CartViewFactoryInterface.php
+++ b/src/Factory/Cart/CartViewFactoryInterface.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Factory\Cart;

--- a/src/Factory/Cart/EstimatedShippingCostViewFactory.php
+++ b/src/Factory/Cart/EstimatedShippingCostViewFactory.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Factory\Cart;

--- a/src/Factory/Cart/EstimatedShippingCostViewFactoryInterface.php
+++ b/src/Factory/Cart/EstimatedShippingCostViewFactoryInterface.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Factory\Cart;

--- a/src/Factory/Cart/TotalViewFactory.php
+++ b/src/Factory/Cart/TotalViewFactory.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Factory\Cart;

--- a/src/Factory/Cart/TotalViewFactoryInterface.php
+++ b/src/Factory/Cart/TotalViewFactoryInterface.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Factory\Cart;

--- a/src/Factory/Checkout/PaymentMethodViewFactory.php
+++ b/src/Factory/Checkout/PaymentMethodViewFactory.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Factory\Checkout;

--- a/src/Factory/Checkout/PaymentMethodViewFactoryInterface.php
+++ b/src/Factory/Checkout/PaymentMethodViewFactoryInterface.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Factory\Checkout;

--- a/src/Factory/Checkout/PaymentViewFactory.php
+++ b/src/Factory/Checkout/PaymentViewFactory.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Factory\Checkout;

--- a/src/Factory/Checkout/PaymentViewFactoryInterface.php
+++ b/src/Factory/Checkout/PaymentViewFactoryInterface.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Factory\Checkout;

--- a/src/Factory/Checkout/ShipmentViewFactory.php
+++ b/src/Factory/Checkout/ShipmentViewFactory.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Factory\Checkout;

--- a/src/Factory/Checkout/ShipmentViewFactoryInterface.php
+++ b/src/Factory/Checkout/ShipmentViewFactoryInterface.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Factory\Checkout;

--- a/src/Factory/Checkout/ShippingMethodViewFactory.php
+++ b/src/Factory/Checkout/ShippingMethodViewFactory.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Factory\Checkout;

--- a/src/Factory/Checkout/ShippingMethodViewFactoryInterface.php
+++ b/src/Factory/Checkout/ShippingMethodViewFactoryInterface.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Factory\Checkout;

--- a/src/Factory/Customer/CustomerViewFactory.php
+++ b/src/Factory/Customer/CustomerViewFactory.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Factory\Customer;

--- a/src/Factory/Customer/CustomerViewFactoryInterface.php
+++ b/src/Factory/Customer/CustomerViewFactoryInterface.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Factory\Customer;

--- a/src/Factory/ImageViewFactory.php
+++ b/src/Factory/ImageViewFactory.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Factory;
@@ -45,7 +54,7 @@ final class ImageViewFactory implements ImageViewFactoryInterface
 
         return $imageView;
     }
-    
+
     private function canImageBeFiltered(string $path): bool
     {
         return substr($path, -4) !== '.svg';

--- a/src/Factory/ImageViewFactoryInterface.php
+++ b/src/Factory/ImageViewFactoryInterface.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Factory;

--- a/src/Factory/Order/PlacedOrderViewFactory.php
+++ b/src/Factory/Order/PlacedOrderViewFactory.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Factory\Order;

--- a/src/Factory/Order/PlacedOrderViewFactoryInterface.php
+++ b/src/Factory/Order/PlacedOrderViewFactoryInterface.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Factory\Order;

--- a/src/Factory/PriceViewFactory.php
+++ b/src/Factory/PriceViewFactory.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Factory;

--- a/src/Factory/PriceViewFactoryInterface.php
+++ b/src/Factory/PriceViewFactoryInterface.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Factory;

--- a/src/Factory/Product/DetailedProductViewFactory.php
+++ b/src/Factory/Product/DetailedProductViewFactory.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Factory\Product;

--- a/src/Factory/Product/LimitedProductAttributeValuesViewFactory.php
+++ b/src/Factory/Product/LimitedProductAttributeValuesViewFactory.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Factory\Product;

--- a/src/Factory/Product/ListProductViewFactory.php
+++ b/src/Factory/Product/ListProductViewFactory.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Factory\Product;
@@ -7,10 +16,10 @@ namespace Sylius\ShopApiPlugin\Factory\Product;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\ProductImageInterface;
 use Sylius\Component\Core\Model\ProductInterface;
-use Sylius\Component\Product\Model\ProductInterface as ProductModelProductInterface;
 use Sylius\Component\Core\Model\ProductVariantInterface;
-use Sylius\Component\Product\Model\ProductVariantInterface as ProductModelProductVariantInterface;
 use Sylius\Component\Product\Model\ProductAssociationInterface;
+use Sylius\Component\Product\Model\ProductInterface as ProductModelProductInterface;
+use Sylius\Component\Product\Model\ProductVariantInterface as ProductModelProductVariantInterface;
 use Sylius\ShopApiPlugin\Exception\ViewCreationException;
 use Sylius\ShopApiPlugin\Factory\ImageViewFactoryInterface;
 use Sylius\ShopApiPlugin\View\Product\ProductVariantView;
@@ -54,7 +63,7 @@ final class ListProductViewFactory implements ProductViewFactoryInterface
         $productView = $this->productViewFactory->create($product, $channel, $locale);
 
         /** @var ProductVariantInterface $variant */
-        foreach ($product->getVariants()->filter(function(ProductModelProductVariantInterface $variant): bool {
+        foreach ($product->getVariants()->filter(function (ProductModelProductVariantInterface $variant): bool {
             return $variant->isEnabled();
         }) as $variant) {
             try {
@@ -68,7 +77,7 @@ final class ListProductViewFactory implements ProductViewFactoryInterface
         foreach ($product->getImages() as $image) {
             $imageView = $this->imageViewFactory->create($image);
 
-            foreach ($image->getProductVariants()->filter(function(ProductModelProductVariantInterface $variant): bool {
+            foreach ($image->getProductVariants()->filter(function (ProductModelProductVariantInterface $variant): bool {
                 return $variant->isEnabled();
             }) as $productVariant) {
                 /** @var ProductVariantView $variantView */
@@ -85,7 +94,7 @@ final class ListProductViewFactory implements ProductViewFactoryInterface
     {
         $associatedProducts = [];
 
-        foreach ($association->getAssociatedProducts()->filter(function(ProductModelProductInterface $product): bool {
+        foreach ($association->getAssociatedProducts()->filter(function (ProductModelProductInterface $product): bool {
             return $product->isEnabled();
         }) as $associatedProduct) {
             $associatedProducts[] = $this->createWithVariants($associatedProduct, $channel, $locale);

--- a/src/Factory/Product/PageViewFactory.php
+++ b/src/Factory/Product/PageViewFactory.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Factory\Product;

--- a/src/Factory/Product/PageViewFactoryInterface.php
+++ b/src/Factory/Product/PageViewFactoryInterface.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Factory\Product;

--- a/src/Factory/Product/ProductAttributeValueViewFactory.php
+++ b/src/Factory/Product/ProductAttributeValueViewFactory.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Factory\Product;

--- a/src/Factory/Product/ProductAttributeValueViewFactoryInterface.php
+++ b/src/Factory/Product/ProductAttributeValueViewFactoryInterface.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Factory\Product;

--- a/src/Factory/Product/ProductAttributeValueViewResolver/DefaultProductAttributeValueViewResolver.php
+++ b/src/Factory/Product/ProductAttributeValueViewResolver/DefaultProductAttributeValueViewResolver.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Factory\Product\ProductAttributeValueViewResolver;

--- a/src/Factory/Product/ProductAttributeValueViewResolver/ProductAttributeValueViewResolverInterface.php
+++ b/src/Factory/Product/ProductAttributeValueViewResolver/ProductAttributeValueViewResolverInterface.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Factory\Product\ProductAttributeValueViewResolver;

--- a/src/Factory/Product/ProductAttributeValueViewResolver/SelectProductAttributeValueViewResolver.php
+++ b/src/Factory/Product/ProductAttributeValueViewResolver/SelectProductAttributeValueViewResolver.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Factory\Product\ProductAttributeValueViewResolver;

--- a/src/Factory/Product/ProductAttributeValuesViewFactoryInterface.php
+++ b/src/Factory/Product/ProductAttributeValuesViewFactoryInterface.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Factory\Product;

--- a/src/Factory/Product/ProductReviewViewFactory.php
+++ b/src/Factory/Product/ProductReviewViewFactory.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Factory\Product;

--- a/src/Factory/Product/ProductReviewViewFactoryInterface.php
+++ b/src/Factory/Product/ProductReviewViewFactoryInterface.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Factory\Product;

--- a/src/Factory/Product/ProductVariantViewFactory.php
+++ b/src/Factory/Product/ProductVariantViewFactory.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Factory\Product;

--- a/src/Factory/Product/ProductVariantViewFactoryInterface.php
+++ b/src/Factory/Product/ProductVariantViewFactoryInterface.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Factory\Product;

--- a/src/Factory/Product/ProductViewFactory.php
+++ b/src/Factory/Product/ProductViewFactory.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Factory\Product;

--- a/src/Factory/Product/ProductViewFactoryInterface.php
+++ b/src/Factory/Product/ProductViewFactoryInterface.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Factory\Product;

--- a/src/Factory/Taxon/TaxonDetailsViewFactory.php
+++ b/src/Factory/Taxon/TaxonDetailsViewFactory.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Factory\Taxon;

--- a/src/Factory/Taxon/TaxonDetailsViewFactoryInterface.php
+++ b/src/Factory/Taxon/TaxonDetailsViewFactoryInterface.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Factory\Taxon;

--- a/src/Factory/Taxon/TaxonViewFactory.php
+++ b/src/Factory/Taxon/TaxonViewFactory.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Factory\Taxon;

--- a/src/Factory/Taxon/TaxonViewFactoryInterface.php
+++ b/src/Factory/Taxon/TaxonViewFactoryInterface.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Factory\Taxon;

--- a/src/Factory/ValidationErrorViewFactory.php
+++ b/src/Factory/ValidationErrorViewFactory.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Factory;

--- a/src/Factory/ValidationErrorViewFactoryInterface.php
+++ b/src/Factory/ValidationErrorViewFactoryInterface.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Factory;

--- a/src/Generator/ProductBreadcrumbGenerator.php
+++ b/src/Generator/ProductBreadcrumbGenerator.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Generator;

--- a/src/Generator/ProductBreadcrumbGeneratorInterface.php
+++ b/src/Generator/ProductBreadcrumbGeneratorInterface.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Generator;

--- a/src/Handler/AddressBook/SetDefaultAddressHandler.php
+++ b/src/Handler/AddressBook/SetDefaultAddressHandler.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Handler\AddressBook;

--- a/src/Handler/Cart/AddCouponHandler.php
+++ b/src/Handler/Cart/AddCouponHandler.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Handler\Cart;

--- a/src/Handler/Cart/AddressOrderHandler.php
+++ b/src/Handler/Cart/AddressOrderHandler.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Handler\Cart;

--- a/src/Handler/Cart/AssignCustomerToCartHandler.php
+++ b/src/Handler/Cart/AssignCustomerToCartHandler.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Handler\Cart;

--- a/src/Handler/Cart/ChangeItemQuantityHandler.php
+++ b/src/Handler/Cart/ChangeItemQuantityHandler.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Handler\Cart;

--- a/src/Handler/Cart/ChoosePaymentMethodHandler.php
+++ b/src/Handler/Cart/ChoosePaymentMethodHandler.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Handler\Cart;
@@ -39,7 +48,7 @@ final class ChoosePaymentMethodHandler
         $this->paymentMethodRepository = $paymentMethodRepository;
         $this->stateMachineFactory = $stateMachineFactory;
 
-        if($this->paymentMethodsResolver === null) {
+        if ($this->paymentMethodsResolver === null) {
             @trigger_error(sprintf('Not passing %s as the fourth argument is deprecated', PaymentMethodsResolverInterface::class), \E_USER_DEPRECATED);
         }
         $this->paymentMethodsResolver = $paymentMethodsResolver;
@@ -65,6 +74,7 @@ final class ChoosePaymentMethodHandler
 
     /**
      * @param string|int $identifier
+     *
      * @return PaymentInterface|\Sylius\Component\Payment\Model\PaymentInterface
      */
     private function getPayment(OrderInterface $cart, $identifier)

--- a/src/Handler/Cart/ChooseShippingMethodHandler.php
+++ b/src/Handler/Cart/ChooseShippingMethodHandler.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Handler\Cart;

--- a/src/Handler/Cart/CompleteOrderHandler.php
+++ b/src/Handler/Cart/CompleteOrderHandler.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Handler\Cart;

--- a/src/Handler/Cart/DropCartHandler.php
+++ b/src/Handler/Cart/DropCartHandler.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Handler\Cart;

--- a/src/Handler/Cart/PickupCartHandler.php
+++ b/src/Handler/Cart/PickupCartHandler.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Handler\Cart;

--- a/src/Handler/Cart/PutOptionBasedConfigurableItemToCartHandler.php
+++ b/src/Handler/Cart/PutOptionBasedConfigurableItemToCartHandler.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Handler\Cart;

--- a/src/Handler/Cart/PutSimpleItemToCartHandler.php
+++ b/src/Handler/Cart/PutSimpleItemToCartHandler.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Handler\Cart;

--- a/src/Handler/Cart/PutVariantBasedConfigurableItemToCartHandler.php
+++ b/src/Handler/Cart/PutVariantBasedConfigurableItemToCartHandler.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Handler\Cart;

--- a/src/Handler/Cart/RemoveCouponHandler.php
+++ b/src/Handler/Cart/RemoveCouponHandler.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Handler\Cart;

--- a/src/Handler/Cart/RemoveItemFromCartHandler.php
+++ b/src/Handler/Cart/RemoveItemFromCartHandler.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Handler\Cart;

--- a/src/Handler/Customer/EnableCustomerHandler.php
+++ b/src/Handler/Customer/EnableCustomerHandler.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Handler\Customer;

--- a/src/Handler/Customer/GenerateResetPasswordTokenHandler.php
+++ b/src/Handler/Customer/GenerateResetPasswordTokenHandler.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Handler\Customer;

--- a/src/Handler/Customer/GenerateVerificationTokenHandler.php
+++ b/src/Handler/Customer/GenerateVerificationTokenHandler.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Handler\Customer;

--- a/src/Handler/Customer/RegisterCustomerHandler.php
+++ b/src/Handler/Customer/RegisterCustomerHandler.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Handler\Customer;

--- a/src/Handler/Customer/SendOrderConfirmationHandler.php
+++ b/src/Handler/Customer/SendOrderConfirmationHandler.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Handler\Customer;

--- a/src/Handler/Customer/SendResetPasswordTokenHandler.php
+++ b/src/Handler/Customer/SendResetPasswordTokenHandler.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Handler\Customer;

--- a/src/Handler/Customer/SendVerificationTokenHandler.php
+++ b/src/Handler/Customer/SendVerificationTokenHandler.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Handler\Customer;

--- a/src/Handler/Customer/UpdateCustomerHandler.php
+++ b/src/Handler/Customer/UpdateCustomerHandler.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Handler\Customer;

--- a/src/Handler/Customer/VerifyAccountHandler.php
+++ b/src/Handler/Customer/VerifyAccountHandler.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Handler\Customer;

--- a/src/Handler/Order/UpdatePaymentMethodHandler.php
+++ b/src/Handler/Order/UpdatePaymentMethodHandler.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Handler\Order;

--- a/src/Handler/Product/AddProductReviewByCodeHandler.php
+++ b/src/Handler/Product/AddProductReviewByCodeHandler.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Handler\Product;

--- a/src/Handler/Product/AddProductReviewBySlugHandler.php
+++ b/src/Handler/Product/AddProductReviewBySlugHandler.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Handler\Product;

--- a/src/Http/RequestBasedLocaleContext.php
+++ b/src/Http/RequestBasedLocaleContext.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Http;

--- a/src/Http/RequestBasedLocaleProvider.php
+++ b/src/Http/RequestBasedLocaleProvider.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Http;

--- a/src/Http/RequestBasedLocaleProviderInterface.php
+++ b/src/Http/RequestBasedLocaleProviderInterface.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Http;

--- a/src/Http/RequestChannelEnsurer.php
+++ b/src/Http/RequestChannelEnsurer.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Http;

--- a/src/Mailer/Emails.php
+++ b/src/Mailer/Emails.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Mailer;

--- a/src/Mapper/AddressMapper.php
+++ b/src/Mapper/AddressMapper.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Mapper;

--- a/src/Mapper/AddressMapperInterface.php
+++ b/src/Mapper/AddressMapperInterface.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Mapper;

--- a/src/Model/Address.php
+++ b/src/Model/Address.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Model;

--- a/src/Model/PaginatorDetails.php
+++ b/src/Model/PaginatorDetails.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Model;

--- a/src/Modifier/OrderModifier.php
+++ b/src/Modifier/OrderModifier.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Modifier;
@@ -88,12 +97,12 @@ final class OrderModifier implements OrderModifierInterface
 
     private function checkCartQuantity(ProductVariantInterface $productVariant, int $targetQuantity): void
     {
-        if($this->availabilityChecker === null) {
+        if ($this->availabilityChecker === null) {
             return;
         }
         Assert::true(
             $this->availabilityChecker->isStockSufficient($productVariant, $targetQuantity),
-            'Not enough stock for product variant: '. $productVariant->getCode()
+            'Not enough stock for product variant: ' . $productVariant->getCode()
         );
     }
 }

--- a/src/Modifier/OrderModifierInterface.php
+++ b/src/Modifier/OrderModifierInterface.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Modifier;

--- a/src/Normalizer/RequestCartTokenNormalizer.php
+++ b/src/Normalizer/RequestCartTokenNormalizer.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Normalizer;

--- a/src/Normalizer/RequestCartTokenNormalizerInterface.php
+++ b/src/Normalizer/RequestCartTokenNormalizerInterface.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Normalizer;

--- a/src/Provider/CustomerProviderInterface.php
+++ b/src/Provider/CustomerProviderInterface.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Provider;

--- a/src/Provider/LoggedInShopUserProvider.php
+++ b/src/Provider/LoggedInShopUserProvider.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Provider;

--- a/src/Provider/LoggedInShopUserProviderInterface.php
+++ b/src/Provider/LoggedInShopUserProviderInterface.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Provider;

--- a/src/Provider/ProductReviewerProvider.php
+++ b/src/Provider/ProductReviewerProvider.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Provider;

--- a/src/Provider/ProductReviewerProviderInterface.php
+++ b/src/Provider/ProductReviewerProviderInterface.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Provider;

--- a/src/Provider/ShopUserAwareCustomerProvider.php
+++ b/src/Provider/ShopUserAwareCustomerProvider.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Provider;

--- a/src/Provider/SupportedLocaleProvider.php
+++ b/src/Provider/SupportedLocaleProvider.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Provider;

--- a/src/Provider/SupportedLocaleProviderInterface.php
+++ b/src/Provider/SupportedLocaleProviderInterface.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Provider;

--- a/src/Request/AddressBook/SetDefaultAddressRequest.php
+++ b/src/Request/AddressBook/SetDefaultAddressRequest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Request\AddressBook;

--- a/src/Request/Cart/AddCouponRequest.php
+++ b/src/Request/Cart/AddCouponRequest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Request\Cart;

--- a/src/Request/Cart/AssignCustomerToCartRequest.php
+++ b/src/Request/Cart/AssignCustomerToCartRequest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Request\Cart;

--- a/src/Request/Cart/ChangeItemQuantityRequest.php
+++ b/src/Request/Cart/ChangeItemQuantityRequest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Request\Cart;

--- a/src/Request/Cart/DropCartRequest.php
+++ b/src/Request/Cart/DropCartRequest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Request\Cart;

--- a/src/Request/Cart/EstimateShippingCostRequest.php
+++ b/src/Request/Cart/EstimateShippingCostRequest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Request\Cart;

--- a/src/Request/Cart/PickupCartRequest.php
+++ b/src/Request/Cart/PickupCartRequest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Request\Cart;

--- a/src/Request/Cart/PutOptionBasedConfigurableItemToCartRequest.php
+++ b/src/Request/Cart/PutOptionBasedConfigurableItemToCartRequest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Request\Cart;

--- a/src/Request/Cart/PutSimpleItemToCartRequest.php
+++ b/src/Request/Cart/PutSimpleItemToCartRequest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Request\Cart;

--- a/src/Request/Cart/PutVariantBasedConfigurableItemToCartRequest.php
+++ b/src/Request/Cart/PutVariantBasedConfigurableItemToCartRequest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Request\Cart;

--- a/src/Request/Cart/RemoveCouponRequest.php
+++ b/src/Request/Cart/RemoveCouponRequest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Request\Cart;

--- a/src/Request/Cart/RemoveItemFromCartRequest.php
+++ b/src/Request/Cart/RemoveItemFromCartRequest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Request\Cart;

--- a/src/Request/ChannelBasedRequestInterface.php
+++ b/src/Request/ChannelBasedRequestInterface.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Request;

--- a/src/Request/Checkout/AddressOrderRequest.php
+++ b/src/Request/Checkout/AddressOrderRequest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Request\Checkout;

--- a/src/Request/Checkout/ChoosePaymentMethodRequest.php
+++ b/src/Request/Checkout/ChoosePaymentMethodRequest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Request\Checkout;

--- a/src/Request/Checkout/ChooseShippingMethodRequest.php
+++ b/src/Request/Checkout/ChooseShippingMethodRequest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Request\Checkout;

--- a/src/Request/Checkout/CompleteOrderRequest.php
+++ b/src/Request/Checkout/CompleteOrderRequest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Request\Checkout;

--- a/src/Request/Customer/GenerateResetPasswordTokenRequest.php
+++ b/src/Request/Customer/GenerateResetPasswordTokenRequest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Request\Customer;

--- a/src/Request/Customer/RegisterCustomerRequest.php
+++ b/src/Request/Customer/RegisterCustomerRequest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Request\Customer;

--- a/src/Request/Customer/ResendVerificationTokenRequest.php
+++ b/src/Request/Customer/ResendVerificationTokenRequest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Request\Customer;

--- a/src/Request/Customer/SendResetPasswordTokenRequest.php
+++ b/src/Request/Customer/SendResetPasswordTokenRequest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Request\Customer;

--- a/src/Request/Customer/UpdateCustomerRequest.php
+++ b/src/Request/Customer/UpdateCustomerRequest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Request\Customer;

--- a/src/Request/Customer/VerifyAccountRequest.php
+++ b/src/Request/Customer/VerifyAccountRequest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Request\Customer;

--- a/src/Request/Order/UpdatePaymentMethodRequest.php
+++ b/src/Request/Order/UpdatePaymentMethodRequest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Request\Order;

--- a/src/Request/Product/AddProductReviewByCodeRequest.php
+++ b/src/Request/Product/AddProductReviewByCodeRequest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Request\Product;

--- a/src/Request/Product/AddProductReviewBySlugRequest.php
+++ b/src/Request/Product/AddProductReviewBySlugRequest.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Request\Product;

--- a/src/Request/RequestInterface.php
+++ b/src/Request/RequestInterface.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Request;

--- a/src/Request/ShopUserBasedRequestInterface.php
+++ b/src/Request/ShopUserBasedRequestInterface.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Request;

--- a/src/Shipping/ShippingCost.php
+++ b/src/Shipping/ShippingCost.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Shipping;

--- a/src/Shipping/ShippingCostEstimator.php
+++ b/src/Shipping/ShippingCostEstimator.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Shipping;

--- a/src/Shipping/ShippingCostEstimatorInterface.php
+++ b/src/Shipping/ShippingCostEstimatorInterface.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Shipping;

--- a/src/SyliusShopApiPlugin.php
+++ b/src/SyliusShopApiPlugin.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin;

--- a/src/Validator/Address/AddressExistsValidator.php
+++ b/src/Validator/Address/AddressExistsValidator.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Validator\Address;

--- a/src/Validator/Address/CountryExistsValidator.php
+++ b/src/Validator/Address/CountryExistsValidator.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Validator\Address;

--- a/src/Validator/Cart/CartEligibilityValidator.php
+++ b/src/Validator/Cart/CartEligibilityValidator.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Validator\Cart;

--- a/src/Validator/Cart/CartExistsValidator.php
+++ b/src/Validator/Cart/CartExistsValidator.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Validator\Cart;

--- a/src/Validator/Cart/CartItemEligibilityValidator.php
+++ b/src/Validator/Cart/CartItemEligibilityValidator.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Validator\Cart;

--- a/src/Validator/Cart/CartItemExistsValidator.php
+++ b/src/Validator/Cart/CartItemExistsValidator.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Validator\Cart;

--- a/src/Validator/Cart/CartNotEmptyValidator.php
+++ b/src/Validator/Cart/CartNotEmptyValidator.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Validator\Cart;

--- a/src/Validator/Cart/CartReadyForCheckoutValidator.php
+++ b/src/Validator/Cart/CartReadyForCheckoutValidator.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Validator\Cart;

--- a/src/Validator/Cart/PaymentMethodAvailableValidator.php
+++ b/src/Validator/Cart/PaymentMethodAvailableValidator.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Validator\Cart;

--- a/src/Validator/Cart/PaymentMethodExistsValidator.php
+++ b/src/Validator/Cart/PaymentMethodExistsValidator.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Validator\Cart;

--- a/src/Validator/Cart/TokenIsNotUsedValidator.php
+++ b/src/Validator/Cart/TokenIsNotUsedValidator.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Validator\Cart;

--- a/src/Validator/Cart/ValidPromotionCouponCodeValidator.php
+++ b/src/Validator/Cart/ValidPromotionCouponCodeValidator.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Validator\Cart;

--- a/src/Validator/ChannelExistsValidator.php
+++ b/src/Validator/ChannelExistsValidator.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Validator;

--- a/src/Validator/Constraints/AddressExists.php
+++ b/src/Validator/Constraints/AddressExists.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Validator\Constraints;

--- a/src/Validator/Constraints/CartEligibility.php
+++ b/src/Validator/Constraints/CartEligibility.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Validator\Constraints;

--- a/src/Validator/Constraints/CartExists.php
+++ b/src/Validator/Constraints/CartExists.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Validator\Constraints;

--- a/src/Validator/Constraints/CartItemEligibility.php
+++ b/src/Validator/Constraints/CartItemEligibility.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Validator\Constraints;

--- a/src/Validator/Constraints/CartItemExists.php
+++ b/src/Validator/Constraints/CartItemExists.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Validator\Constraints;

--- a/src/Validator/Constraints/CartNotEmpty.php
+++ b/src/Validator/Constraints/CartNotEmpty.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Validator\Constraints;

--- a/src/Validator/Constraints/CartReadyForCheckout.php
+++ b/src/Validator/Constraints/CartReadyForCheckout.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Validator\Constraints;

--- a/src/Validator/Constraints/ChannelExists.php
+++ b/src/Validator/Constraints/ChannelExists.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Validator\Constraints;

--- a/src/Validator/Constraints/ConfigurableProduct.php
+++ b/src/Validator/Constraints/ConfigurableProduct.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Validator\Constraints;

--- a/src/Validator/Constraints/CountryExists.php
+++ b/src/Validator/Constraints/CountryExists.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Validator\Constraints;

--- a/src/Validator/Constraints/OrderExists.php
+++ b/src/Validator/Constraints/OrderExists.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Validator\Constraints;

--- a/src/Validator/Constraints/PaymentMethodAvailable.php
+++ b/src/Validator/Constraints/PaymentMethodAvailable.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Validator\Constraints;

--- a/src/Validator/Constraints/PaymentMethodExists.php
+++ b/src/Validator/Constraints/PaymentMethodExists.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Validator\Constraints;

--- a/src/Validator/Constraints/PaymentNotPaid.php
+++ b/src/Validator/Constraints/PaymentNotPaid.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Validator\Constraints;

--- a/src/Validator/Constraints/ProductEligibility.php
+++ b/src/Validator/Constraints/ProductEligibility.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Validator\Constraints;

--- a/src/Validator/Constraints/ProductExists.php
+++ b/src/Validator/Constraints/ProductExists.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Validator\Constraints;

--- a/src/Validator/Constraints/ProductInCartChannel.php
+++ b/src/Validator/Constraints/ProductInCartChannel.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Validator\Constraints;

--- a/src/Validator/Constraints/ProductOptionEligibility.php
+++ b/src/Validator/Constraints/ProductOptionEligibility.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Validator\Constraints;

--- a/src/Validator/Constraints/ProductOptionExists.php
+++ b/src/Validator/Constraints/ProductOptionExists.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Validator\Constraints;

--- a/src/Validator/Constraints/ProductVariantEligibility.php
+++ b/src/Validator/Constraints/ProductVariantEligibility.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Validator\Constraints;

--- a/src/Validator/Constraints/ProductVariantExists.php
+++ b/src/Validator/Constraints/ProductVariantExists.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Validator\Constraints;

--- a/src/Validator/Constraints/ShopUserDoesNotExist.php
+++ b/src/Validator/Constraints/ShopUserDoesNotExist.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Validator\Constraints;

--- a/src/Validator/Constraints/ShopUserExists.php
+++ b/src/Validator/Constraints/ShopUserExists.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Validator\Constraints;

--- a/src/Validator/Constraints/SimpleProduct.php
+++ b/src/Validator/Constraints/SimpleProduct.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Validator\Constraints;

--- a/src/Validator/Constraints/TokenIsNotUsed.php
+++ b/src/Validator/Constraints/TokenIsNotUsed.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Validator\Constraints;

--- a/src/Validator/Constraints/ValidPromotionCouponCode.php
+++ b/src/Validator/Constraints/ValidPromotionCouponCode.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Validator\Constraints;

--- a/src/Validator/Constraints/VerificationTokenExists.php
+++ b/src/Validator/Constraints/VerificationTokenExists.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Validator\Constraints;

--- a/src/Validator/Customer/ShopUserDoesNotExistValidator.php
+++ b/src/Validator/Customer/ShopUserDoesNotExistValidator.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Validator\Customer;

--- a/src/Validator/Customer/ShopUserExistsValidator.php
+++ b/src/Validator/Customer/ShopUserExistsValidator.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Validator\Customer;

--- a/src/Validator/Customer/VerificationTokenExistsValidator.php
+++ b/src/Validator/Customer/VerificationTokenExistsValidator.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Validator\Customer;

--- a/src/Validator/Order/OrderExistsValidator.php
+++ b/src/Validator/Order/OrderExistsValidator.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Validator\Order;

--- a/src/Validator/Order/PaymentNotPaidValidator.php
+++ b/src/Validator/Order/PaymentNotPaidValidator.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Validator\Order;

--- a/src/Validator/Product/ConfigurableProductValidator.php
+++ b/src/Validator/Product/ConfigurableProductValidator.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Validator\Product;

--- a/src/Validator/Product/ProductEligibilityValidator.php
+++ b/src/Validator/Product/ProductEligibilityValidator.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Validator\Product;

--- a/src/Validator/Product/ProductExistsValidator.php
+++ b/src/Validator/Product/ProductExistsValidator.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Validator\Product;

--- a/src/Validator/Product/ProductInCartChannelValidator.php
+++ b/src/Validator/Product/ProductInCartChannelValidator.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Validator\Product;

--- a/src/Validator/Product/ProductOptionEligibilityValidator.php
+++ b/src/Validator/Product/ProductOptionEligibilityValidator.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Validator\Product;

--- a/src/Validator/Product/ProductOptionExistsValidator.php
+++ b/src/Validator/Product/ProductOptionExistsValidator.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Validator\Product;

--- a/src/Validator/Product/ProductVariantEligibilityValidator.php
+++ b/src/Validator/Product/ProductVariantEligibilityValidator.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Validator\Product;

--- a/src/Validator/Product/ProductVariantExistsValidator.php
+++ b/src/Validator/Product/ProductVariantExistsValidator.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Validator\Product;

--- a/src/Validator/Product/SimpleProductValidator.php
+++ b/src/Validator/Product/SimpleProductValidator.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\Validator\Product;

--- a/src/View/AddressBook/AddressView.php
+++ b/src/View/AddressBook/AddressView.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\View\AddressBook;

--- a/src/View/Cart/AdjustmentView.php
+++ b/src/View/Cart/AdjustmentView.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\View\Cart;

--- a/src/View/Cart/CartSummaryView.php
+++ b/src/View/Cart/CartSummaryView.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\View\Cart;

--- a/src/View/Cart/EstimatedShippingCostView.php
+++ b/src/View/Cart/EstimatedShippingCostView.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\View\Cart;

--- a/src/View/Cart/PaymentMethodView.php
+++ b/src/View/Cart/PaymentMethodView.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\View\Cart;

--- a/src/View/Cart/PaymentView.php
+++ b/src/View/Cart/PaymentView.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\View\Cart;

--- a/src/View/Cart/ShippingMethodView.php
+++ b/src/View/Cart/ShippingMethodView.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\View\Cart;

--- a/src/View/Cart/TotalsView.php
+++ b/src/View/Cart/TotalsView.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\View\Cart;

--- a/src/View/Checkout/ShipmentView.php
+++ b/src/View/Checkout/ShipmentView.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\View\Checkout;

--- a/src/View/Customer/CustomerView.php
+++ b/src/View/Customer/CustomerView.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\View\Customer;

--- a/src/View/ImageView.php
+++ b/src/View/ImageView.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\View;

--- a/src/View/ItemView.php
+++ b/src/View/ItemView.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\View;

--- a/src/View/Order/PlacedOrderView.php
+++ b/src/View/Order/PlacedOrderView.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\View\Order;

--- a/src/View/PriceView.php
+++ b/src/View/PriceView.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\View;

--- a/src/View/Product/PageLinksView.php
+++ b/src/View/Product/PageLinksView.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\View\Product;

--- a/src/View/Product/PageView.php
+++ b/src/View/Product/PageView.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\View\Product;

--- a/src/View/Product/ProductAttributeValueView.php
+++ b/src/View/Product/ProductAttributeValueView.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\View\Product;

--- a/src/View/Product/ProductListView.php
+++ b/src/View/Product/ProductListView.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\View\Product;

--- a/src/View/Product/ProductReviewView.php
+++ b/src/View/Product/ProductReviewView.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\View\Product;

--- a/src/View/Product/ProductTaxonView.php
+++ b/src/View/Product/ProductTaxonView.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\View\Product;

--- a/src/View/Product/ProductVariantView.php
+++ b/src/View/Product/ProductVariantView.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\View\Product;

--- a/src/View/Product/ProductView.php
+++ b/src/View/Product/ProductView.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\View\Product;

--- a/src/View/Product/VariantOptionValueView.php
+++ b/src/View/Product/VariantOptionValueView.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\View\Product;

--- a/src/View/Product/VariantOptionView.php
+++ b/src/View/Product/VariantOptionView.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\View\Product;

--- a/src/View/Taxon/TaxonDetailsView.php
+++ b/src/View/Taxon/TaxonDetailsView.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\View\Taxon;

--- a/src/View/Taxon/TaxonView.php
+++ b/src/View/Taxon/TaxonView.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\View\Taxon;

--- a/src/View/ValidationErrorView.php
+++ b/src/View/ValidationErrorView.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\View;

--- a/src/ViewRepository/Cart/CartViewRepository.php
+++ b/src/ViewRepository/Cart/CartViewRepository.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\ViewRepository\Cart;

--- a/src/ViewRepository/Cart/CartViewRepositoryInterface.php
+++ b/src/ViewRepository/Cart/CartViewRepositoryInterface.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\ViewRepository\Cart;

--- a/src/ViewRepository/Order/PlacedOrderViewRepository.php
+++ b/src/ViewRepository/Order/PlacedOrderViewRepository.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\ViewRepository\Order;

--- a/src/ViewRepository/Order/PlacedOrderViewRepositoryInterface.php
+++ b/src/ViewRepository/Order/PlacedOrderViewRepositoryInterface.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\ViewRepository\Order;

--- a/src/ViewRepository/Product/ProductCatalogViewRepository.php
+++ b/src/ViewRepository/Product/ProductCatalogViewRepository.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\ViewRepository\Product;

--- a/src/ViewRepository/Product/ProductCatalogViewRepositoryInterface.php
+++ b/src/ViewRepository/Product/ProductCatalogViewRepositoryInterface.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\ViewRepository\Product;

--- a/src/ViewRepository/Product/ProductDetailsViewRepository.php
+++ b/src/ViewRepository/Product/ProductDetailsViewRepository.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\ViewRepository\Product;

--- a/src/ViewRepository/Product/ProductDetailsViewRepositoryInterface.php
+++ b/src/ViewRepository/Product/ProductDetailsViewRepositoryInterface.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\ViewRepository\Product;

--- a/src/ViewRepository/Product/ProductLatestViewRepository.php
+++ b/src/ViewRepository/Product/ProductLatestViewRepository.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\ViewRepository\Product;

--- a/src/ViewRepository/Product/ProductLatestViewRepositoryInterface.php
+++ b/src/ViewRepository/Product/ProductLatestViewRepositoryInterface.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\ViewRepository\Product;

--- a/src/ViewRepository/Product/ProductReviewsViewRepository.php
+++ b/src/ViewRepository/Product/ProductReviewsViewRepository.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\ViewRepository\Product;

--- a/src/ViewRepository/Product/ProductReviewsViewRepositoryInterface.php
+++ b/src/ViewRepository/Product/ProductReviewsViewRepositoryInterface.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Sylius package.
+ *
+ *  (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\ShopApiPlugin\ViewRepository\Product;


### PR DESCRIPTION
All php files should have a license block, so the easiest solution is to add a rule in the `ecs` for it.